### PR TITLE
feat: ストリーミング応答で URL の OGP プレビューを抑制

### DIFF
--- a/c_lord/discord_ui/streaming_manager.py
+++ b/c_lord/discord_ui/streaming_manager.py
@@ -88,9 +88,9 @@ class StreamingMessageManager:
 
         try:
             if self._current_message is None:
-                self._current_message = await self._thread.send(display_text)
+                self._current_message = await self._thread.send(display_text, suppress_embeds=True)
             else:
-                await self._current_message.edit(content=display_text)
+                await self._current_message.edit(content=display_text, suppress=True)
             self._last_edit_time = time.monotonic()
         except Exception:
             # Catch all exceptions including aiohttp.ClientError (e.g. ServerDisconnectedError

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -1,0 +1,47 @@
+"""Tests for StreamingMessageManager — OGP/embed suppression."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from c_lord.discord_ui.streaming_manager import StreamingMessageManager
+
+
+@pytest.fixture
+def thread():
+    t = MagicMock()
+    t.send = AsyncMock(return_value=MagicMock(edit=AsyncMock()))
+    return t
+
+
+@pytest.mark.asyncio
+async def test_send_suppresses_embeds(thread) -> None:
+    """First send must pass suppress_embeds=True so URL OGP cards do not render."""
+    mgr = StreamingMessageManager(thread)
+    await mgr.append("see https://example.com")
+    await mgr.finalize()
+
+    thread.send.assert_called()
+    _, kwargs = thread.send.call_args
+    assert kwargs.get("suppress_embeds") is True
+
+
+@pytest.mark.asyncio
+async def test_edit_suppresses_embeds(thread) -> None:
+    """Subsequent edits must keep embeds suppressed."""
+    sent_message = MagicMock(edit=AsyncMock())
+    thread.send = AsyncMock(return_value=sent_message)
+
+    mgr = StreamingMessageManager(thread)
+    await mgr.append("first https://a.com")
+    # Force flush so _current_message is set, then trigger edit on next append.
+    await mgr._flush()
+    mgr._last_edit_time = 0  # bypass debounce
+    await mgr.append(" more https://b.com")
+    await mgr.finalize()
+
+    sent_message.edit.assert_called()
+    _, kwargs = sent_message.edit.call_args
+    assert kwargs.get("suppress") is True


### PR DESCRIPTION
## Summary
- \`StreamingMessageManager._flush\` の send/edit に SUPPRESS_EMBEDS フラグを付与
- URL を含む応答で Discord が OGP カードを大量展開する問題を解消

## Test plan
- [x] \`uv run pytest tests/test_streaming_manager.py -v\` (2 tests pass)
- [ ] 実環境: bot 再起動 → URL を含む応答 → 埋め込みカードが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)