### PR TITLE
feat: progress.txt 添付で最終応答を折り畳む (#38)

### DIFF
--- a/c_lord/cogs/event_processor.py
+++ b/c_lord/cogs/event_processor.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import contextlib
 import logging
 
+import discord
+
 from ..claude.types import AskQuestion, MessageType, SessionState, StreamEvent
 from ..discord_ui.chunker import chunk_message
 from ..discord_ui.elicitation_view import ElicitationFormView, ElicitationUrlView
@@ -29,6 +31,7 @@ from ..discord_ui.embeds import (
 )
 from ..discord_ui.permission_view import PermissionView
 from ..discord_ui.plan_view import PlanApprovalView
+from ..discord_ui.progress_buffer import ProgressBuffer
 from ..discord_ui.streaming_manager import StreamingMessageManager
 from ..discord_ui.tool_timer import LiveToolTimer
 from .run_config import RunConfig
@@ -93,6 +96,13 @@ class EventProcessor:
         # (skip events) then handle the ask after the stream ends.
         self._pending_ask: list[AskQuestion] | None = None
 
+        # Accumulates events for progress.txt attachment (Issue #38).
+        self._progress = ProgressBuffer()
+
+        # The last Discord message we sent assistant text to. ``_on_complete``
+        # edits this with the progress.txt attachment when tools were used.
+        self._last_assistant_message: discord.Message | None = None
+
     # ------------------------------------------------------------------
     # Public properties
     # ------------------------------------------------------------------
@@ -123,6 +133,7 @@ class EventProcessor:
 
     async def process(self, event: StreamEvent) -> None:
         """Dispatch a single stream event to the appropriate handler."""
+        self._progress.add(event)
         if event.message_type == MessageType.SYSTEM:
             await self._on_system(event)
         elif event.message_type == MessageType.ASSISTANT:
@@ -251,6 +262,8 @@ class EventProcessor:
         if self._streamer.has_content:
             await self._streamer.finalize()
             self._assistant_text_sent = True
+            if self._streamer.last_message is not None:
+                self._last_assistant_message = self._streamer.last_message
 
         if event.error:
             await self._config.thread.send(embed=_make_error_embed(event.error))
@@ -261,10 +274,14 @@ class EventProcessor:
             response_text = event.text
             if response_text and not self._assistant_text_sent:
                 for chunk in chunk_message(response_text):
-                    await self._config.thread.send(chunk)
+                    sent = await self._config.thread.send(chunk)
+                    self._last_assistant_message = sent
 
             if self._config.status:
                 await self._config.status.set_done()
+
+        # Attach progress.txt to the final message (Issue #38).
+        await self._maybe_attach_progress()
 
         if event.session_id:
             if self._config.repo:
@@ -294,11 +311,14 @@ class EventProcessor:
                 if delta:
                     await self._streamer.append(delta)
                 await self._streamer.finalize()
+                if self._streamer.last_message is not None:
+                    self._last_assistant_message = self._streamer.last_message
                 self._streamer = StreamingMessageManager(self._config.thread)
             else:
                 # No partial events arrived — post the full text directly.
                 for chunk in chunk_message(event.text):
-                    await self._config.thread.send(chunk)
+                    sent = await self._config.thread.send(chunk)
+                    self._last_assistant_message = sent
             self._state.partial_text = ""
             self._state.accumulated_text = event.text
             self._assistant_text_sent = True
@@ -391,6 +411,34 @@ class EventProcessor:
             # Subsequent updates: edit in-place.
             with contextlib.suppress(Exception):
                 await self._state.todo_message.edit(embed=embed)
+
+    async def _maybe_attach_progress(self) -> None:
+        """Edit the last assistant message to attach ``progress-*.txt`` (Issue #38).
+
+        Skips silently when there is nothing to attach (no tool use, or the
+        assistant text was never posted as a regular message — e.g. error path).
+        Discord ``Message.edit(attachments=[...])`` replaces existing attachments;
+        the assistant message has none, so this just adds the file.
+        """
+        if self._last_assistant_message is None:
+            return
+        progress_file = self._progress.to_discord_file()
+        if progress_file is None:
+            return
+        try:
+            await self._last_assistant_message.edit(attachments=[progress_file])
+            logger.info(
+                "Attached %s to final message (events=%d, tools=%d)",
+                progress_file.filename,
+                len(self._progress._events),
+                self._progress.tool_count,
+            )
+        except discord.HTTPException:
+            logger.warning(
+                "Failed to attach progress.txt to thread %d",
+                self._config.thread.id,
+                exc_info=True,
+            )
 
     async def _bump_stop(self) -> None:
         """Move the Stop button to the bottom of the thread if configured."""

--- a/c_lord/discord_ui/progress_buffer.py
+++ b/c_lord/discord_ui/progress_buffer.py
@@ -22,6 +22,7 @@ import json
 import re
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
+from enum import Enum
 from io import BytesIO
 from typing import Any
 
@@ -178,6 +179,6 @@ def _dataclass_to_dict(obj: Any) -> Any:
         return [_dataclass_to_dict(v) for v in obj]
     if isinstance(obj, dict):
         return {k: _dataclass_to_dict(v) for k, v in obj.items()}
-    if hasattr(obj, "value") and hasattr(obj, "name"):  # Enum
+    if isinstance(obj, Enum):
         return obj.value
     return obj

--- a/c_lord/discord_ui/progress_buffer.py
+++ b/c_lord/discord_ui/progress_buffer.py
@@ -1,0 +1,183 @@
+"""ProgressBuffer — accumulate StreamEvents into a ``progress-*.txt`` attachment.
+
+Issue #38: the streamed reply often contains tool-call headers and command
+output inline because c-lord captures Claude Code's TUI via ``tmux
+capture-pane`` (not stream-json). progress.txt gives the user a structured
+record of the run that they can download from the final message, without
+trying to clean up the streamed body (that is a follow-up — TUI parsing is
+fragile and out of scope here).
+
+Design choices (decided per Issue #38 discussion):
+
+* **Content**: each StreamEvent is serialized as one JSON line.
+* **Filename**: ``progress-YYYYMMDD-HHMMSS.txt`` so multiple replies in the
+  same thread are easy to tell apart.
+* **Skip condition**: ``tool_count == 0`` means a simple text-only Q&A —
+  attaching an empty-looking progress file is just noise, so we skip.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from io import BytesIO
+from typing import Any
+
+import discord
+
+from ..claude.types import MessageType, StreamEvent
+
+# c-lord captures Claude Code's TUI via ``tmux capture-pane`` rather than
+# parsing stream-json, so ``event.tool_use`` is rarely populated. We instead
+# scan the captured text for ``ToolName(arg)`` patterns at the start of a
+# line — that is how the TUI renders an in-flight tool call.
+_TUI_TOOL_NAMES = (
+    "Bash",
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "LS",
+    "WebFetch",
+    "WebSearch",
+    "Task",
+    "TodoWrite",
+    "NotebookEdit",
+    "ExitPlanMode",
+    "AskUserQuestion",
+)
+_TUI_TOOL_PATTERN = re.compile(
+    # Closing ``)`` is required so that partial captures growing into a tool
+    # call (e.g. ``Bash(echo``) do not count until the call is complete.
+    r"(?m)^(?P<name>" + "|".join(_TUI_TOOL_NAMES) + r")\((?P<arg>[^)\n]{0,200})\)",
+)
+
+
+class ProgressBuffer:
+    """Accumulate StreamEvents and emit them as a ``progress-*.txt`` attachment.
+
+    One instance per Claude Code run. Wire ``add(event)`` into the event
+    dispatch loop, then call ``to_discord_file()`` once the run is complete.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[dict[str, Any]] = []
+        self._tool_ids: set[str] = set()
+        # Tool calls detected via TUI text scanning. Identified by their
+        # ``ToolName(arg)`` signature so partial events that grow the same
+        # capture do not double-count.
+        self._tui_tool_signatures: set[str] = set()
+
+    @property
+    def tool_count(self) -> int:
+        """Number of distinct tool calls seen during this run.
+
+        Counts both parsed ``tool_use`` events (when available) and tool calls
+        detected by scanning the TUI text capture (the common case under
+        c-lord's tmux-based runner).
+        """
+        return len(self._tool_ids) + len(self._tui_tool_signatures)
+
+    @property
+    def should_attach(self) -> bool:
+        """True iff the buffer is worth attaching as ``progress.txt``.
+
+        Per design: attach only when at least one tool call was made. Pure
+        text Q&A is left without an attachment to keep the thread clean.
+        """
+        return self.tool_count > 0
+
+    def add(self, event: StreamEvent) -> None:
+        """Record one StreamEvent in the buffer.
+
+        PROGRESS events are skipped — they are stall-timer resets carrying no
+        payload, and including them just bloats the file.
+        """
+        if event.message_type == MessageType.PROGRESS:
+            return
+
+        if event.tool_use is not None:
+            self._tool_ids.add(event.tool_use.tool_id)
+        if event.text:
+            for m in _TUI_TOOL_PATTERN.finditer(event.text):
+                # Use ``ToolName(arg-prefix)`` as a stable signature so growing
+                # partial captures of the same call coalesce.
+                self._tui_tool_signatures.add(f"{m.group('name')}({m.group('arg')}")
+
+        self._events.append(_serialize_event(event))
+
+    def to_jsonl(self) -> str:
+        """Return all recorded events as a JSONL string (one event per line)."""
+        return "\n".join(json.dumps(e, ensure_ascii=False) for e in self._events)
+
+    def to_discord_file(self, *, now: datetime | None = None) -> discord.File | None:
+        """Return a ``discord.File`` ready to attach, or ``None`` to skip.
+
+        ``now`` is injectable for testing — defaults to ``datetime.now()``.
+        """
+        if not self.should_attach:
+            return None
+        when = now or datetime.now()
+        filename = f"progress-{when.strftime('%Y%m%d-%H%M%S')}.txt"
+        payload = self.to_jsonl().encode("utf-8")
+        return discord.File(BytesIO(payload), filename=filename)
+
+
+def _serialize_event(event: StreamEvent) -> dict[str, Any]:
+    """Convert a StreamEvent to a JSON-serializable dict.
+
+    Only fields that are non-None / non-empty are emitted, to keep each line
+    short and readable. Nested dataclasses (ToolUseEvent, AskQuestion, etc.)
+    are recursively converted; Enums are coerced to their ``.value``.
+    """
+    out: dict[str, Any] = {"type": event.message_type.value}
+    fields = (
+        "session_id",
+        "text",
+        "thinking",
+        "has_redacted_thinking",
+        "tool_result_id",
+        "tool_result_content",
+        "is_partial",
+        "is_complete",
+        "is_compact",
+        "compact_trigger",
+        "compact_pre_tokens",
+        "cost_usd",
+        "duration_ms",
+        "input_tokens",
+        "output_tokens",
+        "error",
+    )
+    for name in fields:
+        value = getattr(event, name)
+        if value is None or value is False:
+            continue
+        out[name] = value
+    if event.tool_use is not None:
+        out["tool_use"] = _dataclass_to_dict(event.tool_use)
+    if event.ask_questions:
+        out["ask_questions"] = [_dataclass_to_dict(q) for q in event.ask_questions]
+    if event.todo_list:
+        out["todo_list"] = [_dataclass_to_dict(t) for t in event.todo_list]
+    if event.permission_request is not None:
+        out["permission_request"] = _dataclass_to_dict(event.permission_request)
+    if event.elicitation is not None:
+        out["elicitation"] = _dataclass_to_dict(event.elicitation)
+    return out
+
+
+def _dataclass_to_dict(obj: Any) -> Any:
+    """Recursively convert a dataclass into JSON-serializable primitives."""
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return {k: _dataclass_to_dict(v) for k, v in asdict(obj).items()}
+    if isinstance(obj, list):
+        return [_dataclass_to_dict(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _dataclass_to_dict(v) for k, v in obj.items()}
+    if hasattr(obj, "value") and hasattr(obj, "name"):  # Enum
+        return obj.value
+    return obj

--- a/c_lord/discord_ui/streaming_manager.py
+++ b/c_lord/discord_ui/streaming_manager.py
@@ -41,6 +41,11 @@ class StreamingMessageManager:
     def has_content(self) -> bool:
         return bool(self._buffer)
 
+    @property
+    def last_message(self) -> discord.Message | None:
+        """The most recent Discord message this manager sent/edited, if any."""
+        return self._current_message
+
     async def append(self, text: str) -> None:
         """Append text to the streaming buffer and schedule an edit."""
         if self._finalized:

--- a/tests/test_progress_buffer.py
+++ b/tests/test_progress_buffer.py
@@ -1,0 +1,184 @@
+"""Tests for ProgressBuffer — accumulate StreamEvents into a progress.txt attachment."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import discord
+import pytest
+
+from c_lord.claude.types import (
+    MessageType,
+    StreamEvent,
+    ToolCategory,
+    ToolUseEvent,
+)
+from c_lord.discord_ui.progress_buffer import ProgressBuffer
+
+
+def _make_assistant_event(
+    text: str | None = None, tool_use: ToolUseEvent | None = None
+) -> StreamEvent:
+    return StreamEvent(
+        message_type=MessageType.ASSISTANT,
+        text=text,
+        tool_use=tool_use,
+    )
+
+
+def _make_tool_use(name: str, tool_id: str = "t1") -> ToolUseEvent:
+    return ToolUseEvent(
+        tool_id=tool_id,
+        tool_name=name,
+        tool_input={"k": "v"},
+        category=ToolCategory.COMMAND,
+    )
+
+
+class TestProgressBufferBasic:
+    def test_empty_buffer_should_not_attach(self) -> None:
+        buf = ProgressBuffer()
+        assert buf.should_attach is False
+        assert buf.tool_count == 0
+
+    def test_add_event_with_tool_use_marks_attach(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(tool_use=_make_tool_use("Bash")))
+        assert buf.tool_count == 1
+        assert buf.should_attach is True
+
+    def test_text_only_does_not_trigger_attach(self) -> None:
+        # Short text reply with no tools — should skip (per design: tool count 0 skips).
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(text="hello"))
+        assert buf.tool_count == 0
+        assert buf.should_attach is False
+
+    def test_multiple_tools_increment_count(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(tool_use=_make_tool_use("Bash", "t1")))
+        buf.add(_make_assistant_event(tool_use=_make_tool_use("Read", "t2")))
+        assert buf.tool_count == 2
+
+    def test_same_tool_id_counted_once(self) -> None:
+        # tmux_runner may yield the same tool_use multiple times (partial events).
+        # We count distinct tool_ids.
+        buf = ProgressBuffer()
+        tu = _make_tool_use("Bash", "t1")
+        buf.add(_make_assistant_event(tool_use=tu))
+        buf.add(_make_assistant_event(tool_use=tu))
+        assert buf.tool_count == 1
+
+    def test_tool_call_detected_from_tui_text(self) -> None:
+        # c-lord's tmux_runner does not synthesize tool_use events — it streams
+        # the TUI capture as ASSISTANT text. We detect tool calls by scanning
+        # the captured text for ``ToolName(...)`` patterns so progress.txt is
+        # still attached when a real tool ran.
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(text="thinking...\nBash(echo hi)\noutput\n"))
+        assert buf.should_attach is True
+
+    def test_text_without_tool_pattern_does_not_attach(self) -> None:
+        # Plain prose answer (even if multi-line) should not trigger attach.
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(text="Hello, the answer is 42."))
+        assert buf.should_attach is False
+
+    def test_partial_growing_text_counts_tool_once(self) -> None:
+        # Partial events grow the captured text. The same tool pattern across
+        # partials should count as one.
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(text="Bash(echo"))
+        buf.add(_make_assistant_event(text="Bash(echo hi"))
+        buf.add(_make_assistant_event(text="Bash(echo hi)\noutput"))
+        assert buf.tool_count == 1
+
+
+class TestProgressBufferJSONL:
+    def test_jsonl_includes_assistant_text(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(text="hi"))
+        out = buf.to_jsonl()
+        lines = [json.loads(line) for line in out.splitlines()]
+        assert lines == [{"type": "assistant", "text": "hi"}]
+
+    def test_jsonl_includes_tool_use(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(tool_use=_make_tool_use("Bash", "abc")))
+        out = buf.to_jsonl()
+        events = [json.loads(line) for line in out.splitlines()]
+        assert len(events) == 1
+        assert events[0]["type"] == "assistant"
+        assert events[0]["tool_use"]["tool_name"] == "Bash"
+        assert events[0]["tool_use"]["tool_id"] == "abc"
+
+    def test_jsonl_includes_tool_result(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(
+            StreamEvent(
+                message_type=MessageType.USER,
+                tool_result_id="abc",
+                tool_result_content="output line",
+            )
+        )
+        events = [json.loads(line) for line in buf.to_jsonl().splitlines()]
+        assert events[0]["type"] == "user"
+        assert events[0]["tool_result_id"] == "abc"
+        assert events[0]["tool_result_content"] == "output line"
+
+    def test_jsonl_skips_progress_events(self) -> None:
+        # PROGRESS events are noise (stall timer resets) — exclude from progress.txt.
+        buf = ProgressBuffer()
+        buf.add(StreamEvent(message_type=MessageType.PROGRESS))
+        buf.add(_make_assistant_event(text="real"))
+        events = [json.loads(line) for line in buf.to_jsonl().splitlines()]
+        assert len(events) == 1
+        assert events[0]["text"] == "real"
+
+    def test_jsonl_compacts_partial_text_to_final(self) -> None:
+        # Partial events with growing text are noisy. Keep only the latest snapshot
+        # per "partial run" by collapsing consecutive partials of the same kind.
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(text="he"))  # partial-like
+        buf.add(_make_assistant_event(text="hell"))
+        buf.add(_make_assistant_event(text="hello"))
+        events = [json.loads(line) for line in buf.to_jsonl().splitlines()]
+        # All three are recorded — collapsing is out of scope, we preserve fidelity.
+        assert [e["text"] for e in events] == ["he", "hell", "hello"]
+
+
+class TestProgressBufferFile:
+    def test_to_discord_file_returns_none_when_no_tools(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(text="hi"))
+        assert buf.to_discord_file() is None
+
+    def test_to_discord_file_returns_file_when_tool_used(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(tool_use=_make_tool_use("Bash")))
+        f = buf.to_discord_file()
+        assert isinstance(f, discord.File)
+        assert f.filename.startswith("progress-")
+        assert f.filename.endswith(".txt")
+
+    def test_filename_includes_timestamp(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(tool_use=_make_tool_use("Bash")))
+        f = buf.to_discord_file(now=datetime(2026, 5, 11, 10, 30, 45))
+        assert f is not None
+        assert f.filename == "progress-20260511-103045.txt"
+
+    def test_to_discord_file_content_is_jsonl(self) -> None:
+        buf = ProgressBuffer()
+        buf.add(_make_assistant_event(tool_use=_make_tool_use("Bash", "t1")))
+        f = buf.to_discord_file()
+        assert f is not None
+        # Read the buffer's underlying content
+        content = f.fp.read().decode("utf-8")
+        lines = content.splitlines()
+        assert all(json.loads(line) for line in lines)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Issue #38 への第一歩。最終 assistant メッセージに `progress-YYYYMMDD-HHMMSS.txt` (JSONL) を添付して、tool 呼び出しの経過を「畳む」(参照可能だが目立たない) 状態にします。

## Summary
- **`c_lord/discord_ui/progress_buffer.py`** (新規) — 各 StreamEvent を JSONL に蓄積する `ProgressBuffer`。`event.tool_use` が空でも TUI text を `ToolName(arg)` パターンで scan して tool 検知 (tmux runner では `tool_use` が `None` のまま yield されるため)。tool 0 回なら skip
- **`c_lord/cogs/event_processor.py`** — `process()` で buffer に流し、`_on_complete` の最後で最終 assistant message を `message.edit(attachments=[discord.File(...)])` で添付。`_last_assistant_message` を streaming / chunk_message 双方の経路で追跡
- **`c_lord/discord_ui/streaming_manager.py`** — `last_message` プロパティを追加 (添付対象の特定用)

## スコープ外 (別 Issue 候補)
**最終応答本文のクリーンアップ**: tmux capture を直接 Discord に流す現アーキテクチャでは `Bash(...)` 等の TUI 表示が本文に混入します。strip するには TUI パースが必要で別作業量です。今回の PR では「畳む」(参照可能化) のみ実装し、「本文をクリーンに」は follow-up に切り出します。Issue #38 の議論にコメントで記載予定。

## 設計判断 (ユーザ確認済み)
- 中身: StreamEvent の JSONL (raw stream-json は本アーキテクチャに存在しないため近似)
- ファイル名: `progress-YYYYMMDD-HHMMSS.txt`
- スキップ条件: tool 呼び出し 0 回
- UI: ストリーミング中の個別 embed は現状維持

## Test plan (staging で RED→GREEN)
**RED**:
- staging thread `1503200157079048292` に `Bash で echo green-marker-issue38` を送信
- 現状: final message が `Bash(...)\n green-marker-issue38\n出力: ...` で散らかる、添付なし
- ログ: `Attached progress` 行なし

**GREEN** (新コードで再起動後):
- 同じ thread に `Bash で echo green-2` を送信
- 結果: final message `Bash(echo green-2) green-2 出力: green-2` に **`progress-20260511-105937.txt` (427B) が添付**
- ログ: `Attached progress-20260511-105937.txt to final message (events=5, tools=1)`
- 中身: JSONL 5 行 (system + 3 partial assistant + result)

**SKIP ケース**:
- `2+2 を計算して。tool は使わないで` を送信
- 結果: final `4`、**添付なし** ✓
- ログ: `Attached progress` 行なし ✓

**Unit tests**: 17 tests passed (`tests/test_progress_buffer.py`)
**Full suite**: 842 tests passed (`pytest --ignore=tests/e2e`)
**Lint**: `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)