### PR TITLE
fix: TUI 下部の ccstatusline を Discord 出力からストリップ

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -405,20 +405,31 @@ class TmuxClaudeRunner:
         #   ──────────── (separator 1)
         #   ❯ <input or hint>  (or "· Thinking…", "Tip: ...")
         #   ──────────── (separator 2)
+        #   <ccstatusline lines, optional, variable count>
         #   -- INSERT -- (status bar)
         #
         # We track separator_count so that ❯ lines are only stripped while
         # inside the input area (between or below the two separators).
         # Once we've passed both separators, a ❯ line is a user prompt
         # and should NOT be stripped.
+        #
+        # `in_status_bar_zone` is True after we've consumed the vim status
+        # bar (-- INSERT) and before we've crossed the bottom separator.
+        # In this zone, unrecognised lines are user-configured ccstatusline
+        # output (Model:, Cost:, ⎇ branch, etc.) and must be stripped.
         end = len(lines)
         separator_count = 0
+        in_status_bar_zone = False
         while end > 0:
             stripped = lines[end - 1].strip()
             if not stripped or any(stripped.startswith(m) for m in _STATUS_BAR_MARKERS):
+                if any(stripped.startswith(m) for m in _STATUS_BAR_MARKERS):
+                    in_status_bar_zone = True
                 end -= 1
             elif _SEPARATOR_RE.match(stripped):
                 separator_count += 1
+                # Crossing the bottom separator exits the ccstatusline zone.
+                in_status_bar_zone = False
                 end -= 1
             elif stripped.startswith("❯") or stripped.startswith(">"):
                 if separator_count < 2:
@@ -430,6 +441,11 @@ class TmuxClaudeRunner:
             elif any(
                 stripped.startswith(m) for m in _GENERATION_STATUS_MARKERS
             ) or _GENERATION_STATUS_RE.match(stripped):
+                end -= 1
+            elif in_status_bar_zone:
+                # Unrecognised line between vim status bar and bottom separator —
+                # this is ccstatusline output (user-configurable, so we cannot
+                # match it with explicit patterns).
                 end -= 1
             else:
                 break

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -242,6 +242,41 @@ class TestExtractResponse:
         assert result == "Second answer"
         assert "First answer" not in result
 
+    def test_strips_ccstatusline_block(self) -> None:
+        """ccstatusline output (multi-line, indented, between bottom separator and
+        vim status bar) must be stripped from the Discord output.
+
+        The Claude TUI bottom layout when ccstatusline is configured:
+            ───────── (top separator)
+            ❯ <input>
+            ───────── (bottom separator)
+            <ccstatusline lines, variable count, leading whitespace>
+            -- INSERT -- ⏵⏵ ...
+        """
+        pane = "\n".join(
+            [
+                "❯ hello",
+                "",
+                "● Hello! How can I help you today?",
+                "",
+                "✻ Crunched for 2s",
+                "",
+                "─" * 100,
+                "❯ ",
+                "─" * 100,
+                "   Model: Sonnet 4.6  Style: default  Ctx: 21.9k  Context: [...] 22k/1000k",
+                "   Cost: $0.05  Session: 7.0%  Weekly: 14.0%  Reset: 1hr 51m",
+                "   ⎇ main  (+0,-0)  +0  -0  1499210603107975270  cwd: /home/yousan/c-lord",
+                "  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle)",
+            ]
+        )
+        result = TmuxClaudeRunner._extract_response(pane)
+        assert result == "Hello! How can I help you today?"
+        assert "Model:" not in result
+        assert "Cost:" not in result
+        assert "cwd:" not in result
+        assert "INSERT" not in result
+
     def test_strips_generation_status_during_streaming(self) -> None:
         """During generation, thinking indicators and tips at bottom are stripped."""
         pane = "\n".join(
@@ -1093,9 +1128,7 @@ class TestToolExecutionCompletion:
                 events.append(event)
 
         # The final response should contain the table, NOT the raw tool call
-        finals = [
-            e for e in events if e.message_type == MessageType.ASSISTANT and not e.is_partial
-        ]
+        finals = [e for e in events if e.message_type == MessageType.ASSISTANT and not e.is_partial]
         assert len(finals) == 1
         assert "Fix bug" in finals[0].text
         assert "Running…" not in finals[0].text


### PR DESCRIPTION
## Summary
- ccstatusline のような統計行（Model:/Cost:/⎇ branch/cwd: など）が Discord スレッドに混入する問題を修正
- bottom-up ストリップ時、vim ステータスバー (\`-- INSERT\`) と bottom separator の間にある未認識行を「ccstatusline 領域」として一律ストリップ

## Why
ccstatusline はユーザーが自由に設定できるため、明示的なパターンマッチではカバーできません。代わりに **TUI レイアウト上の位置 (vim status bar と bottom separator の間)** で判定する方が堅牢です。

## Test plan
- [x] 新規テスト \`test_strips_ccstatusline_block\` 追加 (TDD: RED → GREEN)
- [x] 既存 73 テスト維持
- [x] 全 798 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)