### PR TITLE
fix: ツール実行中の誤完了判定とメッセージ重複を修正

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -119,6 +119,7 @@ class TmuxClaudeRunner:
         self._permission_mode = permission_mode
         self._dangerously_skip_permissions = dangerously_skip_permissions
         self._stopped = False
+        self._silent_stop = False
         self._last_capture: str = ""
 
     async def run(
@@ -236,14 +237,19 @@ class TmuxClaudeRunner:
             # Done: non-empty response has been stable long enough.
             # Two tiers:
             #  - Quick exit (3s): response stable AND input prompt visible
-            #    (Claude is definitely done and waiting for input).
+            #    AND not actively generating (no ✻ Running… etc.).
+            #    Without the is_gen check, tool execution pauses (where the
+            #    pane is stable for several seconds) would trigger false
+            #    completion, posting raw tool-call text instead of Claude's
+            #    final formatted response.
             #  - Fallback exit (30s): response stable but no input prompt
             #    (Claude may have finished but prompt detection failed,
             #    e.g. completion summary text in the prompt area).
+            is_gen = self._is_generating(current)
             if (
                 last_response
                 and stable_seconds >= _RESPONSE_STABLE_TIMEOUT
-                and (has_prompt or stable_seconds >= _RESPONSE_STABLE_FALLBACK)
+                and ((has_prompt and not is_gen) or stable_seconds >= _RESPONSE_STABLE_FALLBACK)
             ):
                 break
 
@@ -266,7 +272,7 @@ class TmuxClaudeRunner:
                 message_type=MessageType.RESULT,
                 is_complete=True,
                 text=last_response or None,
-                error="Stopped by user",
+                error=None if self._silent_stop else "Stopped by user",
             )
         elif elapsed >= self.timeout_seconds:
             yield StreamEvent(
@@ -292,9 +298,17 @@ class TmuxClaudeRunner:
                 text=last_response or None,
             )
 
-    async def interrupt(self) -> None:
-        """Send C-c to the tmux pane (graceful interrupt)."""
+    async def interrupt(self, *, silent: bool = False) -> None:
+        """Send C-c to the tmux pane (graceful interrupt).
+
+        Args:
+            silent: When True, the RESULT event will have ``error=None``
+                instead of ``"Stopped by user"``.  Used when a new message
+                automatically interrupts the previous run — users should
+                not see a scary error embed they didn't cause.
+        """
         self._stopped = True
+        self._silent_stop = silent
         await asyncio.to_thread(self._tmux.send_interrupt, self._thread_id)
 
     async def kill(self) -> None:
@@ -463,6 +477,22 @@ class TmuxClaudeRunner:
 
         # Step 4: Clean up the response.
         return _clean_tui_lines(response_lines)
+
+    @staticmethod
+    def _is_generating(text: str) -> bool:
+        """Check if Claude is actively generating (thinking/tool indicators visible).
+
+        Looks at the bottom 6 lines (which contain TUI chrome) for a generation
+        status indicator that ends with ``…`` (U+2026).  Active indicators
+        like ``✻ Running…`` end with ellipsis; completion summaries like
+        ``✻ Cooked for 56s`` do not.
+        """
+        lines = text.rstrip().splitlines()
+        for line in lines[-6:]:
+            stripped = line.strip()
+            if _GENERATION_STATUS_RE.match(stripped) and stripped.endswith("…"):
+                return True
+        return False
 
     @staticmethod
     def _has_input_prompt(text: str) -> bool:

--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -85,6 +85,10 @@ class ClaudeChatCog(commands.Cog):
         self._registry = registry or getattr(bot, "session_registry", None)
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._active_runners: dict[int, TmuxClaudeRunner] = {}
+        # Per-thread lock to prevent duplicate _run_claude invocations.
+        # Without this, two messages arriving in quick succession could
+        # both enter _run_claude before the first registers in _active_runners.
+        self._thread_locks: dict[int, asyncio.Lock] = {}
         # Tracks the asyncio.Task running _run_claude for each thread.
         # Used by _handle_thread_reply to wait for an interrupted session
         # to fully clean up before starting the replacement session.
@@ -555,29 +559,35 @@ class ClaudeChatCog(commands.Cog):
         session (graceful interrupt, like pressing Escape) and waits for it to
         finish cleaning up before starting the new session.  This prevents two
         Claude processes from running in parallel in the same thread.
+
+        A per-thread asyncio.Lock serializes concurrent calls so that a second
+        message arriving before the first registers in ``_active_runners``
+        cannot spawn a duplicate ``_run_claude``.
         """
         thread = message.channel
         assert isinstance(thread, discord.Thread)
 
-        record = await self.repo.get(thread.id)
-        session_id = record.session_id if record else None
-        prompt, image_paths = await self._build_prompt_and_images(message)
+        lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
+        async with lock:
+            record = await self.repo.get(thread.id)
+            session_id = record.session_id if record else None
+            prompt, image_paths = await self._build_prompt_and_images(message)
 
-        # Interrupt any active session in this thread before starting a new one.
-        existing_runner = self._active_runners.get(thread.id)
-        existing_task = self._active_tasks.get(thread.id)
-        if existing_runner is not None:
-            await thread.send("-# ⚡ Interrupted. Starting with new instruction...")
-            await existing_runner.interrupt()
-            # Wait for the interrupted _run_claude to finish its finally block
-            # (which releases the semaphore and removes entries from dicts).
-            if existing_task is not None and not existing_task.done():
-                with contextlib.suppress(Exception):
-                    await existing_task
+            # Interrupt any active session in this thread before starting a new one.
+            existing_runner = self._active_runners.get(thread.id)
+            existing_task = self._active_tasks.get(thread.id)
+            if existing_runner is not None:
+                await thread.send("-# ⚡ Interrupted. Starting with new instruction...")
+                await existing_runner.interrupt(silent=True)
+                # Wait for the interrupted _run_claude to finish its finally block
+                # (which releases the semaphore and removes entries from dicts).
+                if existing_task is not None and not existing_task.done():
+                    with contextlib.suppress(Exception):
+                        await existing_task
 
-        await self._run_claude(
-            message, thread, prompt, session_id=session_id, image_paths=image_paths
-        )
+            await self._run_claude(
+                message, thread, prompt, session_id=session_id, image_paths=image_paths
+            )
 
     async def _build_prompt(self, message: discord.Message) -> str:
         """Build the prompt string (text only). Use _build_prompt_and_images for full processing."""

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1339,3 +1339,58 @@ class TestMultiChannelOnMessage:
         await cog.on_message(message)
 
         cog._handle_thread_reply.assert_called_once_with(message)
+
+
+# -- Tests for per-thread Lock (duplicate prevention) -----------------------
+
+
+class TestThreadLockSerialization:
+    """Tests that _handle_thread_reply serializes concurrent calls per thread."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_messages_serialized(self) -> None:
+        """Two on_message calls for the same thread should not run _run_claude concurrently.
+
+        Without a per-thread lock, both messages could enter _run_claude before
+        the first registers in _active_runners, causing duplicate responses.
+        """
+        channel_cog = _make_channel_cog_mock(tmux_manager=MagicMock())
+        cog = _make_cog(channel_cog=channel_cog)
+
+        # Track the order of _run_claude calls and ensure no overlap
+        call_log: list[str] = []
+
+        async def mock_run_claude(*args, **kwargs):
+            call_log.append("start")
+            await asyncio.sleep(0.1)  # simulate work
+            call_log.append("end")
+
+        cog._run_claude = mock_run_claude
+
+        # Create two messages for the same thread
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 42
+        thread.send = AsyncMock()
+
+        msg1 = MagicMock(spec=discord.Message)
+        msg1.channel = thread
+        msg1.content = "first"
+        msg1.attachments = []
+
+        msg2 = MagicMock(spec=discord.Message)
+        msg2.channel = thread
+        msg2.content = "second"
+        msg2.attachments = []
+
+        record = MagicMock()
+        record.session_id = "sess-1"
+        cog.repo.get = AsyncMock(return_value=record)
+
+        # Fire both concurrently
+        t1 = asyncio.create_task(cog._handle_thread_reply(msg1))
+        t2 = asyncio.create_task(cog._handle_thread_reply(msg2))
+        await asyncio.gather(t1, t2)
+
+        # With serialization, call_log should be [start, end, start, end]
+        # Without it, it would be [start, start, end, end]
+        assert call_log == ["start", "end", "start", "end"]

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -900,3 +900,202 @@ class TestTmuxClaudeRunnerInterrupt:
         result_events = [e for e in events if e.is_complete]
         assert len(result_events) == 1
         assert result_events[0].error == "Stopped by user"
+
+    @pytest.mark.asyncio
+    async def test_silent_interrupt_no_error(self, runner, tmux_manager) -> None:
+        """interrupt(silent=True) yields a RESULT with error=None (no error embed)."""
+        tmux_manager.is_claude_running.return_value = True
+        pane = _make_pane(["● Partial response"], user_prompt="q")
+        call_count = 0
+
+        def capture_side_effect(tid):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return ""
+            return pane
+
+        tmux_manager.capture_pane.side_effect = capture_side_effect
+
+        events = []
+
+        async def interrupt_after_delay():
+            await asyncio.sleep(0.15)
+            await runner.interrupt(silent=True)
+
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+        ):
+            task = asyncio.create_task(interrupt_after_delay())
+            async for event in runner.run("q"):
+                events.append(event)
+            await task
+
+        result_events = [e for e in events if e.is_complete]
+        assert len(result_events) == 1
+        # Silent interrupt should NOT produce an error
+        assert result_events[0].error is None
+        assert result_events[0].text == "Partial response"
+
+
+# -- Tests for _is_generating ------------------------------------------------
+
+
+class TestIsGenerating:
+    """Tests for TmuxClaudeRunner._is_generating."""
+
+    def test_is_generating_during_tool_execution(self) -> None:
+        """Active generation indicator (ending with …) → True."""
+        text = "\n".join(
+            [
+                "❯ list issues",
+                "",
+                "● Bash(gh issue list ...)",
+                "",
+                "─" * 40,
+                "✻ Running…",
+                "─" * 40,
+                "-- INSERT -- ⏵⏵ bypass permissions on",
+            ]
+        )
+        assert TmuxClaudeRunner._is_generating(text) is True
+
+    def test_is_generating_when_completed(self) -> None:
+        """No generation indicator, just bare ❯ → False."""
+        text = "\n".join(
+            [
+                "❯ list issues",
+                "",
+                "● Here are the issues.",
+                "",
+                "─" * 40,
+                "❯",
+                "─" * 40,
+                "-- INSERT -- ⏵⏵ bypass permissions on",
+            ]
+        )
+        assert TmuxClaudeRunner._is_generating(text) is False
+
+    def test_is_generating_completion_summary(self) -> None:
+        """Completion summary without … (e.g. 'Cooked for 56s') → False."""
+        text = "\n".join(
+            [
+                "❯ question",
+                "",
+                "● Full answer.",
+                "",
+                "─" * 40,
+                "✻ Cooked for 56s",
+                "─" * 40,
+                "-- INSERT -- ⏵⏵ bypass permissions on",
+            ]
+        )
+        assert TmuxClaudeRunner._is_generating(text) is False
+
+    def test_is_generating_thinking_indicator(self) -> None:
+        """Thinking indicator (ending with …) → True."""
+        text = "\n".join(
+            [
+                "❯ hello",
+                "",
+                "─" * 40,
+                "✻ Envisioning…",
+                "─" * 40,
+                "-- INSERT --",
+            ]
+        )
+        assert TmuxClaudeRunner._is_generating(text) is True
+
+    def test_is_generating_ascii_asterisk(self) -> None:
+        """tmux-captured ASCII asterisk thinking (ending with …) → True."""
+        text = "\n".join(
+            [
+                "❯ test",
+                "",
+                "─" * 40,
+                "* Forming…",
+                "─" * 40,
+                "-- INSERT --",
+            ]
+        )
+        assert TmuxClaudeRunner._is_generating(text) is True
+
+    def test_is_generating_empty_text(self) -> None:
+        """Empty pane text → False."""
+        assert TmuxClaudeRunner._is_generating("") is False
+
+
+class TestToolExecutionCompletion:
+    """Tests that tool execution does not trigger false early completion."""
+
+    @pytest.mark.asyncio
+    async def test_tool_execution_does_not_trigger_early_completion(
+        self, runner, tmux_manager
+    ) -> None:
+        """When ✻ Running… is visible and text is stable, quick-exit should NOT fire.
+
+        The pane shows a tool call with ✻ Running… indicator and bare ❯ prompt.
+        Without the _is_generating guard, the 3s quick-exit would fire.
+        With the guard, only the 30s fallback can trigger completion.
+        """
+        tmux_manager.is_claude_running.return_value = True
+
+        # Pane shows a tool call with ✻ Running… — text is stable but not done
+        tool_pane = "\n".join(
+            [
+                "❯ list issues",
+                "",
+                "● Bash(gh issue list --limit 10)",
+                "",
+                "─" * 40,
+                "✻ Running…",
+                "❯",
+                "─" * 40,
+                "-- INSERT -- ⏵⏵ bypass permissions on",
+            ]
+        )
+        # After several polls at tool_pane (stable but generating),
+        # Claude finishes and shows the final response
+        final_pane = _make_pane(
+            [
+                "● Here are the issues:",
+                "",
+                "  | # | Title     |",
+                "  |---|-----------|",
+                "  | 1 | Fix bug   |",
+            ],
+            user_prompt="list issues",
+            with_input_prompt=True,
+        )
+
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            # Polls 1-8: tool running (stable text with ✻ Running…)
+            if call_idx <= 8:
+                return tool_pane
+            # Polls 9+: final response
+            return final_pane
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.15),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_FALLBACK", 30.0),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+        ):
+            async for event in runner.run("list issues"):
+                events.append(event)
+
+        # The final response should contain the table, NOT the raw tool call
+        finals = [
+            e for e in events if e.message_type == MessageType.ASSISTANT and not e.is_partial
+        ]
+        assert len(finals) == 1
+        assert "Fix bug" in finals[0].text
+        assert "Running…" not in finals[0].text


### PR DESCRIPTION
## Summary

- **ツール実行中の誤完了判定を修正**: `_is_generating()` メソッドを追加し、TUI の生成中インジケータ（`✻ Running…` 等、末尾 `…`）を検出。quick exit（3秒）条件に `not is_gen` ガードを追加し、ツール実行待ちで誤完了しないようにした
- **メッセージ重複を修正**: `_handle_thread_reply` に per-thread `asyncio.Lock` を追加し、同一スレッドへの並行メッセージによる `_run_claude` 重複起動を防止
- **サイレント interrupt**: `interrupt(silent=True)` で自動 interrupt 時にエラー embed を表示しないようにした

## Test plan

- [x] `_is_generating` ユニットテスト 6件（ツール実行中/完了/サマリー/thinking/ASCII/空）
- [x] `test_tool_execution_does_not_trigger_early_completion` — ツール実行中の pane で安定しても完了しないことを確認
- [x] `test_silent_interrupt_no_error` — サイレント interrupt テスト
- [x] `test_concurrent_messages_serialized` — 並行メッセージの直列化テスト
- [x] 既存テスト全 835 件パス
- [x] ruff check / ruff format パス
- [x] Discord E2E: ツールを使う質問で最終応答が正しく表示されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)