### PR TITLE
fix: 「Searching for N …」形式の tool indicator を strip

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -82,8 +82,10 @@ _STRIP_PATTERNS = (
     # TUI noise — interactive prompts and greetings
     re.compile(r"Press Ctrl-C again to exit"),
     re.compile(r"Claude Code has switched.*"),
-    # TUI tool activity indicators (e.g. "Reading 1 file…", "Recalling 2 memories…")
-    re.compile(r"(?:Reading|Recalling|Writing|Searching|Running|Checking) \d+ .+…"),
+    # TUI tool activity indicators (e.g. "Reading 1 file…", "Recalling 2 memories…",
+    # "Searching for 1 pattern…"). The `(?:\s+\w+)*` allows optional words between
+    # the verb and the digit (e.g. "Searching for N …", "Checking against N …").
+    re.compile(r"(?:Reading|Recalling|Writing|Searching|Running|Checking)(?:\s+\w+)*\s+\d+\s+.+…"),
     # Vim-style status bar lines that leak into the response area
     re.compile(r"--\s*INSERT\s.*"),
     re.compile(r"--\s*NORMAL\s.*"),

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -242,6 +242,43 @@ class TestExtractResponse:
         assert result == "Second answer"
         assert "First answer" not in result
 
+    def test_strips_searching_with_intermediate_word(self) -> None:
+        """Tool indicators with words between verb and digit must be stripped.
+
+        The TUI shows "Searching for 1 pattern…" (note "for" between verb and
+        digit) — the original \\d+-only regex missed this case and let it
+        leak into the Discord output.
+        """
+        pane = _make_pane(
+            [
+                "● Searching for 1 pattern…",
+                "● Found it.",
+            ],
+            with_chrome=True,
+            with_input_prompt=True,
+        )
+        result = TmuxClaudeRunner._extract_response(pane)
+        assert "Searching for 1 pattern" not in result
+        assert "Found it." in result
+
+    def test_strips_tool_indicator_with_animation_artifacts(self) -> None:
+        """Tool indicator captured mid-animation has trailing chars after `…`.
+
+        e.g. ``Reading 1 file…e…`` (TUI redraws ellipsis dots one-by-one and
+        ``capture-pane`` snapshots a partial frame). Must still be stripped.
+        """
+        pane = _make_pane(
+            [
+                "● Reading 1 file…e…",
+                "● Done reading.",
+            ],
+            with_chrome=True,
+            with_input_prompt=True,
+        )
+        result = TmuxClaudeRunner._extract_response(pane)
+        assert "Reading 1 file" not in result
+        assert "Done reading." in result
+
     def test_strips_ccstatusline_block(self) -> None:
         """ccstatusline output (multi-line, indented, between bottom separator and
         vim status bar) must be stripped from the Discord output.


### PR DESCRIPTION
## Summary
- TUI の「Searching for 1 pattern…」のように、動詞と数字の間に語を挟む形式の tool indicator が strip されず Discord に漏れていた問題を修正
- 正規表現に \`(?:\s+\w+)*\` を追加して、動詞〜数字間の任意の語を許容

## Why
Discord 側で実際に観測された出力例:
\`\`\`
Searching for 1 pattern…n…n…n…実はあります。/attach (および !attach) ...
\`\`\`
既存パターン \`r"<verb> \d+ .+…"\` は \`Searching\` 直後に数字を要求するため、\`for\` を間に挟むこの形式にはマッチしませんでした。

## Test plan
- [x] TDD: \`test_strips_searching_with_intermediate_word\` 追加 (RED → GREEN)
- [x] \`test_strips_tool_indicator_with_animation_artifacts\` も追加 (既存 greedy 動作の回帰防止)
- [x] 全 800 テスト通過

## Known limitation (本 PR スコープ外)
\`claude_chat.pypy\` のような file path 末尾重複は、TUI の cursor-back redraw を capture-pane が中間フレームで snap した際の artifact。line-strip では拾えないため別途対応が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)