### PR TITLE
feat: discord-prompt-choice Skill で TUI interactive prompt を Discord に転送 (#63)

### DIFF
--- a/c_lord/ext/api_server.py
+++ b/c_lord/ext/api_server.py
@@ -107,6 +107,8 @@ class ApiServer:
         self.app.router.add_post("/api/threads/{thread_id}/messages", self.post_thread_message)
         # Issue #52: Skill-based final reply (clean content, no source prefix)
         self.app.router.add_post("/api/reply", self.reply)
+        # Issue #63: Skill-based interactive choice prompt
+        self.app.router.add_post("/api/prompt-choice", self.prompt_choice)
         # Startup resume routes
         self.app.router.add_post("/api/mark-resume", self.mark_resume)
 
@@ -721,6 +723,80 @@ class ApiServer:
 
         record_reply(thread_id)
 
+        return web.json_response({"status": "sent"})
+
+    async def prompt_choice(self, request: web.Request) -> web.Response:
+        """POST /api/prompt-choice — Skill-based interactive choice (#63).
+
+        Used by the ``discord-prompt-choice`` skill so Claude can push a
+        numbered choice menu to the Discord thread. Without this path,
+        post-#58 the user never sees TUI-rendered option lists.
+
+        Body (JSON):
+            thread_id: Target Discord thread ID (required, int).
+            question: Prompt text shown above the choices (required, non-empty).
+            choices: Non-empty list of ``{"label": str, "description"?: str}``.
+
+        Returns:
+            200 ``{"status": "sent"}`` on success.
+            400 on validation errors.
+            404 if the thread cannot be resolved.
+        """
+        try:
+            data = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        thread_id_raw = data.get("thread_id")
+        if thread_id_raw is None:
+            return web.json_response({"error": "thread_id is required"}, status=400)
+        try:
+            thread_id = int(thread_id_raw)
+        except (TypeError, ValueError):
+            return web.json_response({"error": "thread_id must be an integer"}, status=400)
+
+        question = (data.get("question") or "").strip()
+        if not question:
+            return web.json_response({"error": "question is required"}, status=400)
+
+        choices = data.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return web.json_response({"error": "choices must be a non-empty array"}, status=400)
+
+        # Validate each choice has at least a label.
+        normalized: list[tuple[str, str]] = []
+        for i, ch in enumerate(choices):
+            if not isinstance(ch, dict):
+                return web.json_response({"error": f"choices[{i}] must be an object"}, status=400)
+            label = str(ch.get("label", "")).strip()
+            if not label:
+                return web.json_response({"error": f"choices[{i}].label is required"}, status=400)
+            desc = str(ch.get("description", "")).strip()
+            normalized.append((label, desc))
+
+        raw = self.bot.get_channel(thread_id)
+        if raw is None:
+            try:
+                raw = await self.bot.fetch_channel(thread_id)
+            except Exception:
+                return web.json_response({"error": "Thread not found"}, status=404)
+
+        if not hasattr(raw, "send"):
+            return web.json_response({"error": "Channel is not messageable"}, status=400)
+
+        # Format the message. Bullets use the raw label so the user can copy
+        # it verbatim; description (if present) gives context.
+        lines = [f"🤔 **{question}**", ""]
+        for label, desc in normalized:
+            if desc:
+                lines.append(f"- `{label}` — {desc}")
+            else:
+                lines.append(f"- `{label}`")
+        lines.append("")
+        lines.append("_Reply with the label to continue._")
+        content = "\n".join(lines)
+
+        await raw.send(content=content)  # type: ignore[union-attr]
         return web.json_response({"status": "sent"})
 
     async def _send_lounge_to_discord(self, label: str, message: str, posted_at: str) -> None:

--- a/c_lord/skills/__init__.py
+++ b/c_lord/skills/__init__.py
@@ -9,7 +9,13 @@ Discord by curl-ing the c-lord REST API, replacing the legacy
 
 from __future__ import annotations
 
+from .discord_prompt_choice import render_discord_prompt_choice_skill
 from .discord_reply import DISCORD_REPLY_SKILL, render_discord_reply_skill
 from .injector import inject_skills
 
-__all__ = ["DISCORD_REPLY_SKILL", "inject_skills", "render_discord_reply_skill"]
+__all__ = [
+    "DISCORD_REPLY_SKILL",
+    "inject_skills",
+    "render_discord_prompt_choice_skill",
+    "render_discord_reply_skill",
+]

--- a/c_lord/skills/discord_prompt_choice.py
+++ b/c_lord/skills/discord_prompt_choice.py
@@ -1,0 +1,174 @@
+"""``discord-prompt-choice`` skill template (Issue #63).
+
+When Claude needs to present the user with a multiple-choice question
+(numbered options, yes/no, "which of these N approaches?"), it must call
+this skill so the choices reach Discord. Post-#58 the capture-pane scrape
+path is gone, so TUI-rendered choice prompts no longer leak through —
+the only push channel is the skill REST API.
+
+The template is rendered with the session's ``thread_id``, ``api_url`` and
+optional ``api_secret`` substituted in. The result is written to
+``<session_dir>/.claude/skills/discord-prompt-choice/SKILL.md`` so Claude
+finds it via skill auto-discovery, alongside ``discord-reply``.
+"""
+
+from __future__ import annotations
+
+# NOTE: keep the curl JSON aligned with ``POST /api/prompt-choice`` in
+# ``c_lord/ext/api_server.py``. ``tests/test_skills_contract.py`` parses
+# these examples and round-trips them through the real endpoint.
+
+DISCORD_PROMPT_CHOICE_SKILL_NO_AUTH = """\
+---
+name: discord-prompt-choice
+description: |
+  Present a numbered choice / option menu to the user on Discord. Use this
+  whenever you would otherwise ask the user to pick between alternatives
+  ("which approach? 1, 2, or 3?", "yes / no / cancel", "should I refactor
+  or rewrite?"). Without this skill the choice never reaches Discord and
+  the session stalls. The user's reply arrives in the next turn via the
+  normal Discord-thread → tmux input path.
+---
+
+# discord-prompt-choice
+
+This Claude session is bridged to Discord thread `{thread_id}`.
+Use the c-lord REST API to post a choice prompt.
+
+## When to use
+
+Whenever your response would otherwise be a question with discrete options —
+post the options via this skill instead of just listing them in text. The
+user replies with the label (e.g. `1`) in the Discord thread, and that
+reply arrives as your next turn's input.
+
+## Endpoint
+
+`POST {api_url}/api/prompt-choice` (JSON only).
+
+```bash
+curl -s -X POST "{api_url}/api/prompt-choice" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<'JSON'
+{{
+  "thread_id": {thread_id},
+  "question": "Which approach do you prefer?",
+  "choices": [
+    {{"label": "1", "description": "Refactor in place"}},
+    {{"label": "2", "description": "Rewrite from scratch"}},
+    {{"label": "3", "description": "Leave as-is for now"}}
+  ]
+}}
+JSON
+```
+
+## Schema
+
+- `thread_id` (int, required) — pinned for this session.
+- `question` (string, required) — the prompt shown to the user.
+- `choices` (array, required, non-empty) — each element has:
+  - `label` (string, required) — what the user types to pick this option.
+  - `description` (string, optional) — short explanation of the option.
+
+## Rules
+
+1. Call this skill **instead of** writing "1. ... 2. ... please reply with
+   a number" in `discord-reply`. The two skills are mutually exclusive in a
+   given turn — pick one based on whether you need a decision or not.
+2. After calling this skill, finish your turn. The user's choice arrives as
+   the next turn's prompt; resume work then.
+3. Keep `label` short (one token, ideally a single digit or word). It is
+   what the user types.
+4. Up to ~8 choices fit comfortably on Discord. If you have more, group
+   them first.
+"""
+
+DISCORD_PROMPT_CHOICE_SKILL_WITH_AUTH = """\
+---
+name: discord-prompt-choice
+description: |
+  Present a numbered choice / option menu to the user on Discord. Use this
+  whenever you would otherwise ask the user to pick between alternatives
+  ("which approach? 1, 2, or 3?", "yes / no / cancel", "should I refactor
+  or rewrite?"). Without this skill the choice never reaches Discord and
+  the session stalls. The user's reply arrives in the next turn via the
+  normal Discord-thread → tmux input path.
+---
+
+# discord-prompt-choice
+
+This Claude session is bridged to Discord thread `{thread_id}`.
+Use the c-lord REST API to post a choice prompt. The endpoint is protected
+by Bearer auth — every request must include the `Authorization` header.
+
+## When to use
+
+Whenever your response would otherwise be a question with discrete options —
+post the options via this skill instead of just listing them in text. The
+user replies with the label (e.g. `1`) in the Discord thread, and that
+reply arrives as your next turn's input.
+
+## Endpoint
+
+`POST {api_url}/api/prompt-choice` (JSON only).
+
+```bash
+curl -s -X POST "{api_url}/api/prompt-choice" \\
+  -H "Authorization: Bearer {api_secret}" \\
+  -H "Content-Type: application/json" \\
+  -d @- <<'JSON'
+{{
+  "thread_id": {thread_id},
+  "question": "Which approach do you prefer?",
+  "choices": [
+    {{"label": "1", "description": "Refactor in place"}},
+    {{"label": "2", "description": "Rewrite from scratch"}},
+    {{"label": "3", "description": "Leave as-is for now"}}
+  ]
+}}
+JSON
+```
+
+## Schema
+
+- `thread_id` (int, required) — pinned for this session.
+- `question` (string, required) — the prompt shown to the user.
+- `choices` (array, required, non-empty) — each element has:
+  - `label` (string, required) — what the user types to pick this option.
+  - `description` (string, optional) — short explanation of the option.
+
+## Rules
+
+1. Call this skill **instead of** writing "1. ... 2. ... please reply with
+   a number" in `discord-reply`. The two skills are mutually exclusive in a
+   given turn — pick one based on whether you need a decision or not.
+2. After calling this skill, finish your turn. The user's choice arrives as
+   the next turn's prompt; resume work then.
+3. Keep `label` short (one token, ideally a single digit or word). It is
+   what the user types.
+4. Up to ~8 choices fit comfortably on Discord. If you have more, group
+   them first.
+5. The Bearer token above must be sent with every request. Do not log it.
+"""
+
+
+def render_discord_prompt_choice_skill(
+    thread_id: int,
+    api_url: str,
+    api_secret: str | None = None,
+) -> str:
+    """Render the prompt-choice SKILL.md body with per-session values.
+
+    Args:
+        thread_id: Discord thread ID the session is bridged to.
+        api_url: Base URL of the c-lord REST API.
+        api_secret: Bearer token required by the API server. When set, the
+            curl examples include the ``Authorization`` header.
+    """
+    if api_secret:
+        return DISCORD_PROMPT_CHOICE_SKILL_WITH_AUTH.format(
+            thread_id=thread_id,
+            api_url=api_url,
+            api_secret=api_secret,
+        )
+    return DISCORD_PROMPT_CHOICE_SKILL_NO_AUTH.format(thread_id=thread_id, api_url=api_url)

--- a/c_lord/skills/injector.py
+++ b/c_lord/skills/injector.py
@@ -6,6 +6,7 @@ import logging
 import os
 from pathlib import Path
 
+from .discord_prompt_choice import render_discord_prompt_choice_skill
 from .discord_reply import render_discord_reply_skill
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,24 @@ def inject_skills(
         skill_path,
         api_url,
         "bearer" if api_secret else "none",
+    )
+
+    # Issue #63: prompt-choice skill — lets Claude push a numbered menu to
+    # Discord when it would otherwise stall waiting for the user to pick.
+    choice_dir = skills_root / "discord-prompt-choice"
+    choice_dir.mkdir(parents=True, exist_ok=True)
+    choice_path = choice_dir / "SKILL.md"
+    choice_path.write_text(
+        render_discord_prompt_choice_skill(
+            thread_id=thread_id, api_url=api_url, api_secret=api_secret
+        ),
+        encoding="utf-8",
+    )
+    written.append(str(choice_path))
+    logger.info(
+        "Injected discord-prompt-choice skill for thread %d at %s",
+        thread_id,
+        choice_path,
     )
     return written
 

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -721,3 +721,150 @@ class TestReplyEndpoint:
         )
         assert resp.status == 400
         assert was_replied_since(thread_id=555666777, since=before) is False
+
+
+class TestPromptChoiceEndpoint:
+    """Issue #63: POST /api/prompt-choice — Skill posts a choice prompt."""
+
+    @pytest.fixture
+    def thread_mock(self) -> MagicMock:
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 777888999
+        thread.send = AsyncMock()
+        return thread
+
+    @pytest.fixture
+    def bot_with_thread(self, thread_mock: MagicMock) -> MagicMock:
+        b = MagicMock()
+        b.get_channel.return_value = thread_mock
+        return b
+
+    @pytest.fixture
+    async def choice_client(
+        self, repo: NotificationRepository, bot_with_thread: MagicMock
+    ) -> TestClient:
+        api = ApiServer(repo=repo, bot=bot_with_thread, default_channel_id=12345)
+        server = TestServer(api.app)
+        client = TestClient(server)
+        await client.start_server()
+        yield client
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_posts_formatted_choice_message(
+        self, choice_client: TestClient, thread_mock: MagicMock
+    ) -> None:
+        resp = await choice_client.post(
+            "/api/prompt-choice",
+            json={
+                "thread_id": 777888999,
+                "question": "Which approach do you prefer?",
+                "choices": [
+                    {"label": "1", "description": "Refactor in place"},
+                    {"label": "2", "description": "Rewrite from scratch"},
+                    {"label": "3", "description": "Leave as-is"},
+                ],
+            },
+        )
+        assert resp.status == 200, await resp.text()
+        data = await resp.json()
+        assert data["status"] == "sent"
+        thread_mock.send.assert_called_once()
+        kwargs = thread_mock.send.call_args.kwargs
+        args = thread_mock.send.call_args.args
+        sent = kwargs.get("content") if "content" in kwargs else (args[0] if args else "")
+        assert "Which approach" in sent
+        assert "Refactor in place" in sent
+        assert "Rewrite from scratch" in sent
+        assert "Leave as-is" in sent
+        # Each label is shown so the user can reply with it.
+        assert "1" in sent and "2" in sent and "3" in sent
+
+    @pytest.mark.asyncio
+    async def test_missing_question_returns_400(self, choice_client: TestClient) -> None:
+        resp = await choice_client.post(
+            "/api/prompt-choice",
+            json={"thread_id": 777888999, "choices": [{"label": "a", "description": "x"}]},
+        )
+        assert resp.status == 400
+        assert "question" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_choices_returns_400(self, choice_client: TestClient) -> None:
+        resp = await choice_client.post(
+            "/api/prompt-choice",
+            json={"thread_id": 777888999, "question": "q?"},
+        )
+        assert resp.status == 400
+        assert "choices" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_returns_400(self, choice_client: TestClient) -> None:
+        resp = await choice_client.post(
+            "/api/prompt-choice",
+            json={"thread_id": 777888999, "question": "q?", "choices": []},
+        )
+        assert resp.status == 400
+        assert "choices" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_thread_id_returns_400(self, choice_client: TestClient) -> None:
+        resp = await choice_client.post(
+            "/api/prompt-choice",
+            json={
+                "question": "q?",
+                "choices": [{"label": "1", "description": "x"}],
+            },
+        )
+        assert resp.status == 400
+        assert "thread_id" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_400(self, choice_client: TestClient) -> None:
+        resp = await choice_client.post(
+            "/api/prompt-choice",
+            data=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_thread_not_found_returns_404(self, repo: NotificationRepository) -> None:
+        b = MagicMock()
+        b.get_channel.return_value = None
+        b.fetch_channel = AsyncMock(side_effect=Exception("not found"))
+        api = ApiServer(repo=repo, bot=b, default_channel_id=1)
+        server = TestServer(api.app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            resp = await client.post(
+                "/api/prompt-choice",
+                json={
+                    "thread_id": 999,
+                    "question": "q?",
+                    "choices": [{"label": "1", "description": "x"}],
+                },
+            )
+            assert resp.status == 404
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_label_only_choice_accepted(
+        self, choice_client: TestClient, thread_mock: MagicMock
+    ) -> None:
+        """A choice without description still posts the label."""
+        resp = await choice_client.post(
+            "/api/prompt-choice",
+            json={
+                "thread_id": 777888999,
+                "question": "Yes or no?",
+                "choices": [{"label": "yes"}, {"label": "no"}],
+            },
+        )
+        assert resp.status == 200
+        sent = thread_mock.send.call_args.kwargs.get("content", "")
+        assert "yes" in sent and "no" in sent

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from c_lord.skills import inject_skills, render_discord_reply_skill
+from c_lord.skills import (
+    inject_skills,
+    render_discord_prompt_choice_skill,
+    render_discord_reply_skill,
+)
 from c_lord.skills.injector import skills_enabled
 
 
@@ -42,13 +46,56 @@ class TestRenderDiscordReplySkill:
         assert '"progress_file": "/' in body
 
     def test_renders_bearer_header_when_secret_set(self) -> None:
-        body = render_discord_reply_skill(
-            thread_id=1, api_url="http://x", api_secret="s3cret-xyz"
-        )
+        body = render_discord_reply_skill(thread_id=1, api_url="http://x", api_secret="s3cret-xyz")
         assert "Authorization: Bearer s3cret-xyz" in body
 
     def test_omits_bearer_header_when_no_secret(self) -> None:
         body = render_discord_reply_skill(thread_id=1, api_url="http://x")
+        assert "Bearer" not in body
+        assert "Authorization" not in body
+
+
+class TestRenderDiscordPromptChoiceSkill:
+    """Issue #63: Skill that lets Claude post a choice prompt to Discord."""
+
+    def test_substitutes_thread_id_and_api_url(self) -> None:
+        body = render_discord_prompt_choice_skill(thread_id=123456, api_url="http://x:1111")
+        assert "123456" in body
+        assert "http://x:1111" in body
+        assert body.startswith("---\nname: discord-prompt-choice")
+        assert "{thread_id}" not in body
+        assert "{api_url}" not in body
+
+    def test_curl_targets_prompt_choice_endpoint(self) -> None:
+        body = render_discord_prompt_choice_skill(thread_id=1, api_url="http://x")
+        assert "/api/prompt-choice" in body
+        assert "Content-Type: application/json" in body
+        assert " -F " not in body  # JSON only, no multipart
+
+    def test_documents_question_and_choices_fields(self) -> None:
+        body = render_discord_prompt_choice_skill(thread_id=1, api_url="http://x")
+        assert "question" in body
+        assert "choices" in body
+        # Each choice has label + description (numbered options pattern)
+        assert "label" in body
+        assert "description" in body
+
+    def test_documents_when_to_invoke(self) -> None:
+        """Skill description must direct Claude to use it for choice prompts."""
+        body = render_discord_prompt_choice_skill(thread_id=1, api_url="http://x")
+        # The frontmatter description must clearly signal *when* to invoke.
+        # We deliberately don't pin exact wording — just key concepts.
+        head = body.split("---\n", 2)[1].lower()
+        assert "choice" in head or "選択" in head or "option" in head
+
+    def test_renders_bearer_header_when_secret_set(self) -> None:
+        body = render_discord_prompt_choice_skill(
+            thread_id=1, api_url="http://x", api_secret="sk-cc"
+        )
+        assert "Authorization: Bearer sk-cc" in body
+
+    def test_omits_bearer_header_when_no_secret(self) -> None:
+        body = render_discord_prompt_choice_skill(thread_id=1, api_url="http://x")
         assert "Bearer" not in body
         assert "Authorization" not in body
 
@@ -123,6 +170,20 @@ class TestInjectSkills:
         inject_skills(session_dir, thread_id=1, api_url="http://x")
         body = (session_dir / ".claude" / "skills" / "discord-reply" / "SKILL.md").read_text()
         assert "Authorization" not in body
+
+    def test_also_writes_prompt_choice_skill_md(self, tmp_path: Path) -> None:
+        """Issue #63: prompt-choice skill is injected alongside discord-reply."""
+        session_dir = tmp_path / "thr"
+        session_dir.mkdir()
+        paths = inject_skills(session_dir, thread_id=88, api_url="http://x:2222")
+
+        choice_md = session_dir / ".claude" / "skills" / "discord-prompt-choice" / "SKILL.md"
+        assert choice_md.exists()
+        assert str(choice_md) in paths
+        body = choice_md.read_text()
+        assert "88" in body
+        assert "http://x:2222" in body
+        assert "/api/prompt-choice" in body
 
 
 class TestSkillsEnabled:

--- a/tests/test_skills_contract.py
+++ b/tests/test_skills_contract.py
@@ -19,7 +19,10 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from c_lord.database.notification_repo import NotificationRepository
 from c_lord.ext.api_server import ApiServer
-from c_lord.skills import render_discord_reply_skill
+from c_lord.skills import (
+    render_discord_prompt_choice_skill,
+    render_discord_reply_skill,
+)
 
 THREAD_ID = 444555666
 
@@ -115,9 +118,7 @@ def bot_with_thread(thread_mock: MagicMock) -> MagicMock:
 
 
 @pytest.fixture
-async def client(
-    repo: NotificationRepository, bot_with_thread: MagicMock
-) -> TestClient:
+async def client(repo: NotificationRepository, bot_with_thread: MagicMock) -> TestClient:
     api = ApiServer(repo=repo, bot=bot_with_thread, default_channel_id=1)
     server = TestServer(api.app)
     client = TestClient(server)
@@ -127,12 +128,8 @@ async def client(
 
 
 @pytest.fixture
-async def auth_client(
-    repo: NotificationRepository, bot_with_thread: MagicMock
-) -> TestClient:
-    api = ApiServer(
-        repo=repo, bot=bot_with_thread, default_channel_id=1, api_secret="sk-abc"
-    )
+async def auth_client(repo: NotificationRepository, bot_with_thread: MagicMock) -> TestClient:
+    api = ApiServer(repo=repo, bot=bot_with_thread, default_channel_id=1, api_secret="sk-abc")
     server = TestServer(api.app)
     client = TestClient(server)
     await client.start_server()
@@ -142,9 +139,7 @@ async def auth_client(
 
 class TestSkillMdRoundtripsAgainstEndpoint:
     @pytest.mark.asyncio
-    async def test_plain_payload_accepted(
-        self, client: TestClient, thread_mock: MagicMock
-    ) -> None:
+    async def test_plain_payload_accepted(self, client: TestClient, thread_mock: MagicMock) -> None:
         body = render_discord_reply_skill(thread_id=THREAD_ID, api_url="http://x")
         plain, *_ = _extract_json_payloads(body)
 
@@ -191,6 +186,72 @@ class TestSkillMdRoundtripsAgainstEndpoint:
         resp = await auth_client.post(
             "/api/reply",
             json=plain,
+            headers={"Authorization": "Bearer sk-abc"},
+        )
+        assert resp.status == 200, await resp.text()
+
+
+# ---------------------------------------------------------------------------
+# discord-prompt-choice contract (#63)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptChoiceSkillMdStaticContract:
+    def test_every_curl_targets_prompt_choice(self) -> None:
+        body = render_discord_prompt_choice_skill(thread_id=THREAD_ID, api_url="http://x")
+        blocks = _curl_blocks(body)
+        assert blocks, "no curl blocks found in prompt-choice SKILL.md"
+        for block in blocks:
+            assert "/api/prompt-choice" in block, (
+                f"curl example targets wrong endpoint: {block[:80]!r}"
+            )
+            assert " -F " not in block
+            assert "Content-Type: application/json" in block
+
+    def test_payload_includes_question_and_choices(self) -> None:
+        body = render_discord_prompt_choice_skill(thread_id=THREAD_ID, api_url="http://x")
+        payloads = _extract_json_payloads(body)
+        assert payloads, "no JSON payloads found in prompt-choice SKILL.md"
+        for payload in payloads:
+            assert payload["thread_id"] == THREAD_ID
+            assert isinstance(payload["question"], str) and payload["question"]
+            assert isinstance(payload["choices"], list) and payload["choices"]
+            for ch in payload["choices"]:
+                assert "label" in ch
+
+    def test_bearer_block_present_when_secret_set(self) -> None:
+        body = render_discord_prompt_choice_skill(
+            thread_id=THREAD_ID, api_url="http://x", api_secret="sk-pc"
+        )
+        for block in _curl_blocks(body):
+            assert "Authorization: Bearer sk-pc" in block
+
+
+class TestPromptChoiceRoundtripsAgainstEndpoint:
+    @pytest.mark.asyncio
+    async def test_payload_accepted(self, client: TestClient, thread_mock: MagicMock) -> None:
+        body = render_discord_prompt_choice_skill(thread_id=THREAD_ID, api_url="http://x")
+        payload, *_ = _extract_json_payloads(body)
+        resp = await client.post("/api/prompt-choice", json=payload)
+        assert resp.status == 200, await resp.text()
+        thread_mock.send.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_bearer_payload_authenticated(
+        self, auth_client: TestClient, thread_mock: MagicMock
+    ) -> None:
+        # auth_client fixture is configured with api_secret="sk-abc".
+        body = render_discord_prompt_choice_skill(
+            thread_id=THREAD_ID, api_url="http://x", api_secret="sk-abc"
+        )
+        payload, *_ = _extract_json_payloads(body)
+
+        unauth = await auth_client.post("/api/prompt-choice", json=payload)
+        assert unauth.status == 401
+
+        resp = await auth_client.post(
+            "/api/prompt-choice",
+            json=payload,
             headers={"Authorization": "Bearer sk-abc"},
         )
         assert resp.status == 200, await resp.text()


### PR DESCRIPTION
## Summary
- PR #58 で capture-pane scrape 経路を撤去した結果、Claude TUI がレンダリングする選択メニュー (「1. Yes / 2. No / 3. Always allow」, 「3 案のうちどれ?」等) が Discord に届かなくなり、ユーザが応答できずセッションが詰まる問題に対する **提案 A** の実装 (Issue #63)。
- 新 Skill `discord-prompt-choice` を `<session_dir>/.claude/skills/` に注入。Claude が選択肢を出したいとき curl で `POST /api/prompt-choice` を叩き、c-lord が整形して Discord thread に post。
- ユーザの返信は **既存の Discord thread → tmux send-keys 経路** に乗るため inbound 側は新規コードなし。

## 変更ファイル
| ファイル | 役割 |
|---|---|
| `c_lord/skills/discord_prompt_choice.py` (new) | SKILL.md テンプレート + renderer (auth/no-auth 両対応) |
| `c_lord/ext/api_server.py` | `POST /api/prompt-choice` ハンドラ追加 (thread_id / question / choices[label, description] バリデーション + 404/400 系) |
| `c_lord/skills/injector.py` | `discord-reply` と同じ idempotent 注入で `discord-prompt-choice/SKILL.md` も書き出し |
| `c_lord/skills/__init__.py` | `render_discord_prompt_choice_skill` を公開 |
| `tests/test_skills.py` | `TestRenderDiscordPromptChoiceSkill` (6 件) + injector 追加テスト 1 件 |
| `tests/test_skills_contract.py` | 静的契約 3 件 + endpoint roundtrip 2 件 (Bearer 含) |
| `tests/test_api_server.py` | `TestPromptChoiceEndpoint` 8 件 (success / 400 / 404 / label-only / invalid JSON) |

Discord 出力フォーマット:
```
🤔 **<question>**

- \`<label>\` — <description>
- \`<label>\` — <description>

_Reply with the label to continue._
```

## Test plan

### Unit (TDD)
- [x] **RED**: SKILL.md renderer 未実装 → `ImportError: cannot import name 'render_discord_prompt_choice_skill'`
- [x] **GREEN**: 実装後、新規 19 件含む **840 件 pass**
- [x] `ruff check c_lord/` / `ruff format --check c_lord/` 通過

### Staging E2E (CLAUDE.md L329-L373 必須フロー)
staging bot (`/home/yousan/c-lord-parallel-3`, channel `1503196656265597082`) で本ブランチを起動 (`CLORD_API_PORT=8089` で prod 8087 と分離) し、webhook 経由に「3 案を Skill 経由で尋ねて」と投げた:

**bot ログ** (10:14:14〜10:14:28):
\`\`\`
Injected discord-prompt-choice skill for thread 1503200157079048292 at .../SKILL.md
run_claude: enter (prompt=198 chars)
POST /api/prompt-choice HTTP/1.1" 200   ← Claude が自発的に Skill 発火
run_claude: exit
\`\`\`

**Discord 出力** (msg id `1504290917350739968`):
\`\`\`
🤔 **新機能追加のアプローチを選んでください:**

- \`A\` — feature flag で段階的に — フラグで制御しながら段階的にロールアウト
- \`B\` — 別ファイルでフル実装 — 新しいファイルに独立した実装を追加
- \`C\` — 既存ファイルにマージ — 既存コードに直接統合

_Reply with the label to continue._
\`\`\`

**Before (PR #58 merge 後 / 本 PR 前)**: TUI に選択メニューが出ても Discord には届かず、ユーザが応答できないままタイムアウト or stall。
**After**: Claude が能動的に Skill を呼び、整形済みメニューが Discord 到達。返信は既存経路で tmux に届く。

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)