### PR TITLE
fix: Discord 応答の行頭インデント正規化 + effort footer strip (#43, #50)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"9017782b-bd0e-45dd-88e3-417a9bf40da7","pid":141404,"procStart":"45243731","acquiredAt":1778465473715}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"9017782b-bd0e-45dd-88e3-417a9bf40da7","pid":141404,"procStart":"45243731","acquiredAt":1778465473715}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ htmlcov/
 
 # Personal workflow scripts (not part of the OSS framework)
 tmux.sh
+.claude/scheduled_tasks.lock

--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -112,6 +112,10 @@ _STRIP_PATTERNS = (
     re.compile(r"⎇\s.+\scwd:.+"),  # ccstatusline row 3 ("⎇ branch ... cwd: ...")
     re.compile(r"\d+\s+skill descriptions?\s+dropped.*"),
     re.compile(r"Tip:\s.+"),  # TUI hint line ("Tip: Use Plan Mode ...")
+    # Issue #50: effort/model footer indicator ("◐ medium · /effort", "○ low · /effort").
+    # Geometric Shapes block (U+25A0–U+25FF) is not covered by _GENERATION_STATUS_RE
+    # which only matches Dingbats (U+2700–U+27BF).
+    re.compile(r"^[■-◿]\s+\w+\s+·\s+/\w+"),
 )
 
 

--- a/c_lord/discord_ui/chunker.py
+++ b/c_lord/discord_ui/chunker.py
@@ -11,6 +11,8 @@ across messages both appear with correct column alignment.
 
 from __future__ import annotations
 
+import textwrap
+
 DISCORD_MAX_CHARS = 2000
 # Leave room for fence reopening overhead
 EFFECTIVE_MAX = DISCORD_MAX_CHARS - 50
@@ -29,6 +31,7 @@ def chunk_message(text: str, max_chars: int = EFFECTIVE_MAX) -> list[str]:
     if not text:
         return []
 
+    text = _normalize_leading_indent(text)
     text = _wrap_tables_in_fences(text)
 
     if len(text) <= max_chars:
@@ -56,6 +59,51 @@ def chunk_message(text: str, max_chars: int = EFFECTIVE_MAX) -> list[str]:
             remaining = f"```{fence_lang}\n{remaining}"
 
     return [c for c in chunks if c.strip()]
+
+
+def _normalize_leading_indent(text: str) -> str:
+    """Strip spurious common leading whitespace from each paragraph.
+
+    Discord (CommonMark) treats ``  - item`` as a nested list item even when
+    there is no parent bullet at less indent. Claude sometimes emits flat
+    bullet lists with leading spaces, which renders as visually nested on
+    Discord. ``textwrap.dedent`` applied per paragraph removes the common
+    indent — real nested lists (parent at col 0 in the same paragraph) have
+    a common min of 0 and stay unchanged, while flat indented lists collapse
+    to col 0.
+
+    Lines inside fenced code blocks (``` ... ```) are passed through verbatim.
+    """
+    if not text:
+        return text
+
+    lines = text.split("\n")
+    result: list[str] = []
+    in_fence = False
+    paragraph: list[str] = []
+
+    def flush() -> None:
+        if paragraph:
+            block = "\n".join(paragraph)
+            result.extend(textwrap.dedent(block).split("\n"))
+            paragraph.clear()
+
+    for line in lines:
+        if line.lstrip().startswith("```"):
+            flush()
+            result.append(line)
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            result.append(line)
+            continue
+        if line.strip() == "":
+            flush()
+            result.append(line)
+        else:
+            paragraph.append(line)
+    flush()
+    return "\n".join(result)
 
 
 def _wrap_tables_in_fences(text: str) -> str:

--- a/c_lord/discord_ui/streaming_manager.py
+++ b/c_lord/discord_ui/streaming_manager.py
@@ -13,6 +13,8 @@ import time
 
 import discord
 
+from .chunker import _normalize_leading_indent
+
 logger = logging.getLogger(__name__)
 
 # Streaming message edit interval (seconds). Discord rate limit is 5 edits/5s.
@@ -82,7 +84,7 @@ class StreamingMessageManager:
         if not self._buffer:
             return
 
-        display_text = self._buffer
+        display_text = _normalize_leading_indent(self._buffer)
         if len(display_text) > 2000:
             display_text = display_text[:1997] + "..."
 

--- a/tests/e2e/test_message_flow.py
+++ b/tests/e2e/test_message_flow.py
@@ -23,6 +23,7 @@ CHROME_BLACKLIST = (
     "Tip: Use Plan Mode",  # TUI hint
     "skill descriptions dropped",  # /doctor indicator
     "-- INSERT --",  # vim status bar
+    "· /effort",  # Issue #50: effort/model footer ("◐ medium · /effort")
 )
 
 

--- a/tests/e2e/test_message_flow.py
+++ b/tests/e2e/test_message_flow.py
@@ -85,3 +85,45 @@ def test_url_in_reply_has_embeds_suppressed(
     flags = reply.get("flags", 0)
     assert flags & 4, f"SUPPRESS_EMBEDS flag missing (flags={flags}). PR #33 regression."
     assert not reply.get("embeds"), "Reply contains embed cards despite SUPPRESS_EMBEDS"
+
+
+@pytest.mark.e2e
+def test_bullet_list_leading_indent_is_normalized(
+    discord_client: DiscordE2EClient,
+    bot_id: str,
+    attached_thread_id: str,
+) -> None:
+    """Issue #43: flat bullet lists with leading spaces must be flattened.
+
+    Claude is asked to echo a bullet list with 2-space leading indent. The
+    bot's reply must contain the bullets at column 0, not indented (otherwise
+    Discord renders them as nested under nothing — the regression we fixed).
+    """
+    marker = "e2e-43-indent-zk9"
+    wh = discord_client.webhook_post(
+        "以下を返答にそのままコピーして含めてください。説明不要、装飾不要、"
+        f"marker `{marker}` を含めること:\n\n"
+        f"result {marker}:\n\n  - alpha\n  - beta\n  - gamma",
+        thread_id=attached_thread_id,
+    )
+
+    reply = discord_client.wait_for_bot_reply(
+        attached_thread_id,
+        after_message_id=wh["id"],
+        bot_id=bot_id,
+        contains=marker,
+        timeout=180.0,
+        poll=4.0,
+    )
+    assert reply is not None, f"Bot did not reply with marker {marker!r} within 180s"
+
+    content = reply["content"]
+    # Each bullet must appear at column 0, not preceded by spaces — otherwise
+    # Discord (CommonMark) renders them as a nested list with no parent.
+    for token in ("- alpha", "- beta", "- gamma"):
+        assert f"\n{token}" in content or content.startswith(token), (
+            f"Bullet {token!r} not at column 0 in reply: {content!r}"
+        )
+        assert f"  {token}" not in content, (
+            f"Bullet {token!r} still preceded by indent in reply: {content!r}"
+        )

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -3,6 +3,7 @@
 from c_lord.discord_ui.chunker import (
     _close_open_fence,
     _is_table_line,
+    _normalize_leading_indent,
     _wrap_tables_in_fences,
     chunk_message,
 )
@@ -150,6 +151,55 @@ class TestTableChunking:
             if "| val |" in chunk or "| Col |" in chunk:
                 fence_count = chunk.count("```")
                 assert fence_count % 2 == 0, f"Chunk {i} has unbalanced fences: {chunk[:120]!r}"
+
+
+class TestNormalizeLeadingIndent:
+    def test_flat_bullet_list_dedented(self):
+        """Issue #43: flat `  - ` bullets with no parent get dedented."""
+        text = "残り 2 件:\n\n  - #38 — foo\n  - #20 — bar"
+        result = _normalize_leading_indent(text)
+        assert "\n- #38 — foo\n- #20 — bar" in result
+
+    def test_real_nested_list_preserved(self):
+        """Nested list with parent in same paragraph is not dedented."""
+        text = "- top\n  - nested\n  - also nested"
+        result = _normalize_leading_indent(text)
+        assert result == text
+
+    def test_fenced_content_untouched(self):
+        """Lines inside ``` fences keep their leading whitespace."""
+        text = "```\n  indented in fence\n    deeper\n```"
+        result = _normalize_leading_indent(text)
+        assert result == text
+
+    def test_paragraphs_dedented_independently(self):
+        """Each paragraph computes its own common indent."""
+        text = "  first para\n  also indented\n\n    second para deeper"
+        result = _normalize_leading_indent(text)
+        assert result == "first para\nalso indented\n\nsecond para deeper"
+
+    def test_empty_text(self):
+        assert _normalize_leading_indent("") == ""
+
+    def test_no_leading_whitespace_unchanged(self):
+        text = "Hello\n\nWorld"
+        assert _normalize_leading_indent(text) == text
+
+    def test_gh_output_paragraph_first_line_flush(self):
+        """gh-style output where header is flush and rows are indented: first
+        line at col 0 prevents dedent (common min = 0), so other lines keep
+        their indent. Acceptable — those rows are not bullets and don't get
+        misread as nested lists."""
+        text = "Bash(gh issue list)\n  38 OPEN foo\n     20 OPEN bar"
+        result = _normalize_leading_indent(text)
+        assert result == text
+
+    def test_chunk_message_applies_normalization(self):
+        """chunk_message should dedent flat bullet lists before chunking."""
+        text = "Header:\n\n  - item one\n  - item two"
+        chunks = chunk_message(text)
+        assert "- item one" in chunks[0]
+        assert "  - item one" not in chunks[0]
 
 
 class TestCloseOpenFence:

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -625,6 +625,19 @@ class TestCleanTuiLines:
         )
         assert result == "Real response."
 
+    def test_strips_effort_indicator(self) -> None:
+        """'◐ medium · /effort' TUI footer must not leak (Issue #50)."""
+        result = _clean_tui_lines(
+            [
+                "● Real response.",
+                "",
+                "◐ medium · /effort",
+            ]
+        )
+        assert "◐" not in result
+        assert "/effort" not in result
+        assert "Real response." in result
+
     def test_strips_skill_descriptions_dropped_indicator(self) -> None:
         """'N skill descriptions dropped · /doctor for details' is TUI noise."""
         result = _clean_tui_lines(


### PR DESCRIPTION
## Summary

- **#43**: `chunk_message` と `StreamingMessageManager._flush` の手前で `_normalize_leading_indent` を適用 — 段落単位で `textwrap.dedent` するため、real nested list (親が col 0) は無変化、flat な `  - ` bullet は col 0 に flatten される。fenced code block 内は verbatim 通過
- **#50** (E2E 中に発見): `_STRIP_PATTERNS` に Geometric Shapes ベースの effort/model footer (`◐ medium · /effort`) 用パターンを追加。`_GENERATION_STATUS_RE` は Dingbats のみだったのですり抜けていた

Closes #43, #50

## Test plan

- [x] `uv run pytest tests/test_chunker.py -v` — 37 passed (うち新規 8 件、#43)
- [x] `uv run pytest tests/test_tmux_runner.py -v` — 90 passed (うち新規 1 件、#50)
- [x] `uv run pytest tests/ -q` — 825 passed
- [x] `uv run ruff check c_lord/` / `ruff format --check c_lord/`
- [x] **E2E** (実 Claude + Discord、テスト用 Bot/チャンネル/Webhook/attached thread をセットアップ):
  - `test_simple_message_gets_response_without_chrome` PASSED (CHROME_BLACKLIST に `· /effort` 追加で #50 を回帰チェック)
  - `test_url_in_reply_has_embeds_suppressed` PASSED
  - `test_bullet_list_leading_indent_is_normalized` PASSED (#43 新規)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
