### PR TITLE
feat: main.py で全 Cog を有効化 — setup_bridge() に委譲

### DIFF
--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -13,13 +13,7 @@ from dotenv import load_dotenv
 
 from .bot import ClaudeDiscordBot
 from .claude.runner import ClaudeRunner
-from .cogs.claude_chat import ClaudeChatCog
-from .database.ask_repo import PendingAskRepository
-from .database.lounge_repo import LoungeRepository
-from .database.models import init_db
-from .database.repository import SessionRepository
-from .session_dir import SessionDirManager
-from .tmux import TmuxSessionManager
+from .setup import setup_bridge
 from .utils.logger import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -63,16 +57,10 @@ async def main() -> None:
     setup_logging(log_level)
     config = load_config()
 
-    # Initialize database
     data_dir = Path("data")
     data_dir.mkdir(exist_ok=True)
     db_path = str(data_dir / "sessions.db")
-    await init_db(db_path)
 
-    # Create components
-    repo = SessionRepository(db_path)
-    ask_repo = PendingAskRepository(db_path)
-    lounge_repo = LoungeRepository(db_path)
     runner = ClaudeRunner(
         command=config["claude_command"],
         model=config["claude_model"],
@@ -85,52 +73,26 @@ async def main() -> None:
     coordination_channel_id = (
         int(config["coordination_channel_id"]) if config["coordination_channel_id"] else None
     )
-
-    # Session directory manager (git clone based isolation)
-    session_dir_manager: SessionDirManager | None = None
-    if config["session_dir_base"] and config["session_source_repo"]:
-        session_dir_manager = SessionDirManager(
-            base_dir=config["session_dir_base"],
-            source_repo=config["session_source_repo"],
-            clone_branch=config["session_clone_branch"] or None,
-        )
-        logger.info(
-            "SessionDirManager enabled (base=%s, repo=%s)",
-            config["session_dir_base"],
-            config["session_source_repo"],
-        )
-
-    # Tmux session manager — always enabled (degrades gracefully if tmux not installed)
-    tmux_session_name = os.getenv("CLORD_TMUX_SESSION_NAME") or Path.cwd().name
-    tmux_manager = TmuxSessionManager(session_name=tmux_session_name)
-    logger.info("TmuxSessionManager enabled (session=%s)", tmux_session_name)
+    allowed_user_ids = {owner_id} if owner_id else None
 
     bot = ClaudeDiscordBot(
         channel_id=int(config["channel_id"]),
         owner_id=owner_id,
         coordination_channel_id=coordination_channel_id,
-        ask_repo=ask_repo,
-        lounge_repo=lounge_repo,
-        lounge_channel_id=coordination_channel_id,  # lounge uses the same channel
-        session_dir_manager=session_dir_manager,
-        tmux_manager=tmux_manager,
-    )
-
-    # Register cog
-    cog = ClaudeChatCog(
-        bot=bot,
-        repo=repo,
-        runner=runner,
-        max_concurrent=int(config["max_concurrent"]),
-        ask_repo=ask_repo,
-        lounge_repo=lounge_repo,
     )
 
     async with bot:
-        await bot.add_cog(cog)
+        components = await setup_bridge(
+            bot,
+            runner,
+            session_db_path=db_path,
+            allowed_user_ids=allowed_user_ids,
+            claude_channel_id=int(config["channel_id"]),
+            enable_scheduler=True,
+        )
 
         # Cleanup old sessions on startup
-        deleted = await repo.cleanup_old(days=30)
+        deleted = await components.session_repo.cleanup_old(days=30)
         if deleted:
             logger.info("Cleaned up %d old sessions", deleted)
 

--- a/c_lord/setup.py
+++ b/c_lord/setup.py
@@ -186,6 +186,9 @@ async def setup_bridge(
     # without a hard import dependency on c-lord internals.
     bot.session_repo = session_repo  # type: ignore[attr-defined]
     bot.resume_repo = resume_repo  # type: ignore[attr-defined]
+    bot.ask_repo = ask_repo  # type: ignore[attr-defined]
+    bot.lounge_repo = lounge_repo  # type: ignore[attr-defined]
+    bot.lounge_channel_id = lounge_channel_id  # type: ignore[attr-defined]
 
     # --- ClaudeChatCog ---
     chat_cog = ClaudeChatCog(


### PR DESCRIPTION
## Summary

- `main.py` が `ClaudeChatCog` のみ手動登録していたのを `setup_bridge()` に乗せ換え
- スタンドアロン起動で全 Cog (`SessionManageCog`, `SkillCommandCog`, `SchedulerCog`) が自動有効化
- slash command 数: 4 → 15
- `setup.py` で `bot.ask_repo`, `bot.lounge_repo`, `bot.lounge_channel_id` を setattr 追加

## Test plan

- [x] 全 848 ユニットテスト PASS
- [x] ruff check / ruff format PASS
- [x] E2E: `e2e_discord_attach.py` PASS
- [x] E2E: `e2e_optin_thread.py` PASS
- [x] Bot 再起動で `Synced 15 slash commands` を確認
- [x] 全 4 Cog の `Registered ...Cog` ログを確認

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)