### PR TITLE
feat: Skill 経由で ClaudeCode が Discord に能動 push (#52 Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,11 @@ SESSION_TIMEOUT_SECONDS=300
 # E2E Testing (create a webhook for the DISCORD_CHANNEL_ID channel)
 # E2E_TEST_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
 # E2E_TEST_THREAD_ID=                # Pre-attached thread ID for message-flow tests
+
+# Skill-based reply (issue #52 — capture-pane scraping replacement, Phase 1)
+# When enabled, c-lord injects a `discord-reply` skill into each session dir
+# so Claude pushes its final answer to Discord via the REST API, bypassing
+# the legacy capture-pane scrape path that drives most TUI chrome leaks.
+# Default off — the scrape path stays primary until Phase 2.
+# USE_SKILL_REPLY=true
+# CLORD_API_URL=http://127.0.0.1:8080   # Used by injected skill (default shown)

--- a/.env.example
+++ b/.env.example
@@ -39,4 +39,16 @@ SESSION_TIMEOUT_SECONDS=300
 # the legacy capture-pane scrape path that drives most TUI chrome leaks.
 # Default off — the scrape path stays primary until Phase 2.
 # USE_SKILL_REPLY=true
-# CLORD_API_URL=http://127.0.0.1:8080   # Used by injected skill (default shown)
+#
+# IMPORTANT: CLORD_API_URL is what gets BAKED INTO each injected SKILL.md
+# (Claude curls this exact URL). CLORD_API_PORT is what the bot's API server
+# BINDS TO. They are independent strings — if you change CLORD_API_PORT,
+# you MUST also update CLORD_API_URL to match (and re-create any active
+# session dirs to re-inject SKILL.md with the new URL).
+# CLORD_API_URL=http://127.0.0.1:8080
+# CLORD_API_PORT=8080
+# CLORD_API_HOST=127.0.0.1
+# CLORD_API_SECRET=                      # When set, SKILL.md includes a
+#                                        # `Authorization: Bearer ...` header
+#                                        # and the API rejects requests
+#                                        # without it.

--- a/c_lord/ext/api_server.py
+++ b/c_lord/ext/api_server.py
@@ -105,6 +105,8 @@ class ApiServer:
         self.app.router.add_post("/api/spawn", self.spawn)
         # Thread message route (CLI input forwarding)
         self.app.router.add_post("/api/threads/{thread_id}/messages", self.post_thread_message)
+        # Issue #52: Skill-based final reply (clean content, no source prefix)
+        self.app.router.add_post("/api/reply", self.reply)
         # Startup resume routes
         self.app.router.add_post("/api/mark-resume", self.mark_resume)
 
@@ -643,6 +645,75 @@ class ApiServer:
         # from bot/Claude messages but doesn't overwhelm the thread.
         formatted = f"-# \U0001f4bb ({source}) {content}"
         await raw.send(formatted)  # type: ignore[union-attr]
+
+        return web.json_response({"status": "sent"})
+
+    async def reply(self, request: web.Request) -> web.Response:
+        """POST /api/reply — Skill-based final reply (#52 Phase 1).
+
+        Used by the ``discord-reply`` skill that c-lord injects into each
+        Claude session directory. Unlike ``post_thread_message``, the content
+        is posted *as-is* (no ``-# 💻 (cli)`` prefix) because this represents
+        Claude's actual answer, not a CLI forwarding decoration.
+
+        Body (JSON):
+            thread_id: Target Discord thread ID (required).
+            content: Message body, Discord markdown OK (required, non-empty).
+            progress_file: Absolute path on the server to a file to attach
+                (optional). Used for progress.txt-style detail dumps (#38).
+
+        Returns:
+            200 ``{"status": "sent"}`` on success.
+            400 on validation errors (missing / empty fields, missing file).
+            404 if the thread cannot be resolved.
+        """
+        try:
+            data = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        thread_id_raw = data.get("thread_id")
+        if thread_id_raw is None:
+            return web.json_response({"error": "thread_id is required"}, status=400)
+        try:
+            thread_id = int(thread_id_raw)
+        except (TypeError, ValueError):
+            return web.json_response({"error": "thread_id must be an integer"}, status=400)
+
+        content = (data.get("content") or "").strip()
+        if not content:
+            return web.json_response({"error": "content is required"}, status=400)
+
+        # Optional attachment — resolve and validate before touching Discord.
+        progress_file = data.get("progress_file")
+        attachment = None
+        if progress_file:
+            from pathlib import Path
+
+            path = Path(str(progress_file))
+            if not path.is_file():
+                return web.json_response(
+                    {"error": f"progress_file not found: {progress_file}"},
+                    status=400,
+                )
+            import discord
+
+            attachment = discord.File(str(path), filename=path.name)
+
+        raw = self.bot.get_channel(thread_id)
+        if raw is None:
+            try:
+                raw = await self.bot.fetch_channel(thread_id)
+            except Exception:
+                return web.json_response({"error": "Thread not found"}, status=404)
+
+        if not hasattr(raw, "send"):
+            return web.json_response({"error": "Channel is not messageable"}, status=400)
+
+        send_kwargs: dict = {"content": content}
+        if attachment is not None:
+            send_kwargs["file"] = attachment
+        await raw.send(**send_kwargs)  # type: ignore[union-attr]
 
         return web.json_response({"status": "sent"})
 

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -79,16 +79,54 @@ async def main() -> None:
         coordination_channel_id=coordination_channel_id,
     )
 
+    # Issue #52: optional REST API for skill-based reply path.
+    # Enabled when USE_SKILL_REPLY is truthy or CLORD_API_PORT is set.
+    from .skills.injector import skills_enabled
+
+    api_server = None
+    api_port_env = os.getenv("CLORD_API_PORT", "")
+    if skills_enabled() or api_port_env:
+        try:
+            from .database.notification_repo import NotificationRepository
+            from .ext.api_server import ApiServer
+        except ImportError:
+            logger.warning(
+                "USE_SKILL_REPLY/CLORD_API_PORT set but aiohttp is not installed; "
+                "API server will NOT start. Install with `uv add aiohttp`."
+            )
+        else:
+            notif_db = str(data_dir / "notifications.db")
+            notif_repo = NotificationRepository(notif_db)
+            await notif_repo.init_db()
+            api_port = int(api_port_env) if api_port_env.isdigit() else 8080
+            api_server = ApiServer(
+                repo=notif_repo,
+                bot=bot,
+                default_channel_id=int(config["channel_id"]),
+                host=os.getenv("CLORD_API_HOST", "127.0.0.1"),
+                port=api_port,
+                api_secret=os.getenv("CLORD_API_SECRET") or None,
+            )
+
     async with bot:
         components = await setup_bridge(
             bot,
             runner,
+            api_server=api_server,
             session_db_path=db_path,
             allowed_user_ids=allowed_user_ids,
             allowed_role_name=allowed_role_name,
             claude_channel_id=int(config["channel_id"]),
             enable_scheduler=True,
         )
+
+        if api_server is not None:
+            await api_server.start()
+            logger.info(
+                "REST API enabled (host=%s port=%d) — discord-reply skill ready",
+                api_server.host,
+                api_server.port,
+            )
 
         # Cleanup old sessions on startup
         deleted = await components.session_repo.cleanup_old(days=30)
@@ -97,8 +135,14 @@ async def main() -> None:
 
         # Handle signals
         loop = asyncio.get_running_loop()
+
+        async def _shutdown() -> None:
+            if api_server is not None:
+                await api_server.stop()
+            await bot.close()
+
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, lambda: asyncio.create_task(bot.close()))
+            loop.add_signal_handler(sig, lambda: asyncio.create_task(_shutdown()))
 
         await bot.start(config["token"])
 

--- a/c_lord/session_dir.py
+++ b/c_lord/session_dir.py
@@ -113,40 +113,45 @@ class SessionDirManager:
         """Create (or return existing) session directory for a thread.
 
         Idempotent: if the directory already exists, returns its path
-        without re-cloning.
+        without re-cloning. The skill bundle (#52) is (re)injected on every
+        call when the flag is enabled — this keeps SKILL.md in sync with the
+        current ``CLORD_API_URL`` / ``CLORD_API_SECRET`` even if the operator
+        changes them between sessions.
 
         Returns:
             Absolute path to the session directory.
         """
         target = str(Path(self._base_dir) / str(thread_id))
-        if Path(target).is_dir():
-            logger.info("Session dir already exists: %s", target)
-            return target
+        already_existed = Path(target).is_dir()
 
-        Path(self._base_dir).mkdir(parents=True, exist_ok=True)
+        if not already_existed:
+            Path(self._base_dir).mkdir(parents=True, exist_ok=True)
 
-        args = ["git", "clone"]
-        if _is_local_repo(self._source_repo):
-            args.append("--local")
+            args = ["git", "clone"]
+            if _is_local_repo(self._source_repo):
+                args.append("--local")
+            else:
+                args.extend(["--depth=1", "--single-branch"])
+
+            args.extend([self._source_repo, target])
+
+            result = _run(args)
+            if result.returncode != 0:
+                logger.error(
+                    "git clone failed for thread %d: %s",
+                    thread_id,
+                    result.stderr.strip(),
+                )
+                raise RuntimeError(f"git clone failed: {result.stderr.strip()}")
+
+            logger.info("Created session dir for thread %d: %s", thread_id, target)
         else:
-            args.extend(["--depth=1", "--single-branch"])
+            logger.info("Session dir already exists: %s", target)
 
-        args.extend([self._source_repo, target])
-
-        result = _run(args)
-        if result.returncode != 0:
-            logger.error(
-                "git clone failed for thread %d: %s",
-                thread_id,
-                result.stderr.strip(),
-            )
-            raise RuntimeError(f"git clone failed: {result.stderr.strip()}")
-
-        logger.info("Created session dir for thread %d: %s", thread_id, target)
-
-        # Issue #52 Phase 1: inject discord-reply skill so Claude can push
+        # Issue #52 Phase 1: (re)inject discord-reply skill so Claude can push
         # final answers via REST API instead of relying on capture-pane
         # scraping. Gated by USE_SKILL_REPLY env so old path stays default.
+        # Runs on every call to keep api_url / api_secret in sync.
         from .skills.injector import inject_skills, skills_enabled
 
         if skills_enabled():

--- a/c_lord/session_dir.py
+++ b/c_lord/session_dir.py
@@ -143,6 +143,19 @@ class SessionDirManager:
             raise RuntimeError(f"git clone failed: {result.stderr.strip()}")
 
         logger.info("Created session dir for thread %d: %s", thread_id, target)
+
+        # Issue #52 Phase 1: inject discord-reply skill so Claude can push
+        # final answers via REST API instead of relying on capture-pane
+        # scraping. Gated by USE_SKILL_REPLY env so old path stays default.
+        from .skills.injector import inject_skills, skills_enabled
+
+        if skills_enabled():
+            try:
+                inject_skills(target, thread_id=thread_id)
+            except OSError as exc:
+                # Don't fail session creation on a skill write error.
+                logger.warning("Failed to inject skills for thread %d: %s", thread_id, exc)
+
         return target
 
     def find_session_dirs(self) -> list[SessionDirInfo]:

--- a/c_lord/skills/__init__.py
+++ b/c_lord/skills/__init__.py
@@ -1,0 +1,15 @@
+"""Skill bundles c-lord injects into each Claude Code session directory.
+
+When ``USE_SKILL_REPLY`` env is enabled, :func:`inject_skills` writes per-session
+SKILL.md files (with ``thread_id`` and ``api_url`` baked in) under
+``<session_dir>/.claude/skills/``. This lets Claude push final answers to
+Discord by curl-ing the c-lord REST API, replacing the legacy
+``capture-pane`` scraping path (#52).
+"""
+
+from __future__ import annotations
+
+from .discord_reply import DISCORD_REPLY_SKILL, render_discord_reply_skill
+from .injector import inject_skills
+
+__all__ = ["DISCORD_REPLY_SKILL", "inject_skills", "render_discord_reply_skill"]

--- a/c_lord/skills/discord_reply.py
+++ b/c_lord/skills/discord_reply.py
@@ -1,0 +1,65 @@
+"""``discord-reply`` skill template.
+
+The template is rendered with the session's ``thread_id`` and ``api_url``
+substituted in. The resulting SKILL.md is written to
+``<session_dir>/.claude/skills/discord-reply/SKILL.md`` so Claude finds it via
+its skill auto-discovery.
+"""
+
+from __future__ import annotations
+
+DISCORD_REPLY_SKILL = """\
+---
+name: discord-reply
+description: |
+  Post your final answer to the Discord thread bridged to this Claude
+  session. ALWAYS call this skill at the end of every response — it is the
+  only way the user sees what you produced. Sending text to stdout / the
+  terminal does NOT reach Discord.
+---
+
+# discord-reply
+
+This Claude session is bridged to Discord thread `{thread_id}`.
+Use the c-lord REST API to post your reply.
+
+## Plain text reply
+
+```bash
+curl -s -X POST "{api_url}/api/reply" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<'JSON'
+{{
+  "thread_id": {thread_id},
+  "content": "YOUR FINAL ANSWER (Discord markdown OK)"
+}}
+JSON
+```
+
+## Reply with progress.txt attachment
+
+When you have a long progress log that would clutter the main answer,
+write it to a file and attach it:
+
+```bash
+curl -s -X POST "{api_url}/api/reply" \\
+  -F "thread_id={thread_id}" \\
+  -F "content=YOUR FINAL ANSWER" \\
+  -F "progress=@/path/to/progress.txt"
+```
+
+## Rules
+
+1. Call this skill exactly once per turn, at the very end, with your final answer.
+2. Do not include intermediate progress in `content` — put it in `progress.txt`
+   if you want it preserved.
+3. Keep `content` under ~1800 characters (Discord limit is 2000; leave room
+   for chrome). If your answer is longer, paginate or attach it.
+4. Markdown is supported (bold, lists, code fences). URLs render as text only
+   (no preview embeds, by design).
+"""
+
+
+def render_discord_reply_skill(thread_id: int, api_url: str) -> str:
+    """Render the SKILL.md body with per-session values substituted."""
+    return DISCORD_REPLY_SKILL.format(thread_id=thread_id, api_url=api_url)

--- a/c_lord/skills/discord_reply.py
+++ b/c_lord/skills/discord_reply.py
@@ -1,14 +1,20 @@
 """``discord-reply`` skill template.
 
-The template is rendered with the session's ``thread_id`` and ``api_url``
-substituted in. The resulting SKILL.md is written to
+The template is rendered with the session's ``thread_id``, ``api_url`` and
+optional ``api_secret`` substituted in. The resulting SKILL.md is written to
 ``<session_dir>/.claude/skills/discord-reply/SKILL.md`` so Claude finds it via
 its skill auto-discovery.
 """
 
 from __future__ import annotations
 
-DISCORD_REPLY_SKILL = """\
+# NOTE: when editing the curl examples, keep them strictly aligned with the
+# ``POST /api/reply`` contract in ``c_lord/ext/api_server.py``. The endpoint
+# accepts JSON only (no multipart) and ``progress_file`` must be an absolute
+# path readable by the c-lord process. ``tests/test_skills_contract.py``
+# parses these examples and round-trips them through the real endpoint.
+
+DISCORD_REPLY_SKILL_NO_AUTH = """\
 ---
 name: discord-reply
 description: |
@@ -23,6 +29,9 @@ description: |
 This Claude session is bridged to Discord thread `{thread_id}`.
 Use the c-lord REST API to post your reply.
 
+The endpoint accepts **JSON only** (no multipart). Attachments are passed by
+**absolute filesystem path** — c-lord reads the file on the server side.
+
 ## Plain text reply
 
 ```bash
@@ -36,30 +45,131 @@ curl -s -X POST "{api_url}/api/reply" \\
 JSON
 ```
 
-## Reply with progress.txt attachment
+## Reply with a progress.txt attachment
 
-When you have a long progress log that would clutter the main answer,
-write it to a file and attach it:
+Write the detail to a file first, then pass its **absolute path** in the same
+JSON body. Do NOT use multipart (`-F`) — it will not work.
 
 ```bash
+cat > /tmp/progress-{thread_id}.txt <<'LOG'
+step 1 ...
+step 2 ...
+LOG
+
 curl -s -X POST "{api_url}/api/reply" \\
-  -F "thread_id={thread_id}" \\
-  -F "content=YOUR FINAL ANSWER" \\
-  -F "progress=@/path/to/progress.txt"
+  -H "Content-Type: application/json" \\
+  -d @- <<JSON
+{{
+  "thread_id": {thread_id},
+  "content": "done — details attached",
+  "progress_file": "/tmp/progress-{thread_id}.txt"
+}}
+JSON
 ```
 
 ## Rules
 
 1. Call this skill exactly once per turn, at the very end, with your final answer.
-2. Do not include intermediate progress in `content` — put it in `progress.txt`
-   if you want it preserved.
+2. Do not include intermediate progress in `content` — write it to a file and
+   pass the absolute path via `progress_file`.
 3. Keep `content` under ~1800 characters (Discord limit is 2000; leave room
    for chrome). If your answer is longer, paginate or attach it.
 4. Markdown is supported (bold, lists, code fences). URLs render as text only
    (no preview embeds, by design).
 """
 
+DISCORD_REPLY_SKILL_WITH_AUTH = """\
+---
+name: discord-reply
+description: |
+  Post your final answer to the Discord thread bridged to this Claude
+  session. ALWAYS call this skill at the end of every response — it is the
+  only way the user sees what you produced. Sending text to stdout / the
+  terminal does NOT reach Discord.
+---
 
-def render_discord_reply_skill(thread_id: int, api_url: str) -> str:
-    """Render the SKILL.md body with per-session values substituted."""
-    return DISCORD_REPLY_SKILL.format(thread_id=thread_id, api_url=api_url)
+# discord-reply
+
+This Claude session is bridged to Discord thread `{thread_id}`.
+Use the c-lord REST API to post your reply.
+
+The endpoint accepts **JSON only** (no multipart) and is protected by Bearer
+auth — every request must include the `Authorization` header below.
+Attachments are passed by **absolute filesystem path** — c-lord reads the
+file on the server side.
+
+## Plain text reply
+
+```bash
+curl -s -X POST "{api_url}/api/reply" \\
+  -H "Authorization: Bearer {api_secret}" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<'JSON'
+{{
+  "thread_id": {thread_id},
+  "content": "YOUR FINAL ANSWER (Discord markdown OK)"
+}}
+JSON
+```
+
+## Reply with a progress.txt attachment
+
+Write the detail to a file first, then pass its **absolute path** in the same
+JSON body. Do NOT use multipart (`-F`) — it will not work.
+
+```bash
+cat > /tmp/progress-{thread_id}.txt <<'LOG'
+step 1 ...
+step 2 ...
+LOG
+
+curl -s -X POST "{api_url}/api/reply" \\
+  -H "Authorization: Bearer {api_secret}" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<JSON
+{{
+  "thread_id": {thread_id},
+  "content": "done — details attached",
+  "progress_file": "/tmp/progress-{thread_id}.txt"
+}}
+JSON
+```
+
+## Rules
+
+1. Call this skill exactly once per turn, at the very end, with your final answer.
+2. Do not include intermediate progress in `content` — write it to a file and
+   pass the absolute path via `progress_file`.
+3. Keep `content` under ~1800 characters (Discord limit is 2000; leave room
+   for chrome). If your answer is longer, paginate or attach it.
+4. Markdown is supported (bold, lists, code fences). URLs render as text only
+   (no preview embeds, by design).
+5. The Bearer token above must be sent with every request. Do not log or
+   echo it.
+"""
+
+# Kept as an alias for backward-compat with tests that imported the old name.
+DISCORD_REPLY_SKILL = DISCORD_REPLY_SKILL_NO_AUTH
+
+
+def render_discord_reply_skill(
+    thread_id: int,
+    api_url: str,
+    api_secret: str | None = None,
+) -> str:
+    """Render the SKILL.md body with per-session values substituted.
+
+    Args:
+        thread_id: Discord thread ID the session is bridged to.
+        api_url: Base URL of the c-lord REST API.
+        api_secret: Bearer token required by the API server. When set, the
+            curl examples include the ``Authorization`` header. When None
+            (the default), the auth-less template is rendered.
+    """
+    if api_secret:
+        return DISCORD_REPLY_SKILL_WITH_AUTH.format(
+            thread_id=thread_id,
+            api_url=api_url,
+            api_secret=api_secret,
+        )
+    return DISCORD_REPLY_SKILL_NO_AUTH.format(thread_id=thread_id, api_url=api_url)

--- a/c_lord/skills/injector.py
+++ b/c_lord/skills/injector.py
@@ -17,17 +17,21 @@ def inject_skills(
     session_dir: str | os.PathLike[str],
     thread_id: int,
     api_url: str | None = None,
+    api_secret: str | None = None,
 ) -> list[str]:
     """Write the c-lord skill bundle into ``<session_dir>/.claude/skills/``.
 
     Idempotent: existing files are overwritten so per-session values
-    (``thread_id``, ``api_url``) stay in sync if they change.
+    (``thread_id``, ``api_url``, ``api_secret``) stay in sync if they change.
 
     Args:
         session_dir: Path to the per-thread session directory.
         thread_id: Discord thread ID the session is bridged to.
         api_url: Base URL of the c-lord REST API. Defaults to
             ``CLORD_API_URL`` env var, or ``http://127.0.0.1:8080``.
+        api_secret: Bearer token the API server requires. When omitted,
+            falls back to the ``CLORD_API_SECRET`` env var. If neither is
+            set, the auth-less template is rendered.
 
     Returns:
         Absolute paths to the SKILL.md files written.
@@ -36,6 +40,9 @@ def inject_skills(
         api_url = os.getenv("CLORD_API_URL") or DEFAULT_API_URL
     api_url = api_url.rstrip("/")
 
+    if api_secret is None:
+        api_secret = os.getenv("CLORD_API_SECRET") or None
+
     skills_root = Path(session_dir) / ".claude" / "skills"
 
     written: list[str] = []
@@ -43,15 +50,16 @@ def inject_skills(
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_path = skill_dir / "SKILL.md"
     skill_path.write_text(
-        render_discord_reply_skill(thread_id=thread_id, api_url=api_url),
+        render_discord_reply_skill(thread_id=thread_id, api_url=api_url, api_secret=api_secret),
         encoding="utf-8",
     )
     written.append(str(skill_path))
     logger.info(
-        "Injected discord-reply skill for thread %d at %s (api_url=%s)",
+        "Injected discord-reply skill for thread %d at %s (api_url=%s, auth=%s)",
         thread_id,
         skill_path,
         api_url,
+        "bearer" if api_secret else "none",
     )
     return written
 

--- a/c_lord/skills/injector.py
+++ b/c_lord/skills/injector.py
@@ -1,0 +1,62 @@
+"""Inject per-session skill files under ``<session_dir>/.claude/skills/``."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from .discord_reply import render_discord_reply_skill
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_URL = "http://127.0.0.1:8080"
+
+
+def inject_skills(
+    session_dir: str | os.PathLike[str],
+    thread_id: int,
+    api_url: str | None = None,
+) -> list[str]:
+    """Write the c-lord skill bundle into ``<session_dir>/.claude/skills/``.
+
+    Idempotent: existing files are overwritten so per-session values
+    (``thread_id``, ``api_url``) stay in sync if they change.
+
+    Args:
+        session_dir: Path to the per-thread session directory.
+        thread_id: Discord thread ID the session is bridged to.
+        api_url: Base URL of the c-lord REST API. Defaults to
+            ``CLORD_API_URL`` env var, or ``http://127.0.0.1:8080``.
+
+    Returns:
+        Absolute paths to the SKILL.md files written.
+    """
+    if api_url is None:
+        api_url = os.getenv("CLORD_API_URL") or DEFAULT_API_URL
+    api_url = api_url.rstrip("/")
+
+    skills_root = Path(session_dir) / ".claude" / "skills"
+
+    written: list[str] = []
+    skill_dir = skills_root / "discord-reply"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text(
+        render_discord_reply_skill(thread_id=thread_id, api_url=api_url),
+        encoding="utf-8",
+    )
+    written.append(str(skill_path))
+    logger.info(
+        "Injected discord-reply skill for thread %d at %s (api_url=%s)",
+        thread_id,
+        skill_path,
+        api_url,
+    )
+    return written
+
+
+def skills_enabled() -> bool:
+    """Return True if skill-based reply is enabled via env var (#52 flag)."""
+    value = os.getenv("USE_SKILL_REPLY", "").strip().lower()
+    return value in {"1", "true", "yes", "on"}

--- a/tests/e2e/test_skill_reply.py
+++ b/tests/e2e/test_skill_reply.py
@@ -1,0 +1,67 @@
+"""E2E: discord-reply Skill → c-lord REST API → Discord (#52 Phase 1).
+
+These tests assume the bot under test was started with ``USE_SKILL_REPLY=true``
+so that ``inject_skills`` ran when the session dir was created.  They are
+skipped otherwise.
+
+To run::
+
+    USE_SKILL_REPLY=true uv run python -m c_lord.main &
+    uv run pytest -m e2e tests/e2e/test_skill_reply.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from .conftest import DiscordE2EClient
+
+
+def _skill_reply_enabled() -> bool:
+    return os.getenv("USE_SKILL_REPLY", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    not _skill_reply_enabled(),
+    reason="USE_SKILL_REPLY not enabled — Skill is not injected on this bot",
+)
+def test_claude_uses_discord_reply_skill_to_post_marker(
+    discord_client: DiscordE2EClient,
+    bot_id: str,
+    attached_thread_id: str,
+) -> None:
+    """Ask Claude to use the discord-reply skill and verify the marker arrives.
+
+    The skill's curl command is the only way the marker can reach Discord
+    (we don't ask Claude to print to stdout). If the marker shows up, the
+    full Skill → REST API → bot.send pipeline is working.
+    """
+    marker = "e2e-skill-reply-fa9k2"
+    prompt = (
+        "あなたがいる作業ディレクトリの .claude/skills/discord-reply/SKILL.md を "
+        "読み、その手順 (curl /api/reply への POST) のみを使って次のマーカーを "
+        f"このスレッドに返答してください: {marker}\n\n"
+        "応答本文は他に何も含めないこと。説明、装飾、進捗ログ不要。"
+    )
+    wh = discord_client.webhook_post(prompt, thread_id=attached_thread_id)
+
+    reply = discord_client.wait_for_bot_reply(
+        attached_thread_id,
+        after_message_id=wh["id"],
+        bot_id=bot_id,
+        contains=marker,
+        timeout=240.0,
+        poll=4.0,
+    )
+    assert reply is not None, f"Bot did not reply with marker {marker!r} within 240s"
+
+    content = reply["content"]
+    # The skill posts as a plain message — no `-# 💻 (cli)` prefix like
+    # /api/threads/{id}/messages would add.
+    assert not content.startswith("-# "), (
+        f"Skill reply should be plain text, but got CLI-style prefix: {content[:80]!r}"
+    )
+    assert marker in content

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -562,3 +562,133 @@ class TestPostThreadMessage:
             headers={"Content-Type": "application/json"},
         )
         assert resp.status == 400
+
+
+class TestReplyEndpoint:
+    """Tests for POST /api/reply — Skill-based final reply (#52 Phase 1)."""
+
+    @pytest.fixture
+    def thread_mock(self) -> MagicMock:
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 555666777
+        thread.send = AsyncMock()
+        return thread
+
+    @pytest.fixture
+    def bot_with_thread(self, thread_mock: MagicMock) -> MagicMock:
+        b = MagicMock()
+        b.get_channel.return_value = thread_mock
+        return b
+
+    @pytest.fixture
+    async def reply_client(
+        self, repo: NotificationRepository, bot_with_thread: MagicMock
+    ) -> TestClient:
+        api = ApiServer(repo=repo, bot=bot_with_thread, default_channel_id=12345)
+        server = TestServer(api.app)
+        client = TestClient(server)
+        await client.start_server()
+        yield client
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_plain_content_posts_to_thread(
+        self, reply_client: TestClient, thread_mock: MagicMock
+    ) -> None:
+        resp = await reply_client.post(
+            "/api/reply",
+            json={"thread_id": 555666777, "content": "final answer here"},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "sent"
+        thread_mock.send.assert_called_once()
+        kwargs = thread_mock.send.call_args.kwargs
+        args = thread_mock.send.call_args.args
+        sent = kwargs.get("content") if "content" in kwargs else (args[0] if args else "")
+        assert "final answer here" in sent
+        # Unlike post_thread_message, /api/reply MUST NOT add a "-# 💻 (cli)" prefix.
+        assert "💻" not in sent
+        assert not sent.startswith("-# ")
+
+    @pytest.mark.asyncio
+    async def test_missing_content_returns_400(self, reply_client: TestClient) -> None:
+        resp = await reply_client.post("/api/reply", json={"thread_id": 555666777})
+        assert resp.status == 400
+        assert "content" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_thread_id_returns_400(self, reply_client: TestClient) -> None:
+        resp = await reply_client.post("/api/reply", json={"content": "hi"})
+        assert resp.status == 400
+        assert "thread_id" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_400(self, reply_client: TestClient) -> None:
+        resp = await reply_client.post(
+            "/api/reply",
+            data=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_thread_not_found_returns_404(
+        self, repo: NotificationRepository
+    ) -> None:
+        b = MagicMock()
+        b.get_channel.return_value = None
+        b.fetch_channel = AsyncMock(side_effect=Exception("not found"))
+        api = ApiServer(repo=repo, bot=b, default_channel_id=1)
+        server = TestServer(api.app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            resp = await client.post(
+                "/api/reply",
+                json={"thread_id": 999, "content": "x"},
+            )
+            assert resp.status == 404
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_attachment_via_progress_file(
+        self,
+        reply_client: TestClient,
+        thread_mock: MagicMock,
+        tmp_path,
+    ) -> None:
+        """When `progress_file` is given, it is attached to the Discord message."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text("step1\nstep2\n")
+
+        resp = await reply_client.post(
+            "/api/reply",
+            json={
+                "thread_id": 555666777,
+                "content": "done",
+                "progress_file": str(progress),
+            },
+        )
+        assert resp.status == 200
+        thread_mock.send.assert_called_once()
+        kwargs = thread_mock.send.call_args.kwargs
+        # Discord.py's send(file=...) — verify a file was passed
+        assert "file" in kwargs or "files" in kwargs
+
+    @pytest.mark.asyncio
+    async def test_missing_progress_file_returns_400(
+        self, reply_client: TestClient
+    ) -> None:
+        resp = await reply_client.post(
+            "/api/reply",
+            json={
+                "thread_id": 555666777,
+                "content": "x",
+                "progress_file": "/no/such/path.txt",
+            },
+        )
+        assert resp.status == 400

--- a/tests/test_session_dir.py
+++ b/tests/test_session_dir.py
@@ -146,6 +146,48 @@ class TestCreateSessionDir:
         assert result == str(session_dir)
         mock_run.assert_not_called()
 
+    def test_injects_skills_when_flag_enabled(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Issue #52: with USE_SKILL_REPLY=true the discord-reply SKILL.md
+        is dropped into the freshly cloned session dir."""
+        monkeypatch.setenv("USE_SKILL_REPLY", "true")
+        base = str(tmp_path / "sessions")
+
+        def fake_run(args, cwd=None):  # noqa: ANN001 — test helper
+            # Simulate git clone success by creating the target dir.
+            if "clone" in args:
+                Path(args[-1]).mkdir(parents=True, exist_ok=True)
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        with patch("c_lord.session_dir._run", side_effect=fake_run):
+            mgr = SessionDirManager(base_dir=base, source_repo="/repo")
+            Path(base).mkdir(parents=True)
+            target = mgr.create_session_dir(987)
+
+        skill = Path(target) / ".claude" / "skills" / "discord-reply" / "SKILL.md"
+        assert skill.exists(), "discord-reply SKILL.md should be injected"
+        assert "987" in skill.read_text()
+
+    def test_does_not_inject_skills_when_flag_disabled(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.delenv("USE_SKILL_REPLY", raising=False)
+        base = str(tmp_path / "sessions")
+
+        def fake_run(args, cwd=None):  # noqa: ANN001 — test helper
+            if "clone" in args:
+                Path(args[-1]).mkdir(parents=True, exist_ok=True)
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        with patch("c_lord.session_dir._run", side_effect=fake_run):
+            mgr = SessionDirManager(base_dir=base, source_repo="/repo")
+            Path(base).mkdir(parents=True)
+            target = mgr.create_session_dir(123)
+
+        skill = Path(target) / ".claude" / "skills" / "discord-reply" / "SKILL.md"
+        assert not skill.exists(), "skills should be opt-in via env flag"
+
     def test_clone_failure_raises(self, tmp_path: Path) -> None:
         base = str(tmp_path / "sessions")
 

--- a/tests/test_session_dir.py
+++ b/tests/test_session_dir.py
@@ -169,6 +169,30 @@ class TestCreateSessionDir:
         assert skill.exists(), "discord-reply SKILL.md should be injected"
         assert "987" in skill.read_text()
 
+    def test_reinjects_skills_on_existing_session_dir(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When the dir already exists, the skill is still (re)written so
+        api_url / api_secret stay in sync with current env values."""
+        monkeypatch.setenv("USE_SKILL_REPLY", "true")
+        base = str(tmp_path / "sessions")
+        existing = Path(base) / "555"
+        existing.mkdir(parents=True)
+
+        # First call with one URL
+        monkeypatch.setenv("CLORD_API_URL", "http://first:1")
+        mgr = SessionDirManager(base_dir=base, source_repo="/repo")
+        mgr.create_session_dir(555)
+        skill = existing / ".claude" / "skills" / "discord-reply" / "SKILL.md"
+        assert "http://first:1" in skill.read_text()
+
+        # Second call with a different URL — skill must reflect the new value
+        monkeypatch.setenv("CLORD_API_URL", "http://second:2")
+        mgr.create_session_dir(555)
+        body = skill.read_text()
+        assert "http://second:2" in body
+        assert "http://first:1" not in body
+
     def test_does_not_inject_skills_when_flag_disabled(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,90 @@
+"""Tests for c_lord.skills — discord-reply skill injection (#52)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from c_lord.skills import inject_skills, render_discord_reply_skill
+from c_lord.skills.injector import skills_enabled
+
+
+class TestRenderDiscordReplySkill:
+    def test_substitutes_thread_id_and_api_url(self) -> None:
+        body = render_discord_reply_skill(thread_id=987654321, api_url="http://x:9999")
+        assert "987654321" in body
+        assert "http://x:9999" in body
+        # YAML frontmatter is present
+        assert body.startswith("---\nname: discord-reply")
+        # No unfilled placeholders
+        assert "{thread_id}" not in body
+        assert "{api_url}" not in body
+
+    def test_curl_payload_is_valid_template(self) -> None:
+        """The JSON curl example must include the actual thread_id literal."""
+        body = render_discord_reply_skill(thread_id=42, api_url="http://x")
+        assert '"thread_id": 42' in body
+
+
+class TestInjectSkills:
+    def test_writes_discord_reply_skill_md(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "12345"
+        session_dir.mkdir()
+
+        paths = inject_skills(session_dir, thread_id=42, api_url="http://x:1234")
+
+        skill_md = session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md"
+        assert skill_md.exists()
+        assert str(skill_md) in paths
+        body = skill_md.read_text()
+        assert "42" in body
+        assert "http://x:1234" in body
+
+    def test_idempotent_overwrites(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "99"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://a")
+        inject_skills(session_dir, thread_id=1, api_url="http://b")
+        body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
+        assert "http://b" in body
+        assert "http://a" not in body
+
+    def test_strips_trailing_slash_from_api_url(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x:9/")
+        body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
+        assert "http://x:9/api/reply" in body
+
+    def test_falls_back_to_env_var(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("CLORD_API_URL", "http://envset:7")
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1)
+        body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
+        assert "http://envset:7" in body
+
+    def test_default_url_when_no_env(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.delenv("CLORD_API_URL", raising=False)
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1)
+        body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
+        assert "http://127.0.0.1:8080" in body
+
+
+class TestSkillsEnabled:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on"])
+    def test_truthy_values(self, value: str, monkeypatch) -> None:
+        monkeypatch.setenv("USE_SKILL_REPLY", value)
+        assert skills_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_falsy_values(self, value: str, monkeypatch) -> None:
+        monkeypatch.setenv("USE_SKILL_REPLY", value)
+        assert skills_enabled() is False
+
+    def test_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv("USE_SKILL_REPLY", raising=False)
+        assert skills_enabled() is False

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -26,6 +26,32 @@ class TestRenderDiscordReplySkill:
         body = render_discord_reply_skill(thread_id=42, api_url="http://x")
         assert '"thread_id": 42' in body
 
+    def test_no_multipart_examples(self) -> None:
+        """The endpoint is JSON-only — SKILL.md must not show -F multipart."""
+        body = render_discord_reply_skill(thread_id=1, api_url="http://x")
+        # `-F` would mean multipart form-data which /api/reply does NOT accept.
+        # `-d` (data) is JSON which it does accept.
+        assert " -F " not in body, "SKILL.md must not advertise multipart form-data"
+
+    def test_progress_file_uses_absolute_path(self) -> None:
+        """`progress_file` is an absolute server-side path, not @local-file."""
+        body = render_discord_reply_skill(thread_id=7, api_url="http://x")
+        assert "progress_file" in body
+        # Make sure we don't suggest the multipart `@path` upload syntax.
+        assert '"progress_file": "@' not in body
+        assert '"progress_file": "/' in body
+
+    def test_renders_bearer_header_when_secret_set(self) -> None:
+        body = render_discord_reply_skill(
+            thread_id=1, api_url="http://x", api_secret="s3cret-xyz"
+        )
+        assert "Authorization: Bearer s3cret-xyz" in body
+
+    def test_omits_bearer_header_when_no_secret(self) -> None:
+        body = render_discord_reply_skill(thread_id=1, api_url="http://x")
+        assert "Bearer" not in body
+        assert "Authorization" not in body
+
 
 class TestInjectSkills:
     def test_writes_discord_reply_skill_md(self, tmp_path: Path) -> None:
@@ -72,6 +98,31 @@ class TestInjectSkills:
         inject_skills(session_dir, thread_id=1)
         body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
         assert "http://127.0.0.1:8080" in body
+
+    def test_reads_api_secret_from_env(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("CLORD_API_SECRET", "env-secret-99")
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x")
+        body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
+        assert "Authorization: Bearer env-secret-99" in body
+
+    def test_explicit_api_secret_overrides_env(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("CLORD_API_SECRET", "from-env")
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x", api_secret="explicit")
+        body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
+        assert "Bearer explicit" in body
+        assert "from-env" not in body
+
+    def test_no_auth_header_when_no_secret(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.delenv("CLORD_API_SECRET", raising=False)
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x")
+        body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
+        assert "Authorization" not in body
 
 
 class TestSkillsEnabled:

--- a/tests/test_skills_contract.py
+++ b/tests/test_skills_contract.py
@@ -1,0 +1,196 @@
+"""Contract test: SKILL.md examples must work against /api/reply.
+
+Each curl example in the discord-reply SKILL.md is parsed back into the JSON
+payload it would send, then POSTed to a real ``ApiServer`` instance. If the
+endpoint and the template ever drift (e.g. someone switches the API to
+multipart again, or adds a required field), this test breaks loudly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from c_lord.database.notification_repo import NotificationRepository
+from c_lord.ext.api_server import ApiServer
+from c_lord.skills import render_discord_reply_skill
+
+THREAD_ID = 444555666
+
+
+def _extract_json_payloads(skill_md: str) -> list[dict]:
+    """Pull every ``-d @- <<JSON ... JSON`` heredoc body out of SKILL.md.
+
+    The here-doc delimiter may be quoted (``<<'JSON'``) or unquoted (``<<JSON``)
+    — both forms appear in the template. Returns a list of parsed JSON dicts
+    in the order they appear.
+    """
+    # Match heredocs:  <<['"]?JSON['"]?  ... JSON  (delimiter "JSON" both ends)
+    pattern = re.compile(
+        r"<<['\"]?JSON['\"]?\n(?P<body>.*?)\nJSON\b",
+        re.DOTALL,
+    )
+    return [json.loads(m.group("body")) for m in pattern.finditer(skill_md)]
+
+
+def _curl_blocks(skill_md: str) -> list[str]:
+    """Return every fenced ``bash`` block containing ``curl``."""
+    return re.findall(r"```bash\n(.*?curl.*?)\n```", skill_md, re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# Static contract checks (no network)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillMdStaticContract:
+    def test_every_curl_targets_api_reply(self) -> None:
+        body = render_discord_reply_skill(thread_id=THREAD_ID, api_url="http://x")
+        blocks = _curl_blocks(body)
+        assert blocks, "no curl blocks found in SKILL.md"
+        for block in blocks:
+            assert "/api/reply" in block, f"curl example targets wrong endpoint: {block[:80]!r}"
+            # Must be JSON, never multipart.
+            assert " -F " not in block, f"multipart leaked into SKILL.md: {block[:120]!r}"
+            assert "Content-Type: application/json" in block
+
+    def test_payloads_parse_as_json(self) -> None:
+        body = render_discord_reply_skill(thread_id=THREAD_ID, api_url="http://x")
+        payloads = _extract_json_payloads(body)
+        assert len(payloads) >= 2, "expected at least plain + attachment examples"
+        for payload in payloads:
+            assert payload["thread_id"] == THREAD_ID
+            assert isinstance(payload["content"], str) and payload["content"]
+            if "progress_file" in payload:
+                assert payload["progress_file"].startswith("/"), (
+                    f"progress_file must be an absolute path: {payload['progress_file']!r}"
+                )
+
+    def test_bearer_block_present_when_secret_set(self) -> None:
+        body = render_discord_reply_skill(
+            thread_id=THREAD_ID, api_url="http://x", api_secret="sk-abc"
+        )
+        for block in _curl_blocks(body):
+            assert "Authorization: Bearer sk-abc" in block, (
+                "every curl example must include the Bearer header when api_secret is set"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Live roundtrip: payload from SKILL.md → real /api/reply
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def repo() -> NotificationRepository:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    repo = NotificationRepository(path)
+    await repo.init_db()
+    yield repo
+    os.unlink(path)
+
+
+@pytest.fixture
+def thread_mock() -> MagicMock:
+    import discord
+
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = THREAD_ID
+    thread.send = AsyncMock()
+    return thread
+
+
+@pytest.fixture
+def bot_with_thread(thread_mock: MagicMock) -> MagicMock:
+    b = MagicMock()
+    b.get_channel.return_value = thread_mock
+    return b
+
+
+@pytest.fixture
+async def client(
+    repo: NotificationRepository, bot_with_thread: MagicMock
+) -> TestClient:
+    api = ApiServer(repo=repo, bot=bot_with_thread, default_channel_id=1)
+    server = TestServer(api.app)
+    client = TestClient(server)
+    await client.start_server()
+    yield client
+    await client.close()
+
+
+@pytest.fixture
+async def auth_client(
+    repo: NotificationRepository, bot_with_thread: MagicMock
+) -> TestClient:
+    api = ApiServer(
+        repo=repo, bot=bot_with_thread, default_channel_id=1, api_secret="sk-abc"
+    )
+    server = TestServer(api.app)
+    client = TestClient(server)
+    await client.start_server()
+    yield client
+    await client.close()
+
+
+class TestSkillMdRoundtripsAgainstEndpoint:
+    @pytest.mark.asyncio
+    async def test_plain_payload_accepted(
+        self, client: TestClient, thread_mock: MagicMock
+    ) -> None:
+        body = render_discord_reply_skill(thread_id=THREAD_ID, api_url="http://x")
+        plain, *_ = _extract_json_payloads(body)
+
+        resp = await client.post("/api/reply", json=plain)
+        assert resp.status == 200, await resp.text()
+        thread_mock.send.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_attachment_payload_accepted(
+        self,
+        client: TestClient,
+        thread_mock: MagicMock,
+        tmp_path,
+    ) -> None:
+        body = render_discord_reply_skill(thread_id=THREAD_ID, api_url="http://x")
+        payloads = _extract_json_payloads(body)
+        attachment_payload = next(p for p in payloads if "progress_file" in p)
+
+        # The template uses /tmp/progress-{thread_id}.txt — create the file so
+        # the endpoint can read it.
+        real_path = tmp_path / "progress.txt"
+        real_path.write_text("contract test detail")
+        attachment_payload["progress_file"] = str(real_path)
+
+        resp = await client.post("/api/reply", json=attachment_payload)
+        assert resp.status == 200, await resp.text()
+        kwargs = thread_mock.send.call_args.kwargs
+        assert "file" in kwargs
+
+    @pytest.mark.asyncio
+    async def test_bearer_payload_authenticated(
+        self, auth_client: TestClient, thread_mock: MagicMock
+    ) -> None:
+        body = render_discord_reply_skill(
+            thread_id=THREAD_ID, api_url="http://x", api_secret="sk-abc"
+        )
+        plain, *_ = _extract_json_payloads(body)
+
+        # Without the header → 401
+        unauth = await auth_client.post("/api/reply", json=plain)
+        assert unauth.status == 401
+
+        # With the header (matches what SKILL.md tells Claude to send) → 200
+        resp = await auth_client.post(
+            "/api/reply",
+            json=plain,
+            headers={"Authorization": "Bearer sk-abc"},
+        )
+        assert resp.status == 200, await resp.text()


### PR DESCRIPTION
## Summary

`tmux capture-pane` で Claude TUI をスクレイピングする旧経路は、連続的な TUI chrome leak バグ (#23, #27, #28, #29, #30, #32, #34, #35, #39, #41, #43, #45, #49, #50, ...) を生み続けている。本 PR は **旧経路を残したまま並走** で、Claude 自身が Skill (curl → REST API) で Discord に push する新方式を opt-in 導入する。

### 追加要素

- `c_lord/skills/` — per-session SKILL.md を thread_id / api_url 埋め込みで生成
- `POST /api/reply` — Skill 用の REST エンドポイント。`(cli)` 装飾を付けないクリーンな投稿 + `progress_file` 添付対応
- `SessionDirManager.create_session_dir` — `USE_SKILL_REPLY=true` 時のみ `<session_dir>/.claude/skills/discord-reply/SKILL.md` を書き出し
- `main.py` — `USE_SKILL_REPLY` または `CLORD_API_PORT` で `ApiServer` を自動起動

### Feature flag

```
USE_SKILL_REPLY=true
CLORD_API_URL=http://127.0.0.1:8080   # injected skill 用
CLORD_API_PORT=8080                    # bot が起動する API ポート
```

デフォルトは off。旧 scrape 経路は無変更。

## 受け入れ条件

- [x] `discord-reply` 呼び出しで Discord スレッドに本文 + (あれば) progress.txt が投稿される
- [x] feature flag で旧/新を切替可能 (`USE_SKILL_REPLY`)
- [x] 新方式の E2E が pytest スイートで green
- [x] 既存テストが壊れていない

## Test plan

- [x] `uv run pytest tests/ -q` → **888 passed** (+25 new: test_skills.py / test_session_dir injection / test_api_server reply endpoint)
- [x] `uv run ruff check c_lord/` / `ruff format --check`
- [x] **E2E (実 Claude + Discord)**:
  - テスト用 Bot を `USE_SKILL_REPLY=true CLORD_API_PORT=8087` で起動
  - `pytest -m e2e tests/e2e/test_skill_reply.py` → PASS
  - Bot log で `Injected discord-reply skill ... (api_url=http://127.0.0.1:8087)` を確認
  - aiohttp access log で `POST /api/reply HTTP/1.1 200` を確認
  - Discord に marker が到達、`-# ` 装飾なし

## 非スコープ (別 Issue 候補)

- Phase 2: `tmux_runner` scrape 経路の削除
- Phase 3: CHROME_BLACKLIST ベース E2E の整理・移行
- `discord-heartbeat` skill (長時間作業の生存通知)

Refs #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
