### PR TITLE
fix: capture-pane の中間フレーム artifact を debounce で抑制

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -196,6 +196,10 @@ class TmuxClaudeRunner:
         elapsed = 0.0
         stable_seconds = 0.0
         last_response = ""
+        # Previous capture's extracted response — used to debounce non-prefix
+        # changes so that transient TUI redraw artifacts (e.g. mid-frame cursor
+        # rewrites that produce text like "claude_chat.pypy") are not yielded.
+        prev_capture_response = ""
 
         while not self._stopped and elapsed < self.timeout_seconds:
             await asyncio.sleep(_POLL_INTERVAL)
@@ -222,19 +226,29 @@ class TmuxClaudeRunner:
                     self._thread_id,
                 )
 
-            if response != last_response:
-                # Response changed (new content appeared or grew).
-                stable_seconds = 0.0
-                if response:
-                    last_response = response
-                    yield StreamEvent(
-                        raw={},
-                        message_type=MessageType.ASSISTANT,
-                        text=last_response,
-                        is_partial=True,
-                    )
-            else:
+            if response == last_response:
+                # No change from already-yielded state — accumulate stability.
                 stable_seconds += _POLL_INTERVAL
+            elif response and response == prev_capture_response:
+                # Confirmed by two consecutive captures — debounced yield.
+                # Adds ~_POLL_INTERVAL latency per change, but drops transient
+                # TUI redraw artifacts (e.g. mid-frame ".pypy" corruptions
+                # caused by capture-pane snapping a cursor-back rewrite).
+                stable_seconds = 0.0
+                last_response = response
+                yield StreamEvent(
+                    raw={},
+                    message_type=MessageType.ASSISTANT,
+                    text=last_response,
+                    is_partial=True,
+                )
+            else:
+                # First sighting of this response — hold for one more poll.
+                # If the next capture confirms it, we yield; otherwise it is
+                # dropped as a transient artifact.
+                stable_seconds = 0.0
+
+            prev_capture_response = response
 
             # Done: non-empty response has been stable long enough.
             # Two tiers:

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -820,6 +820,54 @@ class TestTmuxClaudeRunnerRun:
         assert events[-1].error == "Failed to send input to Claude in tmux"
 
     @pytest.mark.asyncio
+    async def test_artifact_frame_not_yielded(self, runner, tmux_manager) -> None:
+        """A transient TUI redraw artifact frame must not be yielded to Discord.
+
+        Scenario: capture-pane snaps a mid-redraw frame where a file path got
+        corrupted (``claude_chat.pypy``), then the next frame shows the clean
+        version (``claude_chat.py``). The artifact must be debounced —
+        only the clean text reaches Discord.
+        """
+        pane_clean1 = _make_pane(["● Reading file:", "  c_lord/cogs/claude_chat.py"])
+        pane_artifact = _make_pane(["● Reading file:", "  c_lord/cogs/claude_chat.pypy"])
+        pane_clean2 = _make_pane(
+            ["● Reading file:", "  c_lord/cogs/claude_chat.py"],
+            with_input_prompt=True,
+        )
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            if call_idx <= 2:
+                return "Loading..."  # _handle_startup_prompts
+            if call_idx == 3:
+                return pane_clean1
+            if call_idx == 4:
+                return pane_artifact  # transient corruption
+            return pane_clean2  # back to clean, then stable
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+        tmux_manager.is_claude_running.return_value = False
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+        ):
+            async for event in runner.run("test"):
+                events.append(event)
+
+        partials = [e for e in events if e.message_type == MessageType.ASSISTANT]
+        # The artifact text must never appear in any yielded event.
+        for ev in partials:
+            assert "pypy" not in ev.text, f"Artifact leaked: {ev.text}"
+        # The clean text should reach Discord.
+        assert any("claude_chat.py" in ev.text for ev in partials)
+
+    @pytest.mark.asyncio
     async def test_extracted_text_yielded_as_partial(self, runner, tmux_manager) -> None:
         """Extracted response text is yielded as partial ASSISTANT events."""
         pane_v1 = _make_pane(["● Line 1"])
@@ -907,9 +955,11 @@ class TestTmuxClaudeRunnerRun:
             async for event in runner.run("q"):
                 events.append(event)
 
-        # Should have partial events as response grew.
+        # Should have at least one partial event with the final response.
+        # Note: with debounce, only responses confirmed by 2 consecutive
+        # captures are yielded — transient intermediate frames may be skipped.
         partials = [e for e in events if e.message_type == MessageType.ASSISTANT and e.is_partial]
-        assert len(partials) == 2  # v1 and v2
+        assert len(partials) >= 1
         assert "Done now." in partials[-1].text
 
         # Should have final non-partial and result.


### PR DESCRIPTION
## Summary
- TUI cursor-back redraw を capture-pane が中間フレームで掴むことで生じる artifact (例: \`claude_chat.pypy\`) を抑制
- 2 回連続で同一の response を確認してから yield する debounce を導入

## Why
prefix-extension 判定では artifact (\`.py\` → \`.pypy\` のような末尾重複) も「成長」に見えてしまうため、シンプルに「2 回連続一致で confirm」のロジックに統一しました。

## Trade-off
- ストリーミングの latency が \`_POLL_INTERVAL\` (~0.5s) 増える
- 代わりに single-frame の TUI artifact は確実に破棄される

## Test plan
- [x] TDD: \`test_artifact_frame_not_yielded\` (RED → GREEN)
- [x] 既存 \`test_response_stability_detection\` を新仕様に合わせて緩和
- [x] 全 801 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)