### PR TITLE
fix: /clord-attach が手動作成 tmux window で失敗する (#37)

### DIFF
--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -251,20 +251,25 @@ class TmuxSessionManager:
         if not self._check_available():
             return False
 
-        # Check the window exists by reading its @thread_id option.
-        # (tmux has no ``has-window`` command; ``show-option -w`` fails
-        # with "no such window" when the target does not exist.)
+        # Check the window exists via list-windows. We cannot use
+        # ``show-option -w @thread_id`` because tmux returns rc=1 for both
+        # "window missing" and "option unset" — the latter is the normal
+        # case for windows created manually with ``tmux new-window`` (issue #37).
         result = _run(
             [
                 "tmux",
-                "show-option",
-                "-w",
+                "list-windows",
                 "-t",
-                f"{self.session_name}:{window_name}",
-                "@thread_id",
+                self.session_name,
+                "-F",
+                "#{window_name}",
             ]
         )
         if result.returncode != 0:
+            logger.debug("remap_window: session %s not found", self.session_name)
+            return False
+        existing = {line for line in result.stdout.splitlines() if line}
+        if window_name not in existing:
             logger.debug("remap_window: window %s not found", window_name)
             return False
 

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -631,8 +631,8 @@ class TestTmuxSessionManager:
 
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.side_effect = [
-                # show-option @thread_id → window exists
-                MagicMock(returncode=0, stdout="11111\n"),
+                # list-windows → window exists
+                MagicMock(returncode=0, stdout="work1\n"),
                 # set-option @thread_id
                 MagicMock(returncode=0),
             ]
@@ -654,7 +654,8 @@ class TestTmuxSessionManager:
         mgr._available = True
 
         with patch("c_lord.tmux._run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=1)
+            # list-windows succeeds but does not contain target name
+            mock_run.return_value = MagicMock(returncode=0, stdout="work1\nwork2\n")
             result = mgr.remap_window(99999, "nonexistent")
 
         assert result is False
@@ -669,7 +670,7 @@ class TestTmuxSessionManager:
 
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="11111\n"),  # show-option → window exists
+                MagicMock(returncode=0, stdout="work1\n"),  # list-windows → exists
                 MagicMock(returncode=0),  # set-option
             ]
             result = mgr.remap_window(22222, "work1")
@@ -688,3 +689,51 @@ class TestTmuxSessionManager:
         result = mgr.remap_window(12345, "work1")
 
         assert result is False
+
+    def test_remap_window_manually_created(self) -> None:
+        """remap_window succeeds for a window with no pre-existing @thread_id.
+
+        Regression for issue #37: windows created manually via ``tmux new-window``
+        do not have the ``@thread_id`` option set, so ``show-option -w @thread_id``
+        returns rc=1 ("no such option"). Existence must instead be checked via
+        ``list-windows``.
+        """
+        mgr = TmuxSessionManager()
+        mgr._available = True
+
+        def fake_run(argv: list[str], *args, **kwargs) -> MagicMock:
+            # show-option for @thread_id on a manually-created window → rc=1
+            if "show-option" in argv and "@thread_id" in argv:
+                return MagicMock(returncode=1, stdout="")
+            # list-windows → window exists in session
+            if "list-windows" in argv:
+                return MagicMock(returncode=0, stdout="work1\nproj34\nwork2\n")
+            # set-option succeeds
+            if "set-option" in argv:
+                return MagicMock(returncode=0, stdout="")
+            return MagicMock(returncode=0, stdout="")
+
+        with patch("c_lord.tmux._run", side_effect=fake_run):
+            result = mgr.remap_window(77777, "proj34")
+
+        assert result is True
+        assert mgr._thread_to_window[77777] == "proj34"
+
+    def test_remap_window_truly_missing(self) -> None:
+        """remap_window returns False when window genuinely does not exist."""
+        mgr = TmuxSessionManager()
+        mgr._available = True
+
+        def fake_run(argv: list[str], *args, **kwargs) -> MagicMock:
+            if "show-option" in argv:
+                return MagicMock(returncode=1, stdout="")
+            if "list-windows" in argv:
+                # session listing does NOT contain target name
+                return MagicMock(returncode=0, stdout="work1\nwork2\n")
+            return MagicMock(returncode=0, stdout="")
+
+        with patch("c_lord.tmux._run", side_effect=fake_run):
+            result = mgr.remap_window(77777, "proj34")
+
+        assert result is False
+        assert 77777 not in mgr._thread_to_window


### PR DESCRIPTION
## Summary
- `remap_window` の存在確認を `show-option -w @thread_id` から `list-windows -F '#{window_name}'` に変更
- tmux の `show-option` は「window 不在」と「option 未設定」を区別できないため、手動作成 window (= `@thread_id` 未設定) では常に `Window not found` で失敗していた
- regression test を 2 件追加 (手動作成 window は成功 / 真に存在しない window は失敗)

Fixes #37

## Test plan
- [x] `uv run pytest tests/test_tmux.py -v` → 50 passed
- [x] `uv run pytest tests/ -q` → 818 passed
- [x] `uv run ruff check c_lord/tmux.py tests/test_tmux.py` → clean
- [ ] E2E: 手動作成 tmux window に対して `/clord-attach` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)