### PR TITLE
feat: 最終応答本文から tool 呼び出しノイズを strip (#38 Step 2)

### DIFF
--- a/c_lord/cogs/event_processor.py
+++ b/c_lord/cogs/event_processor.py
@@ -435,9 +435,7 @@ class EventProcessor:
         # ``discord.Message.content`` may be stale after several edits — fetch
         # the latest server-side state so the stripper sees what the user sees.
         try:
-            refreshed = await self._config.thread.fetch_message(
-                self._last_assistant_message.id
-            )
+            refreshed = await self._config.thread.fetch_message(self._last_assistant_message.id)
             original_content = refreshed.content or ""
             self._last_assistant_message = refreshed
         except discord.HTTPException:

--- a/c_lord/cogs/event_processor.py
+++ b/c_lord/cogs/event_processor.py
@@ -34,6 +34,7 @@ from ..discord_ui.plan_view import PlanApprovalView
 from ..discord_ui.progress_buffer import ProgressBuffer
 from ..discord_ui.streaming_manager import StreamingMessageManager
 from ..discord_ui.tool_timer import LiveToolTimer
+from ..discord_ui.tui_strip import strip_tool_noise
 from .run_config import RunConfig
 
 logger = logging.getLogger(__name__)
@@ -413,29 +414,55 @@ class EventProcessor:
                 await self._state.todo_message.edit(embed=embed)
 
     async def _maybe_attach_progress(self) -> None:
-        """Edit the last assistant message to attach ``progress-*.txt`` (Issue #38).
+        """Edit the last assistant message: clean the body + attach ``progress-*.txt`` (Issue #38).
 
-        Skips silently when there is nothing to attach (no tool use, or the
-        assistant text was never posted as a regular message — e.g. error path).
-        Discord ``Message.edit(attachments=[...])`` replaces existing attachments;
-        the assistant message has none, so this just adds the file.
+        Two transformations applied together when tools were used:
+
+        1. **Body cleanup** — strip ``ToolName(arg)`` headers and the indented
+           output that follows, so the user sees only Claude's final answer.
+        2. **Attachment** — attach ``progress-*.txt`` (JSONL of stream events)
+           for users who want the raw progress.
+
+        Skips silently when there was no assistant message or no tool use
+        (``ProgressBuffer.should_attach`` is False).
         """
         if self._last_assistant_message is None:
             return
         progress_file = self._progress.to_discord_file()
         if progress_file is None:
             return
+
+        # ``discord.Message.content`` may be stale after several edits — fetch
+        # the latest server-side state so the stripper sees what the user sees.
         try:
-            await self._last_assistant_message.edit(attachments=[progress_file])
+            refreshed = await self._config.thread.fetch_message(
+                self._last_assistant_message.id
+            )
+            original_content = refreshed.content or ""
+            self._last_assistant_message = refreshed
+        except discord.HTTPException:
+            original_content = self._last_assistant_message.content or ""
+        cleaned_content = strip_tool_noise(original_content)
+        should_replace_content = bool(cleaned_content) and cleaned_content != original_content
+
+        try:
+            if should_replace_content:
+                await self._last_assistant_message.edit(
+                    content=cleaned_content, attachments=[progress_file]
+                )
+            else:
+                await self._last_assistant_message.edit(attachments=[progress_file])
             logger.info(
-                "Attached %s to final message (events=%d, tools=%d)",
+                "Attached %s to final message (events=%d, tools=%d, stripped=%d→%d chars)",
                 progress_file.filename,
                 len(self._progress._events),
                 self._progress.tool_count,
+                len(original_content),
+                len(cleaned_content),
             )
         except discord.HTTPException:
             logger.warning(
-                "Failed to attach progress.txt to thread %d",
+                "Failed to finalize assistant message in thread %d",
                 self._config.thread.id,
                 exc_info=True,
             )

--- a/c_lord/discord_ui/tui_strip.py
+++ b/c_lord/discord_ui/tui_strip.py
@@ -1,0 +1,87 @@
+"""Strip tool-call noise from a streamed assistant message (Issue #38 Step 2).
+
+c-lord captures Claude Code's TUI via ``tmux capture-pane``, so the streamed
+text in Discord ends up containing tool-call headers (``Bash(...)``) and the
+inline command output. The user only cares about Claude's final response.
+
+This module removes the tool-call blocks while preserving conversational text
+before/between/after them. A "tool block" is the ``ToolName(arg)`` header line
+plus the indented output lines that immediately follow it, ending at the next
+blank line or non-indented line.
+
+Markers like ``●`` and ``⎿`` from the raw TUI are already stripped upstream by
+``tmux_runner``; what reaches us looks like::
+
+    Bash(echo green-2)
+      green-2
+
+    出力: green-2
+"""
+
+from __future__ import annotations
+
+import re
+
+_TOOL_NAMES = (
+    "Bash",
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "LS",
+    "WebFetch",
+    "WebSearch",
+    "Task",
+    "TodoWrite",
+    "NotebookEdit",
+    "ExitPlanMode",
+    "AskUserQuestion",
+)
+_TOOL_LINE_RE = re.compile(r"^(?:" + "|".join(_TOOL_NAMES) + r")\(.*$")
+_MANY_BLANKS_RE = re.compile(r"\n{3,}")
+
+
+def strip_tool_noise(text: str) -> str:
+    """Remove ``ToolName(...)`` blocks from a streamed assistant message.
+
+    The original text is returned unchanged when no tool pattern is found, and
+    also when stripping would yield an empty body (a defensive fallback so the
+    user never sees a blank reply if our heuristic misfires).
+    """
+    if not text:
+        return text
+
+    lines = text.split("\n")
+    result: list[str] = []
+    in_tool_output = False
+
+    for line in lines:
+        if _TOOL_LINE_RE.match(line):
+            # Start of a tool block — drop the header and prepare to drop the
+            # indented output that follows.
+            in_tool_output = True
+            continue
+
+        if in_tool_output:
+            if line.strip() == "":
+                # Blank line ends the tool output region. Keep the blank so we
+                # do not glue surrounding text together; ``_MANY_BLANKS_RE`` will
+                # collapse runs.
+                in_tool_output = False
+                result.append("")
+                continue
+            if line.startswith((" ", "\t")):
+                # Still inside the indented output block — drop it.
+                continue
+            # Non-indented, non-blank line — the tool output is over and this
+            # line belongs to Claude's response again.
+            in_tool_output = False
+            result.append(line)
+            continue
+
+        result.append(line)
+
+    cleaned = "\n".join(result).strip()
+    cleaned = _MANY_BLANKS_RE.sub("\n\n", cleaned)
+    return cleaned or text

--- a/tests/test_tui_strip.py
+++ b/tests/test_tui_strip.py
@@ -1,0 +1,68 @@
+"""Tests for the TUI tool-noise stripper (Issue #38 Step 2)."""
+
+from __future__ import annotations
+
+from c_lord.discord_ui.tui_strip import strip_tool_noise
+
+
+class TestStripToolNoise:
+    def test_passthrough_when_no_tool_pattern(self) -> None:
+        assert strip_tool_noise("Hello, the answer is 42.") == "Hello, the answer is 42."
+
+    def test_strips_simple_bash_block(self) -> None:
+        body = "Bash(echo green-2)\n  green-2\n\n出力: green-2"
+        assert strip_tool_noise(body) == "出力: green-2"
+
+    def test_strips_multiple_tool_blocks_keeping_final(self) -> None:
+        body = (
+            "Bash(pwd)\n  /home/foo\n\n"
+            "Read(README.md)\n  # README\n  intro line\n\n"
+            "最終回答: ここが本文です。"
+        )
+        assert strip_tool_noise(body) == "最終回答: ここが本文です。"
+
+    def test_keeps_text_before_first_tool(self) -> None:
+        # Conversational text before the first tool call is part of Claude's
+        # reasoning we want to keep.
+        body = "まず確認します。\n\nBash(ls)\n  a\n  b\n\nファイルは a, b です。"
+        cleaned = strip_tool_noise(body)
+        assert "まず確認します。" in cleaned
+        assert "ファイルは a, b です。" in cleaned
+        assert "Bash(ls)" not in cleaned
+        assert "  a" not in cleaned
+
+    def test_collapses_excessive_blank_lines(self) -> None:
+        body = "first\n\n\n\nsecond"
+        assert strip_tool_noise(body) == "first\n\nsecond"
+
+    def test_strips_indented_output_only_following_tool(self) -> None:
+        # Indented lines that are NOT after a tool call (e.g. code block continuation)
+        # are preserved. We only strip indented lines that immediately follow a
+        # tool call line.
+        body = "Here is code:\n    indent line\n    another\n\nDone"
+        # No tool pattern → unchanged.
+        assert strip_tool_noise(body) == body
+
+    def test_preserves_message_when_stripping_would_empty_it(self) -> None:
+        # Defensive: if the result would be empty (very unusual), return the
+        # original so the user does not see a blank reply.
+        body = "Bash(only this)\n  no follow-up"
+        result = strip_tool_noise(body)
+        # Should fall back to the original since the cleaned text is empty.
+        assert result == body
+
+    def test_handles_all_known_tool_names(self) -> None:
+        # Every tool we recognize gets stripped.
+        for name in ("Read", "Write", "Edit", "Grep", "Glob", "WebFetch", "Task"):
+            body = f"{name}(arg here)\n  output line\n\nresponse"
+            assert strip_tool_noise(body) == "response", f"failed for {name}"
+
+    def test_tool_call_with_no_following_output(self) -> None:
+        body = "Bash(echo hi)\n\nDone"
+        assert strip_tool_noise(body) == "Done"
+
+    def test_real_capture_with_arrow_marker_stripped_upstream(self) -> None:
+        # The actual capture-pane output the bot streams (markers like ●/⎿ are
+        # already stripped by tmux_runner). This is the format we observed live.
+        body = "Bash(echo green-2)\n  green-2\n\n出力: green-2"
+        assert strip_tool_noise(body) == "出力: green-2"


### PR DESCRIPTION
Issue #38 の Step 2。PR #48 (Step 1) で progress.txt 添付までは入ったが、Discord メッセージ本文に \`Bash(echo ...)\` ヘッダとインデント出力が残っていた。本文を Claude の最終応答だけに絞り込む。

## Summary
- **\`c_lord/discord_ui/tui_strip.py\`** (新規) — \`ToolName(arg)\` 行とそれに続くインデントブロック (tmux capture-pane が出す形式) を除去するパーサー。strip 後に本文が空になりそうなときは fallback で元テキストを返す (heuristic misfire 時の defensive 動作)
- **\`c_lord/cogs/event_processor.py\`** — \`_maybe_attach_progress\` で添付と同タイミングで本文 edit。\`message.content\` のローカルキャッシュは edit 連発で stale になるので \`thread.fetch_message\` で最新を取り直してから strip にかける

## Test plan (staging で RED→GREEN)
**RED** (PR #48 状態):
- staging thread に \`echo hello-world を Bash で実行して、その後に「コマンドは hello-world を出力しました」と要約してください\` を送信
- 結果: 本文は \`Bash(echo hello-world)\\n  hello-world\\n\\nコマンドは hello-world を出力しました。\` ← tool noise が混入

**GREEN** (本 PR):
- 同じ prompt
- 結果: 本文は \`'コマンドは hello-world を出力しました。'\` ← クリーン！
- ログ: \`Attached progress-20260511-112134.txt to final message (events=5, tools=1, stripped=64→26 chars)\`
- progress.txt も従来通り添付済み

**Defensive 動作確認**: TUI capture が中途半端で「strip すると空になる」ケース (Claude の最終応答がまだ TUI に現れていないタイミング) では fallback が動き、ユーザに空メッセージを見せない (ログで \`stripped=42→42\` を確認)

**Unit tests**: 10 tests passed (\`tests/test_tui_strip.py\`) — passthrough, simple strip, multi-tool, blank line collapse, all tool names, defensive empty-fallback
**Full suite**: 852 tests passed
**Lint/Type**: \`ruff check\`, \`ruff format --check\`, \`pyright c_lord/\` clean

## Issue #38 の状態
Step 2 が完了することで Issue #38 のゴール (「最終応答メッセージ本文には完成した回答のみを出し、途中経過は progress.txt として添付」) が満たされる見込み。マージ後に Issue close 可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)