### PR TITLE
fix: TUI 'Tip:' hint も response から strip

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -111,6 +111,7 @@ _STRIP_PATTERNS = (
     re.compile(r"Cost:\s\$.+\sSession:.+"),  # ccstatusline row 2 ("Cost: $... Session: ...")
     re.compile(r"⎇\s.+\scwd:.+"),  # ccstatusline row 3 ("⎇ branch ... cwd: ...")
     re.compile(r"\d+\s+skill descriptions?\s+dropped.*"),
+    re.compile(r"Tip:\s.+"),  # TUI hint line ("Tip: Use Plan Mode ...")
 )
 
 

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -615,6 +615,16 @@ class TestCleanTuiLines:
         )
         assert result == "Real response."
 
+    def test_strips_tip_line(self) -> None:
+        """'Tip: Use Plan Mode ...' lines are TUI hints, not Claude response."""
+        result = _clean_tui_lines(
+            [
+                "Tip: Use Plan Mode to prepare for a complex request before making changes.",
+                "● Real response.",
+            ]
+        )
+        assert result == "Real response."
+
     def test_strips_skill_descriptions_dropped_indicator(self) -> None:
         """'N skill descriptions dropped · /doctor for details' is TUI noise."""
         result = _clean_tui_lines(


### PR DESCRIPTION
## Summary

PR #34 と同根の漏れ。redraw race で `Tip: Use Plan Mode ...` 行が response 領域に leak することがあったので `_STRIP_PATTERNS` に追加。

## Test plan

- [x] RED: 1 test fails before fix
- [x] GREEN: 全 816 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)