### PR TITLE
feat: structured log context + debugging guide (#20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,55 @@ curl -s -X POST -H "Authorization: Bot $TOKEN" \
 **代替: c-lord REST API (`ext/api_server.py`)**:
 api_server をオプトインで有効化してある環境では `POST /api/threads/{thread_id}/messages` で同等の操作が可能 (詳細は `docs/COMMANDS.md`)。bot を再起動せずに有効化する手段はないため、デバッグ目的では上の curl が手軽。
 
+## Debugging & Troubleshooting
+
+Bot の挙動が怪しいとき、最初に見るべき情報源は **bot ログ** と **Discord 上のメッセージ** の 2 つ。前者は `nohup` 経由で `/tmp/clord-bot.log` に出ているのが運用上の標準 (上の "Running (standalone)" 参照)。後者は `.env` を読んで Discord REST API を curl で叩く ("Debugging Discord from a Claude session" 参照 — Claude Code から実行可)。
+
+### ログの読み方
+
+すべてのログは Python `logging` 経由で `c_lord/utils/logger.py` で設定された StreamHandler に流れる。フォーマットは `%(asctime)s [%(levelname)s] %(name)s: %(message)s`。
+
+**構造化コンテキスト**: 重要な処理ポイントには `log_ctx()` ヘルパー (`c_lord/utils/logger.py`) で `[thread=<id> session=<short> task=<id> channel=<id>]` 形式の prefix が付く。これで `grep "thread=12345"` すると 1 スレッドの一連の処理を抽出できる。`session=` は UUID-shaped (≥32 文字) のときは先頭セグメントだけに省略される。
+
+**主要な入口/出口ログ**:
+- `_run_helper.py:run_claude_with_config` — `run_claude: enter` / `run_claude: exit` (Claude 実行 1 回ごと)
+- `cogs/scheduler.py:_run_task` — `_run_task: enter` / `_run_task: exit` (スケジュール実行ごと)
+- `cogs/scheduler.py:_master_loop` — `SchedulerCog: N task(s) due (ids=[...])` (30 秒ごと、due があるときのみ)
+- `cogs/webhook_trigger.py:on_message` — `Webhook trigger matched` (CI/CD webhook 着弾時)
+
+**典型的な調査フロー**:
+1. Discord で問題のスレッド ID を取得 (URL の末尾、または右クリック → Copy ID)
+2. `grep "thread=<ID>" /tmp/clord-bot.log` で当該スレッドの処理ログを抽出
+3. `enter` と `exit` の対応関係 / エラー stacktrace の有無を確認
+4. `session=<short>` を別途 grep すると Claude CLI 側のセッションスコープも追える
+
+新規にログを書くときは、**thread / session / task / channel のいずれかが文脈上ある場合は必ず `log_ctx()` を使う**。素の文字列 interpolation を増やすと grep 性が落ちる。
+
+### セッションライフサイクル
+
+c-lord で 1 つの「セッション」が辿る状態遷移:
+
+1. **作成** — ユーザーがチャンネルにメッセージ → `ClaudeChatCog` がスレッドを作成
+2. **session_dir セットアップ** — `session_dir.py` が `c-lord-sessions/<channel_id>/<thread_id>/` に repo を git clone (channel が `/clord-init` で repo に bind されている場合のみ)
+3. **tmux window 作成** — `tmux.py::resolve_tmux_manager(channel_id)` で per-channel session を取得し、新規 window (`work1`, `work2`, ...) を立てる
+4. **Claude CLI 起動** — `claude/tmux_runner.py` が tmux window 内で `claude` コマンドを起動。stream-json で stdout を読みつつ Discord にストリーミング表示
+5. **応答完了** — `EventProcessor.finalize()` で最終応答を post、reaction 更新、registry から unregister
+6. **継続** — 同じスレッドへの reply は session_id を `--resume` で渡して同一セッションを継続
+7. **クリーンアップ (任意)** — `_cleanup_session_dir` / `_cleanup_tmux_session` (現状はコマンド経由で明示的にトリガ。スレッド close 時の自動クリーンアップは未実装)
+
+**よくある問題と確認手順**:
+
+| 症状 | 最初に見るべき場所 | 典型的な原因 |
+|------|-----------------|------------|
+| スレッドが作られない | bot ログの `on_message` 周辺、`DISCORD_CHANNEL_ID` が一致しているか | Intent 不足 / channel ID 設定ミス |
+| 応答が返ってこない | `grep "thread=<ID>"` で `run_claude: enter` はあるか / `exit` まで届くか | tmux window 作成失敗、Claude CLI hang、timeout |
+| 同一セッションのはずが別セッション扱い | `_run_helper` で `session_id=` ログを確認、DB の `sessions` テーブル | repository から session_id が読めていない |
+| Webhook trigger が無視される | `Webhook trigger matched` ログの有無 | webhook_id allowlist / channel_ids 不一致、prefix mismatch |
+| Scheduler が動かない | `SchedulerCog: N task(s) due` の有無 (30 秒間隔) | `next_run_at` が未来、`scheduled_tasks` が空 |
+| tmux session が見つからない | `tmux ls` で session 名を確認 | channel に `/clord-init` 未実行 → fallback `clord` を期待してしまう。常に `resolve_tmux_manager(channel_id)` 経由で取得 |
+
+これでも切り分かないときは Discord 側の状態 (リアクション・スレッド存在・最終メッセージの author) を上の curl で確認するのが速い。
+
 ## Code Conventions
 
 ### Style

--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -30,6 +30,7 @@ from ..discord_ui.streaming_manager import (  # noqa: F401
 )
 from ..discord_ui.tool_timer import TOOL_TIMER_INTERVAL, LiveToolTimer  # noqa: F401
 from ..lounge import build_lounge_prompt
+from ..utils.logger import log_ctx
 from .event_processor import EventProcessor
 from .run_config import RunConfig  # noqa: F401
 
@@ -172,6 +173,9 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
     Returns:
         The final session_id, or None if the run failed.
     """
+    ctx = log_ctx(thread_id=config.thread.id, session_id=config.session_id)
+    logger.info("%s run_claude: enter (prompt=%d chars)", ctx, len(config.prompt))
+
     # Build system context for side effects (session registry, lounge prompt).
     # The context string itself is not injected — tmux TUI mode does not
     # support --append-system-prompt.
@@ -186,7 +190,7 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
                 continue
             await processor.process(event)
     except Exception:
-        logger.exception("Error running Claude CLI for thread %d", config.thread.id)
+        logger.exception("%s Error running Claude CLI", ctx)
         # Wrap Discord sends in suppress — the connection may already be closed
         # (e.g. ServerDisconnectedError on bot shutdown), and sending would fail too.
         with contextlib.suppress(Exception):
@@ -213,11 +217,15 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
         )
         if answer_prompt:
             logger.info(
-                "Resuming session %s after AskUserQuestion answer",
-                processor.session_id,
+                "%s Resuming after AskUserQuestion answer",
+                log_ctx(thread_id=config.thread.id, session_id=processor.session_id),
             )
             return await run_claude_with_config(config.with_prompt(answer_prompt))
 
+    logger.info(
+        "%s run_claude: exit",
+        log_ctx(thread_id=config.thread.id, session_id=processor.session_id),
+    )
     return processor.session_id
 
 

--- a/c_lord/cogs/scheduler.py
+++ b/c_lord/cogs/scheduler.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 import discord
 from discord.ext import commands, tasks
 
+from ..utils.logger import log_ctx
 from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
 
@@ -73,11 +74,12 @@ class SchedulerCog(commands.Cog):
         if not due:
             return
 
-        logger.info("SchedulerCog: %d task(s) due", len(due))
+        due_ids = [t["id"] for t in due]
+        logger.info("SchedulerCog: %d task(s) due (ids=%s)", len(due), due_ids)
         for task in due:
             task_id: int = task["id"]
             if task_id in self._running:
-                logger.debug("Task %d still running — skipping", task_id)
+                logger.debug("%s still running — skipping", log_ctx(task_id=task_id))
                 continue
 
             # Advance next_run_at *before* spawning to prevent duplicate runs
@@ -107,29 +109,21 @@ class SchedulerCog(commands.Cog):
         from ..claude.tmux_runner import TmuxClaudeRunner
 
         task_id: int = task["id"]
+        ctx = log_ctx(task_id=task_id, channel_id=task["channel_id"])
         self._running.add(task_id)
+        logger.info("%s _run_task: enter (name=%s)", ctx, task["name"])
         try:
             channel = self.bot.get_channel(task["channel_id"])
             if channel is None:
-                logger.warning(
-                    "SchedulerCog: channel %d not found for task %d (%s)",
-                    task["channel_id"],
-                    task_id,
-                    task["name"],
-                )
+                logger.warning("%s channel not found (name=%s)", ctx, task["name"])
                 return
             if not isinstance(channel, discord.TextChannel):
-                logger.warning("SchedulerCog: channel %d is not a TextChannel", task["channel_id"])
+                logger.warning("%s channel is not a TextChannel", ctx)
                 return
 
             tmux = await self._resolve_tmux_manager(channel.id)
             if tmux is None:
-                logger.warning(
-                    "SchedulerCog: no tmux manager for channel %d, task %d (%s)",
-                    task["channel_id"],
-                    task_id,
-                    task["name"],
-                )
+                logger.warning("%s no tmux manager (name=%s)", ctx, task["name"])
                 return
 
             # Post a starter message first so the thread appears in the channel
@@ -164,6 +158,7 @@ class SchedulerCog(commands.Cog):
             )
 
         except Exception:
-            logger.exception("SchedulerCog: task %d (%s) failed", task_id, task["name"])
+            logger.exception("%s task failed (name=%s)", ctx, task["name"])
         finally:
             self._running.discard(task_id)
+            logger.info("%s _run_task: exit", ctx)

--- a/c_lord/cogs/webhook_trigger.py
+++ b/c_lord/cogs/webhook_trigger.py
@@ -23,6 +23,7 @@ from discord.ext import commands
 from ..cogs._run_helper import run_claude_with_config
 from ..cogs.run_config import RunConfig
 from ..concurrency import SessionRegistry
+from ..utils.logger import log_ctx
 
 if TYPE_CHECKING:
     from ..claude.config import ClaudeConfig
@@ -117,7 +118,8 @@ class WebhookTriggerCog(commands.Cog):
             return
 
         logger.info(
-            "Webhook trigger matched: prefix=%r, webhook_id=%d",
+            "%s Webhook trigger matched: prefix=%r, webhook_id=%d",
+            log_ctx(channel_id=message.channel.id),
             matched_prefix,
             message.webhook_id,
         )

--- a/c_lord/utils/logger.py
+++ b/c_lord/utils/logger.py
@@ -1,5 +1,7 @@
 """Logging configuration."""
 
+from __future__ import annotations
+
 import logging
 import sys
 
@@ -21,3 +23,36 @@ def setup_logging(level: int = logging.INFO) -> None:
     # Quiet down discord.py's verbose logging
     logging.getLogger("discord").setLevel(logging.WARNING)
     logging.getLogger("discord.http").setLevel(logging.WARNING)
+
+
+def log_ctx(
+    *,
+    thread_id: int | None = None,
+    session_id: str | None = None,
+    task_id: int | None = None,
+    channel_id: int | None = None,
+) -> str:
+    """Format a structured context prefix for log messages.
+
+    Returns ``"[thread=<id> session=<short> task=<id> channel=<id>]"`` (only
+    fields that are not None are included). Returns ``""`` when all fields
+    are None. Session IDs are truncated to the first UUID segment so that long
+    UUIDs do not dominate log lines while remaining greppable.
+
+    Use this at process entry/exit points and any log line where a reader needs
+    to filter by ``thread_id`` or ``session_id``.
+    """
+    parts: list[str] = []
+    if thread_id is not None:
+        parts.append(f"thread={thread_id}")
+    if session_id is not None:
+        # Truncate UUID-shaped IDs (8-4-4-4-12) to the first segment for readability.
+        short = session_id.split("-", 1)[0] if len(session_id) >= 32 else session_id
+        parts.append(f"session={short}")
+    if task_id is not None:
+        parts.append(f"task={task_id}")
+    if channel_id is not None:
+        parts.append(f"channel={channel_id}")
+    if not parts:
+        return ""
+    return "[" + " ".join(parts) + "]"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,32 @@
+"""Tests for log context helper."""
+
+from __future__ import annotations
+
+from c_lord.utils.logger import log_ctx
+
+
+def test_log_ctx_thread_only() -> None:
+    assert log_ctx(thread_id=123) == "[thread=123]"
+
+
+def test_log_ctx_thread_and_session() -> None:
+    assert log_ctx(thread_id=123, session_id="abc-def") == "[thread=123 session=abc-def]"
+
+
+def test_log_ctx_all_fields() -> None:
+    out = log_ctx(thread_id=1, session_id="s", task_id=7, channel_id=99)
+    assert out == "[thread=1 session=s task=7 channel=99]"
+
+
+def test_log_ctx_empty_returns_empty_string() -> None:
+    assert log_ctx() == ""
+
+
+def test_log_ctx_skips_none_values() -> None:
+    assert log_ctx(thread_id=1, session_id=None, task_id=None) == "[thread=1]"
+
+
+def test_log_ctx_truncates_long_session_id() -> None:
+    # Full UUIDs are noisy in logs; the helper keeps them readable.
+    out = log_ctx(session_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    assert out == "[session=aaaaaaaa]"


### PR DESCRIPTION
Closes #20.

## Summary
- Adds `log_ctx()` helper in `c_lord/utils/logger.py` that formats `[thread=X session=Y task=Z channel=W]` prefixes. UUID-shaped session IDs are truncated to the first segment so log lines stay readable while remaining greppable.
- Applies the helper at process entry/exit in `_run_helper.run_claude_with_config`, `SchedulerCog._run_task` / `_master_loop`, and `WebhookTriggerCog.on_message`. Operators can now `grep "thread=<id>" /tmp/clord-bot.log` to extract a single thread's lifecycle.
- Adds a top-level `## Debugging & Troubleshooting` section to `CLAUDE.md` with a log-reading guide, session lifecycle walkthrough, and a common-issues table. The existing "Debugging Discord from a Claude session" section stays where it is and is referenced from the new section.

## Test plan
- [x] `uv run pytest tests/test_logger.py -v` (6 new tests, TDD: written RED → GREEN)
- [x] `uv run pytest tests/ --ignore=tests/e2e` — 825 passed
- [x] `uv run ruff check c_lord/` — clean
- [x] `uv run ruff format --check c_lord/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)