### PR TITLE
fix: スレッド自動応答をオプトイン方式に変更

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -168,10 +168,9 @@ class ClaudeChatCog(commands.Cog):
         if ctx.valid:
             return
 
-        # Handle threads: configured channel always, other channels if session exists
+        # Handle threads: only respond if session exists in DB (opt-in)
         if isinstance(message.channel, discord.Thread) and (
-            message.channel.parent_id == self.bot.channel_id
-            or await self.repo.get(message.channel.id) is not None
+            await self.repo.get(message.channel.id) is not None
         ):
             await self._handle_thread_reply(message)
 

--- a/tests/e2e_optin_thread.py
+++ b/tests/e2e_optin_thread.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""E2E test: verify bot does NOT respond to threads without DB session.
+
+This reproduces the original problem where the bot auto-responded to ALL
+threads in the monitored channel, even those not created via /clord or !attach.
+
+Prerequisites:
+  1. Bot is running with the opt-in thread change
+  2. E2E_TEST_WEBHOOK_URL is set in .env
+  3. DISCORD_BOT_TOKEN and DISCORD_CHANNEL_ID are set in .env
+
+Usage:
+  uv run python tests/e2e_optin_thread.py
+
+Expected result:
+  PASS — bot does NOT respond to a manually created thread.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+UA = "DiscordBot (https://github.com/yousan/c-lord, 1.0)"
+
+
+def load_env() -> dict[str, str]:
+    """Load .env file from project root."""
+    env_path = Path(__file__).parent.parent / ".env"
+    env: dict[str, str] = {}
+    for line in env_path.read_text().strip().split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        env[key.strip()] = value.strip()
+    return env
+
+
+def discord_request(
+    url: str,
+    *,
+    method: str = "GET",
+    token: str | None = None,
+    payload: dict | None = None,
+) -> dict:
+    """Make a Discord API request."""
+    data = json.dumps(payload).encode() if payload else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("User-Agent", UA)
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bot {token}")
+    resp = urllib.request.urlopen(req)
+    return json.loads(resp.read())
+
+
+def main() -> None:
+    env = load_env()
+
+    bot_token = env.get("DISCORD_BOT_TOKEN")
+    channel_id = env.get("DISCORD_CHANNEL_ID")
+    webhook_url = env.get("E2E_TEST_WEBHOOK_URL")
+
+    if not bot_token or not channel_id:
+        print("ERROR: DISCORD_BOT_TOKEN and DISCORD_CHANNEL_ID must be set in .env")
+        sys.exit(1)
+
+    if not webhook_url:
+        print("ERROR: E2E_TEST_WEBHOOK_URL is not set in .env")
+        sys.exit(1)
+
+    # Get bot user ID
+    bot_info = discord_request("https://discord.com/api/v10/users/@me", token=bot_token)
+    bot_id = bot_info["id"]
+    print(f"Bot: {bot_info['username']} (ID: {bot_id})")
+
+    # Step 1: Create a seed message and thread (manually, NOT via /clord)
+    print("\n[1/4] Creating seed message via Bot API (simulating manual thread)...")
+    seed = discord_request(
+        f"https://discord.com/api/v10/channels/{channel_id}/messages",
+        method="POST",
+        token=bot_token,
+        payload={"content": "[E2E] Opt-in thread test — this thread has NO DB session"},
+    )
+    seed_id = seed["id"]
+    print(f"  Seed message: {seed_id}")
+
+    print("  Creating thread from seed...")
+    thread = discord_request(
+        f"https://discord.com/api/v10/channels/{channel_id}/messages/{seed_id}/threads",
+        method="POST",
+        token=bot_token,
+        payload={"name": "E2E: opt-in test (no session)", "auto_archive_duration": 60},
+    )
+    thread_id = thread["id"]
+    print(f"  Thread: {thread_id}")
+
+    # Step 2: Send a normal message via webhook (simulating a user message)
+    print("\n[2/4] Sending normal message via webhook (not a command)...")
+    wh_msg = discord_request(
+        f"{webhook_url}?thread_id={thread_id}&wait=true",
+        method="POST",
+        payload={
+            "content": "Hello, is anyone there? This should be ignored by the bot.",
+            "username": "E2E Tester",
+        },
+    )
+    wh_msg_id = wh_msg["id"]
+    print(f"  Webhook message: {wh_msg_id}")
+
+    # Step 3: Wait for potential bot response
+    wait_secs = 8
+    print(f"\n[3/4] Waiting {wait_secs}s for potential bot response...")
+    time.sleep(wait_secs)
+
+    # Step 4: Check thread messages
+    print("\n[4/4] Checking thread messages...")
+    messages = discord_request(
+        f"https://discord.com/api/v10/channels/{thread_id}/messages?limit=10",
+        token=bot_token,
+    )
+
+    print("\n--- Thread messages ---")
+    for m in reversed(messages):
+        author = m["author"]["username"]
+        flags = []
+        if m["author"].get("bot"):
+            flags.append("BOT")
+        if m.get("webhook_id"):
+            flags.append("WEBHOOK")
+        flag_str = f" [{','.join(flags)}]" if flags else ""
+        content = m["content"][:100] if m["content"] else "(empty)"
+        print(f"  {author}{flag_str}: {content}")
+
+    # Evaluate: bot should NOT have responded
+    bot_responses = [
+        m
+        for m in messages
+        if m["author"]["id"] == bot_id
+        and m.get("webhook_id") is None
+        and int(m["id"]) > int(wh_msg_id)
+    ]
+
+    print("\n=== RESULT ===")
+    if bot_responses:
+        print("FAIL: Bot responded to a thread with no DB session!")
+        print("  The opt-in change is not working correctly.")
+        for r in bot_responses:
+            print(f"  Bot said: {r['content'][:200]}")
+        sys.exit(1)
+    else:
+        print("PASS: Bot correctly ignored the thread (no DB session, no response).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1232,6 +1232,11 @@ class TestOnMessageSkipsTextCommands:
         msg.author.id = 42
         msg.webhook_id = None
 
+        # DB session must exist for opt-in response
+        record = MagicMock()
+        record.session_id = "sess-123"
+        cog.repo.get = AsyncMock(return_value=record)
+
         # Mock get_context to return an invalid context (not a command)
         mock_ctx = MagicMock()
         mock_ctx.valid = False
@@ -1288,11 +1293,27 @@ class TestMultiChannelOnMessage:
         cog._handle_thread_reply.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_configured_channel_thread_still_works(self) -> None:
-        """Threads under the configured channel still work as before."""
+    async def test_configured_channel_thread_without_session_ignored(self) -> None:
+        """Threads under the configured channel are ignored if no DB session exists."""
         cog = _make_cog()  # bot.channel_id = 999
         message = self._make_thread_message(thread_id=42, parent_id=999)
 
+        cog.repo.get = AsyncMock(return_value=None)
+        cog._handle_thread_reply = AsyncMock()
+
+        await cog.on_message(message)
+
+        cog._handle_thread_reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_configured_channel_thread_with_session_handled(self) -> None:
+        """Threads under the configured channel are handled if DB session exists."""
+        cog = _make_cog()  # bot.channel_id = 999
+        message = self._make_thread_message(thread_id=42, parent_id=999)
+
+        record = MagicMock()
+        record.session_id = "sess-abc"
+        cog.repo.get = AsyncMock(return_value=record)
         cog._handle_thread_reply = AsyncMock()
 
         await cog.on_message(message)


### PR DESCRIPTION
## 問題

監視チャンネル (`bot.channel_id`) に作られたスレッド**全て**に Bot が自動応答していた。
これにより、他のボット (ClaudeBot等) 用のスレッドや、人間同士の会話スレッドにも反応してしまう。

## 原因

`on_message` の条件に `parent_id == bot.channel_id` があり、監視チャンネル配下のスレッドは DB レコードの有無に関わらず応答対象になっていた。

```python
# Before
if isinstance(message.channel, discord.Thread) and (
    message.channel.parent_id == self.bot.channel_id        # ← これが原因
    or await self.repo.get(message.channel.id) is not None
):
```

## 修正内容

`parent_id == bot.channel_id` 条件を削除し、DB にセッションレコードがあるスレッドのみ応答するオプトイン方式に変更。

```python
# After
if isinstance(message.channel, discord.Thread) and (
    await self.repo.get(message.channel.id) is not None
):
```

DB レコードは `/clord`、`!attach`、REST API spawn 経由で作成されるため、意図的に紐づけたスレッドのみ応答対象になる。

## 変更ファイル

- `c_lord/cogs/claude_chat.py` — `on_message` の条件分岐を簡素化
- `tests/test_claude_chat.py` — テスト更新・追加（DB レコードなしの監視チャンネルスレッド → 無視を確認）
- `tests/e2e_optin_thread.py` — E2E テスト追加（手動スレッドに Bot が応答しないことを確認）

## Test plan

- [x] `uv run pytest tests/test_claude_chat.py -v -k "OnMessage"` — 6 passed
- [x] `uv run pytest tests/ -v --cov=c_lord` — 848 passed
- [x] `uv run ruff check c_lord/ tests/` — clean
- [x] E2E: 手動スレッドにメッセージ送信 → Bot 応答なし (PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)