### PR TITLE
fix: TUI thinking indicator が response として leak する問題 (#39)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -74,17 +74,18 @@ _GENERATION_STATUS_MARKERS = ("Tip:", "·")
 # Markers that indicate Claude has actually started producing output:
 #   ● — assistant response paragraph
 #   ⎿ — tool result
-#   ✻ ✶ ✽ ✦ ✹ — thinking / generation indicators (when leaked into response zone)
-# If none of these appear in the post-prompt region, what we see is just the
-# user's own input echoing through the TUI and we should yield nothing.
-_RESPONSE_MARKERS: tuple[str, ...] = ("●", "⎿", "✻", "✶", "✽", "✦", "✹")
+# Thinking/generation indicators (✻ ✶ ✽ ✦ ✹) are intentionally NOT included:
+# anchoring on them caused TUI animations like "✶ Calling plugin:discord:discord…"
+# to leak as response text and stall the turn (issue #39).
+_RESPONSE_MARKERS: tuple[str, ...] = ("●", "⎿")
 
 # Lines to strip from the response (TUI hints, not useful on Discord).
 _STRIP_PATTERNS = (
     re.compile(r"● Recalled \d+ memor(?:y|ies).*"),
     re.compile(r"\(ctrl\+o to expand\)"),
-    # Thinking animations: "✻ Forming…", "* Moseying…", "· Thinking…"
-    re.compile(r"[^\w\s●⎿❯>] \w+…"),
+    # Thinking animations: "✻ Forming…", "* Moseying…", "· Thinking…",
+    # and multi-word variants like "✶ Calling plugin:discord:discord…" (#39).
+    re.compile(r"[^\w\s●⎿❯>] [^\n]+…"),
     # Completion summaries: "✻ Cooked for 56s", "* Worked for 3s"
     re.compile(r"[^\w\s●⎿❯>] \w+ for \d+s?"),
     # TUI noise — interactive prompts and greetings

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -511,6 +511,24 @@ class TestExtractResponse:
         )
         assert TmuxClaudeRunner._extract_response(pane) != ""
 
+    def test_extract_response_strips_calling_mcp_tool_indicator(self) -> None:
+        """`✶ Calling plugin:discord:discord…` is a thinking indicator,
+        not a response anchor — must not leak as content. Regression for #39.
+        """
+        pane = (
+            "❯ user question\n"
+            "\n"
+            "✶ Calling plugin:discord:discord…\n"
+            "\n"
+            "──────────────────────────────────────\n"
+            "❯ \n"
+            "──────────────────────────────────────\n"
+            "-- INSERT -- ⏵⏵ bypass permissions on\n"
+        )
+        result = TmuxClaudeRunner._extract_response(pane)
+        assert "Calling plugin:discord:discord" not in result
+        assert result == ""
+
     def test_strips_ascii_asterisk_thinking_in_chrome(self) -> None:
         """Plain * thinking indicators in bottom chrome are stripped."""
         pane = "\n".join(


### PR DESCRIPTION
## Summary
- `✶ Calling plugin:discord:discord…` のような MCP tool 呼び出し中の thinking アニメーションが `_RESPONSE_MARKERS` に含まれていたため、`_extract_response` が応答アンカーと誤認し placeholder が Discord に leak してターンが silent stall していた (#39)
- `_RESPONSE_MARKERS` を `(●, ⎿)` のみに絞り、strip 正規表現も `\w+…` → `[^\n]+…` に拡張し多語 ellipsis にも対応 (defense-in-depth)
- issue 記載のリプロを `test_extract_response_strips_calling_mcp_tool_indicator` としてユニットテスト化

Closes #39

## Test plan
- [x] `uv run pytest tests/test_tmux_runner.py` → 90 passed
- [x] `uv run pytest tests/` → 819 passed
- [x] `uv run ruff check c_lord/` / `ruff format --check` → clean
- [ ] Manual: Discord thread で MCP tool 呼び出しを伴う質問を投げ、`Calling …` placeholder が leak せず最終応答が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)