### PR TITLE
fix: TUI chrome leak をストリップ (#32)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -101,6 +101,16 @@ _STRIP_PATTERNS = (
     re.compile(r"^-{5,}$"),
     # Box-drawing separator lines (safety net if bottom-chrome stripping misses them)
     re.compile(r"^[─━═\s]{10,}$"),
+    # Issue #32: defense-in-depth against TUI chrome leaking into Discord
+    # when capture-pane catches a mid-redraw frame. Step 1 walks bottom-up
+    # and bails on unrecognised lines, so a "ghost" copy of chrome above the
+    # real chrome is not stripped. These patterns catch the chrome content
+    # itself in _clean_tui_lines.
+    re.compile(r"❯"),  # bare input prompt char
+    re.compile(r"Model:\s.+\sStyle:.+"),  # ccstatusline row 1 ("Model: ... Style: ...")
+    re.compile(r"Cost:\s\$.+\sSession:.+"),  # ccstatusline row 2 ("Cost: $... Session: ...")
+    re.compile(r"⎇\s.+\scwd:.+"),  # ccstatusline row 3 ("⎇ branch ... cwd: ...")
+    re.compile(r"\d+\s+skill descriptions?\s+dropped.*"),
 )
 
 

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -76,7 +76,7 @@ class TestStreamingMessageManager:
         mgr = StreamingMessageManager(thread)
         mgr._buffer = "test content"
         await mgr.finalize()
-        thread.send.assert_called_once_with("test content")
+        thread.send.assert_called_once_with("test content", suppress_embeds=True)
 
     @pytest.mark.asyncio
     async def test_append_after_finalize_ignored(self, thread: MagicMock) -> None:

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -529,12 +529,101 @@ class TestExtractResponse:
         assert result == "Answer."
         assert "Forming" not in result
 
+    def test_does_not_emit_chrome_during_redraw_race(self) -> None:
+        """Regression for issue #32.
+
+        When tmux capture-pane catches a frame mid-redraw, the pane may show
+        a "ghost" copy of the bottom chrome (bare ❯ + ccstatusline + tool
+        fragment) above the real bottom chrome. The extractor must NOT emit
+        these chrome lines as response text.
+
+        Real-world reproduction: Discord message 1501818362169397428 in
+        thread 1499664870948339834 on 2026-05-07 contained:
+            ❯
+               Model: Opus 4.7 ... Style: default ...
+               Cost: $0.06 ...
+               ⎇ main ... cwd: ... Skill: none
+               ... 3 skill descriptions dropped · /doctor for details ...
+              Error: Exit code 127
+        """
+        pane = "\n".join(
+            [
+                "$ cd /home/yousan/c-lord",
+                "yousan@host:~$ claude",
+                "",
+                # "ghost" mid-pane chrome from a stale redraw frame
+                "❯",
+                "   Model: Opus 4.7  v2.1.132  Style: default  Ctx: 22.8k  Context: [...]",
+                "   Cost: $0.06  Session: 5.0%  Weekly: 21.0%  Reset: 4hr 10m",
+                "   ⎇ main  (+0,-0)  +0  -0  cwd: /home/yousan/c-lord  Skill: none",
+                "                3 skill descriptions dropped · /doctor for details",
+                "  Error: Exit code 127",
+                "     === /home/yousan/c-lord/data/sessions.db ===",
+                # real bottom chrome
+                "─" * 100,
+                "❯",
+                "─" * 100,
+                "   Model: Opus 4.7  v2.1.132  Style: default  Ctx: 22.8k",
+                "  -- INSERT -- ⏵⏵ bypass permissions on",
+            ]
+        )
+        result = TmuxClaudeRunner._extract_response(pane)
+        assert "Model:" not in result, f"ccstatusline leaked: {result!r}"
+        assert "Cost:" not in result, f"ccstatusline leaked: {result!r}"
+        assert "/doctor" not in result, f"tool indicator leaked: {result!r}"
+        for line in result.splitlines():
+            assert line.strip() != "❯", f"bare prompt leaked: {result!r}"
+
 
 # -- Tests for _clean_tui_lines ---------------------------------------------
 
 
 class TestCleanTuiLines:
     """Tests for the _clean_tui_lines helper function."""
+
+    def test_strips_bare_input_prompt_line(self) -> None:
+        """Bare ❯ line in response area is chrome leakage; must be dropped."""
+        assert _clean_tui_lines(["❯", "● Hi"]) == "Hi"
+
+    def test_strips_ccstatusline_model_row(self) -> None:
+        """ccstatusline 'Model: ... Style:' rows must not leak (issue #32)."""
+        result = _clean_tui_lines(
+            [
+                "● Real response.",
+                "   Model: Opus 4.7  Style: default  Ctx: 22.8k",
+            ]
+        )
+        assert result == "Real response."
+
+    def test_strips_ccstatusline_cost_row(self) -> None:
+        """ccstatusline 'Cost: $... Session:' rows must not leak (issue #32)."""
+        result = _clean_tui_lines(
+            [
+                "● Real response.",
+                "   Cost: $0.06  Session: 5.0%  Weekly: 21.0%",
+            ]
+        )
+        assert result == "Real response."
+
+    def test_strips_ccstatusline_branch_row(self) -> None:
+        """ccstatusline '⎇ branch ... cwd:' rows must not leak (issue #32)."""
+        result = _clean_tui_lines(
+            [
+                "● Real response.",
+                "   ⎇ main  (+0,-0)  cwd: /home/yousan/c-lord  Skill: none",
+            ]
+        )
+        assert result == "Real response."
+
+    def test_strips_skill_descriptions_dropped_indicator(self) -> None:
+        """'N skill descriptions dropped · /doctor for details' is TUI noise."""
+        result = _clean_tui_lines(
+            [
+                "● Real response.",
+                "                3 skill descriptions dropped · /doctor for details",
+            ]
+        )
+        assert result == "Real response."
 
     def test_strips_bullet_marker(self) -> None:
         assert _clean_tui_lines(["● Hello"]) == "Hello"


### PR DESCRIPTION
## Summary

- tmux capture-pane が redraw 中フレームを取り込むと、bottom chrome (`❯` / ccstatusline / `N skill descriptions dropped`) が pane 上方に "ghost" 複製され、Step 1 の bottom-up stripping を逃れて Discord に流出していた (issue #32)
- `_STRIP_PATTERNS` に防御層として 5 パターン追加: 単独 `❯`, `Model: ... Style: ...`, `Cost: $... Session: ...`, `⎇ ... cwd: ...`, `N skill descriptions dropped ...`
- `tests/test_run_helper.py::test_finalize_sends_message` を PR #33 の `suppress_embeds=True` 追加に追従

## RED → GREEN E2E 比較

実環境 thread 1499664870948339834 で確認:

| | Before (msg 1501818362169397428) | After (msg 1501821231819657408) |
|---|---|---|
| `❯` 露出 | あり | なし |
| `Model:`/`Cost:`/`⎇` ccstatusline | あり | なし |
| `Error: Exit code 127` 中間フレーム | あり | なし |
| `/doctor for details` | あり | なし |

## Test plan

- [x] RED: 6 tests fail before fix
- [x] GREEN: 6 tests pass after fix
- [x] 全 815 tests pass + ruff check / format clean
- [x] Bot 再起動して E2E (Bash ツール含む prompt) で chrome leak が消えることを確認

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)