### PR TITLE
fix: TUI 出力中の OSC 8 ハイパーリンクを bare URL に書き戻す (#47)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -120,6 +120,48 @@ _STRIP_PATTERNS = (
 )
 
 
+# OSC 8 hyperlink: ESC ] 8 ; <params> ; <URL> ESC \ <TEXT> ESC ] 8 ; ; ESC \
+# Captured by ``tmux capture-pane -e``. Issue #47: without unpacking these,
+# the URL portion is lost and Discord users only see the visible text.
+_OSC8_RE = re.compile(
+    r"\x1b\]8;[^;]*;(?P<url>[^\x1b\x07]*)(?:\x1b\\|\x07)"
+    r"(?P<text>.*?)"
+    r"\x1b\]8;;(?:\x1b\\|\x07)",
+    re.DOTALL,
+)
+
+# ANSI CSI sequences (colors, cursor control). After OSC 8 rewrite we strip
+# everything else so the existing line-based chrome filters see plain text.
+_ANSI_CSI_RE = re.compile(r"\x1b\[[\d;?]*[A-Za-z]")
+_ANSI_OSC_REMNANT_RE = re.compile(r"\x1b\][^\x1b\x07]*(?:\x1b\\|\x07)?")
+
+
+def _normalize_capture(text: str) -> str:
+    """Rewrite OSC 8 hyperlinks to plain text and strip ANSI escapes.
+
+    OSC 8 ``\\x1b]8;;URL\\x1b\\TEXT\\x1b]8;;\\x1b\\`` becomes:
+      - ``TEXT (URL)`` for http(s) URLs
+      - ``URL`` alone when visible text already equals the URL
+      - ``TEXT`` for file:// (URL is local to bot, useless on Discord)
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        url = match.group("url")
+        visible = _ANSI_CSI_RE.sub("", match.group("text"))
+        if url.startswith("file://"):
+            return visible
+        if visible == url:
+            return url
+        if not url:
+            return visible
+        return f"{visible} ({url})"
+
+    text = _OSC8_RE.sub(_replace, text)
+    text = _ANSI_CSI_RE.sub("", text)
+    text = _ANSI_OSC_REMNANT_RE.sub("", text)
+    return text
+
+
 class TmuxClaudeRunner:
     """Runs Claude Code inside a tmux window and streams output via capture-pane.
 
@@ -417,6 +459,10 @@ class TmuxClaudeRunner:
         - User prompt: ``❯ <user message>``
         - (previous exchanges, banner, shell noise above)
         """
+        # Issue #47: capture-pane is invoked with ``-e`` so terminal hyperlinks
+        # (OSC 8) survive. Rewrite them to plain text + bare URL and strip
+        # remaining ANSI before the line-based chrome filters run.
+        pane_text = _normalize_capture(pane_text)
         lines = pane_text.splitlines()
 
         # Step 1: Strip bottom TUI chrome (status bar, separators, input

--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -538,10 +538,16 @@ class TmuxSessionManager:
             return ""
 
         target = f"{self.session_name}:{window}"
+        # -e: preserve escape sequences (ANSI colors, OSC 8 hyperlinks).
+        # tmux_runner._normalize_capture rewrites OSC 8 to bare URLs and
+        # strips remaining color codes before line-based chrome filters run.
+        # Without -e, terminal hyperlinks from Claude TUI lose the URL
+        # portion entirely (issue #47).
         result = _run(
             [
                 "tmux",
                 "capture-pane",
+                "-e",
                 "-p",
                 "-J",
                 "-t",

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from c_lord.claude.tmux_runner import TmuxClaudeRunner, _clean_tui_lines
+from c_lord.claude.tmux_runner import TmuxClaudeRunner, _clean_tui_lines, _normalize_capture
 from c_lord.claude.types import MessageType
 
 
@@ -1055,6 +1055,7 @@ class TestTmuxClaudeRunnerRun:
         result_events = [e for e in events if e.is_complete]
         assert len(result_events) == 1
 
+
 class TestTmuxClaudeRunnerInterrupt:
     """Tests for interrupt() and kill()."""
 
@@ -1234,3 +1235,139 @@ class TestIsGenerating:
 class TestToolExecutionCompletion:
     """Tests that tool execution does not trigger false early completion."""
 
+    @pytest.mark.asyncio
+    async def test_tool_execution_does_not_trigger_early_completion(
+        self, runner, tmux_manager
+    ) -> None:
+        """When ✻ Running… is visible and text is stable, quick-exit should NOT fire.
+
+        The pane shows a tool call with ✻ Running… indicator and bare ❯ prompt.
+        Without the _is_generating guard, the 3s quick-exit would fire.
+        With the guard, only the 30s fallback can trigger completion.
+        """
+        tmux_manager.is_claude_running.return_value = True
+
+        # Pane shows a tool call with ✻ Running… — text is stable but not done
+        tool_pane = "\n".join(
+            [
+                "❯ list issues",
+                "",
+                "● Bash(gh issue list --limit 10)",
+                "",
+                "─" * 40,
+                "✻ Running…",
+                "❯",
+                "─" * 40,
+                "-- INSERT -- ⏵⏵ bypass permissions on",
+            ]
+        )
+        # After several polls at tool_pane (stable but generating),
+        # Claude finishes and shows the final response
+        final_pane = _make_pane(
+            [
+                "● Here are the issues:",
+                "",
+                "  | # | Title     |",
+                "  |---|-----------|",
+                "  | 1 | Fix bug   |",
+            ],
+            user_prompt="list issues",
+            with_input_prompt=True,
+        )
+
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            # Polls 1-8: tool running (stable text with ✻ Running…)
+            if call_idx <= 8:
+                return tool_pane
+            # Polls 9+: final response
+            return final_pane
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.15),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_FALLBACK", 30.0),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+        ):
+            async for event in runner.run("list issues"):
+                events.append(event)
+
+        # Runner should complete normally without early exit during tool execution.
+        # ASSISTANT events are no longer yielded (#53); check RESULT instead.
+        results = [e for e in events if e.message_type == MessageType.RESULT]
+        assert len(results) == 1
+        assert results[0].is_complete is True
+        assert results[0].error is None
+
+
+# -- Tests for OSC 8 hyperlink normalization (issue #47) --------------------
+
+
+class TestNormalizeCapture:
+    """Tests for _normalize_capture — OSC 8 → bare URL + ANSI strip."""
+
+    def test_http_osc8_becomes_text_with_bare_url(self) -> None:
+        """`#45` link to GitHub PR becomes `#45 (https://...)`."""
+        text = "PR \x1b]8;id=abc;https://github.com/yousan/c-lord/pull/45\x1b\\#45\x1b]8;;\x1b\\"
+        result = _normalize_capture(text)
+        assert "#45" in result
+        assert "https://github.com/yousan/c-lord/pull/45" in result
+
+    def test_file_url_dropped_keep_text_only(self) -> None:
+        """file:// URLs are local to bot; keep only the visible text."""
+        text = "\x1b]8;id=x;file:///home/y/foo.py\x1b\\foo.py\x1b]8;;\x1b\\"
+        result = _normalize_capture(text)
+        assert result.strip() == "foo.py"
+        assert "file://" not in result
+
+    def test_ansi_color_codes_stripped(self) -> None:
+        """CSI color escapes are removed."""
+        text = "\x1b[38;5;114m●\x1b[39m \x1b[1mHello\x1b[0m"
+        result = _normalize_capture(text)
+        assert result == "● Hello"
+
+    def test_osc8_and_ansi_combined(self) -> None:
+        """Realistic capture-pane output with both."""
+        text = (
+            "\x1b[34m\x1b]8;id=1;https://docs.pytest.org/x.html\x1b\\"
+            "https://docs.pytest.org/x.html\x1b[39m\x1b]8;;\x1b\\"
+        )
+        result = _normalize_capture(text)
+        # When visible text == URL, emit URL once (no duplication).
+        assert result.count("https://docs.pytest.org/x.html") == 1
+        assert "\x1b" not in result
+
+    def test_plain_text_unchanged(self) -> None:
+        assert _normalize_capture("hello world") == "hello world"
+
+    def test_empty_string(self) -> None:
+        assert _normalize_capture("") == ""
+
+
+class TestExtractResponsePreservesHyperlinks:
+    """Issue #47: URLs in TUI markdown links must survive into Discord output."""
+
+    def test_issue_reference_link_preserved(self) -> None:
+        """Claude TUI output `[#271](https://...)` (rendered as OSC 8) keeps URL."""
+        link = "\x1b]8;id=a;https://github.com/foo/bar/issues/271\x1b\\#271\x1b]8;;\x1b\\"
+        pane = "\n".join(
+            [
+                "❯ list issues",
+                "",
+                f"● - {link} a bug",
+                "",
+                "─" * 40,
+                "❯",
+                "─" * 40,
+                "-- INSERT --",
+            ]
+        )
+        result = TmuxClaudeRunner._extract_response(pane)
+        assert "#271" in result
+        assert "https://github.com/foo/bar/issues/271" in result


### PR DESCRIPTION
## Summary
- Claude Code TUI が markdown link を OSC 8 ハイパーリンクとして描画するのに対し、`tmux capture-pane` を `-e` なしで呼んでいたため URL 部分が剥がれ、Discord 投稿時には visible text のみ残る (Issue #47)。
- `tmux.py::capture_pane` に `-e` を追加し、`tmux_runner.py::_normalize_capture` で OSC 8 を `TEXT (URL)` に書き戻して残 ANSI を strip。後段の line-based chrome filter は従来どおり plain text を扱う。
- file:// URL は破棄、`visible == URL` のときは URL のみ出力 (重複抑制)。

## Test plan

### Unit tests (TDD)
- [x] RED: `TestNormalizeCapture` (6 cases) + `TestExtractResponsePreservesHyperlinks` を追加 → ImportError で FAIL
- [x] GREEN: 実装後 `_normalize_capture` 7 件 + 既存 90 件 = 97 件 pass
- [x] Full suite: 832 passed

### Staging E2E (CLAUDE.md 必須フロー)
- staging bot (`c-lord-parallel-3`, channel `1503196656265597082`) でブランチをチェックアウトして再起動
- 同じプロンプト (`各 issue を markdown link 形式で箇条書き`) を webhook 経由で投入し before/after を比較

**Before (main, msg `1503250314600517652`)**: Bash tool 出力のみで Claude 最終応答 (`- #50 / #47 / #43` リスト) は URL 無し or Discord に届かない。

**After (fix branch, msg `1503252311827284089`)**:
```
- #50 (https://github.com/yousan/c-lord/issues/50) TUI chrome leak: ...
  - #47 (https://github.com/yousan/c-lord/issues/47) TUI 出力中の OSC 8 ...
  - #43 (https://github.com/yousan/c-lord/issues/43) Claude 応答の行頭 ...
```
bare URL として Discord に到達し、クリッカブルに。

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)