### PR TITLE
chore: tmux.sh を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 .coverage
 htmlcov/
 .pytest_cache/
+
+# Personal workflow scripts (not part of the OSS framework)
+tmux.sh


### PR DESCRIPTION
## Summary
- 個人ワークフロー用の tmux 起動スクリプト `tmux.sh` を `.gitignore` に追加
- OSS フレームワーク本体には含めず、開発者各自のローカル運用に委ねる

🤖 Generated with [Claude Code](https://claude.com/claude-code)