### PR TITLE
fix: discord-reply 未呼び出しターンでフォールバック通知 (#67)

### DIFF
--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+import time
 
 import discord
 
@@ -178,14 +179,21 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
 
     runner = config.runner
     processor = EventProcessor(config)
+    # Issue #67: capture turn start so we can detect whether Claude ever
+    # invoked the discord-reply skill before the runner finished.
+    turn_started_at = time.monotonic()
+    run_errored = False
 
     try:
         async for event in runner.run(config.prompt, session_id=config.session_id):
             if processor.should_drain:
                 continue
             await processor.process(event)
+            if event.is_complete and event.error:
+                run_errored = True
     except Exception:
         logger.exception("%s Error running Claude CLI", ctx)
+        run_errored = True
         # Wrap Discord sends in suppress — the connection may already be closed
         # (e.g. ServerDisconnectedError on bot shutdown), and sending would fail too.
         with contextlib.suppress(Exception):
@@ -200,6 +208,23 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
             config.registry.unregister(config.thread.id)
         if config.image_paths:
             await _cleanup_image_tempfiles(config.image_paths)
+
+    # Issue #67: surface a fallback notice when the turn finished cleanly but
+    # Claude never called the discord-reply skill — otherwise the user is left
+    # staring at silence (only the "no activity 30s" stall warning).
+    if not run_errored and not processor.pending_ask:
+        from ..skills.reply_tracker import was_replied_since
+
+        if not was_replied_since(config.thread.id, turn_started_at):
+            logger.warning(
+                "%s Claude finished without calling discord-reply — posting fallback notice",
+                ctx,
+            )
+            with contextlib.suppress(Exception):
+                await config.thread.send(
+                    "-# ⚠️ Claude finished without calling the `discord-reply` skill. "
+                    "Check the tmux pane for the response, or retry the turn."
+                )
 
     # After the stream ends, handle pending AskUserQuestion by showing Discord
     # UI and resuming the session with the user's answer.

--- a/c_lord/ext/api_server.py
+++ b/c_lord/ext/api_server.py
@@ -715,6 +715,12 @@ class ApiServer:
             send_kwargs["file"] = attachment
         await raw.send(**send_kwargs)  # type: ignore[union-attr]
 
+        # Issue #67: record the successful reply so run_helper can detect
+        # turns where Claude never invoked the discord-reply skill.
+        from ..skills.reply_tracker import record_reply
+
+        record_reply(thread_id)
+
         return web.json_response({"status": "sent"})
 
     async def _send_lounge_to_discord(self, label: str, message: str, posted_at: str) -> None:

--- a/c_lord/skills/reply_tracker.py
+++ b/c_lord/skills/reply_tracker.py
@@ -1,0 +1,33 @@
+"""In-memory tracker recording when ``discord-reply`` was last invoked.
+
+Used to detect turns where the Claude session finished without calling the
+skill (issue #67). The api_server records the timestamp on every successful
+``POST /api/reply``; the run helper checks the tracker at the end of a turn
+and surfaces a fallback notification to the Discord thread if the skill was
+never called.
+
+Process-scoped state — both writer (api_server) and reader (run_helper)
+live in the same bot process, so a plain module-level dict is sufficient.
+"""
+
+from __future__ import annotations
+
+import time
+
+_last_reply_at: dict[int, float] = {}
+
+
+def record_reply(thread_id: int) -> None:
+    """Record that ``discord-reply`` was just invoked for ``thread_id``."""
+    _last_reply_at[thread_id] = time.monotonic()
+
+
+def was_replied_since(thread_id: int, since: float) -> bool:
+    """Return True if a reply was recorded for ``thread_id`` at or after ``since``."""
+    last = _last_reply_at.get(thread_id)
+    return last is not None and last >= since
+
+
+def reset_tracker() -> None:
+    """Clear all recorded replies. For tests only."""
+    _last_reply_at.clear()

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -635,9 +635,7 @@ class TestReplyEndpoint:
         assert resp.status == 400
 
     @pytest.mark.asyncio
-    async def test_thread_not_found_returns_404(
-        self, repo: NotificationRepository
-    ) -> None:
+    async def test_thread_not_found_returns_404(self, repo: NotificationRepository) -> None:
         b = MagicMock()
         b.get_channel.return_value = None
         b.fetch_channel = AsyncMock(side_effect=Exception("not found"))
@@ -680,9 +678,7 @@ class TestReplyEndpoint:
         assert "file" in kwargs or "files" in kwargs
 
     @pytest.mark.asyncio
-    async def test_missing_progress_file_returns_400(
-        self, reply_client: TestClient
-    ) -> None:
+    async def test_missing_progress_file_returns_400(self, reply_client: TestClient) -> None:
         resp = await reply_client.post(
             "/api/reply",
             json={
@@ -692,3 +688,36 @@ class TestReplyEndpoint:
             },
         )
         assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_successful_reply_records_in_tracker(self, reply_client: TestClient) -> None:
+        """Issue #67: api_server records each /api/reply call so run_helper
+        can detect turns where the skill was never invoked."""
+        import time
+
+        from c_lord.skills.reply_tracker import reset_tracker, was_replied_since
+
+        reset_tracker()
+        before = time.monotonic()
+        resp = await reply_client.post(
+            "/api/reply",
+            json={"thread_id": 555666777, "content": "answered"},
+        )
+        assert resp.status == 200
+        assert was_replied_since(thread_id=555666777, since=before) is True
+
+    @pytest.mark.asyncio
+    async def test_failed_reply_does_not_record(self, reply_client: TestClient) -> None:
+        """A 400 (missing content) MUST NOT be recorded as a successful reply."""
+        import time
+
+        from c_lord.skills.reply_tracker import reset_tracker, was_replied_since
+
+        reset_tracker()
+        before = time.monotonic()
+        resp = await reply_client.post(
+            "/api/reply",
+            json={"thread_id": 555666777},  # missing content
+        )
+        assert resp.status == 400
+        assert was_replied_since(thread_id=555666777, since=before) is False

--- a/tests/test_reply_tracker.py
+++ b/tests/test_reply_tracker.py
@@ -1,0 +1,49 @@
+"""Tests for c_lord.skills.reply_tracker.
+
+The tracker records when Claude posts via the ``discord-reply`` skill so
+``run_claude_with_config`` can detect turns where the skill was never called
+and surface a fallback notification to Discord (issue #67).
+"""
+
+from __future__ import annotations
+
+import time
+
+from c_lord.skills.reply_tracker import (
+    record_reply,
+    reset_tracker,
+    was_replied_since,
+)
+
+
+def setup_function() -> None:
+    reset_tracker()
+
+
+def test_no_reply_returns_false() -> None:
+    assert was_replied_since(thread_id=12345, since=time.monotonic()) is False
+
+
+def test_recorded_reply_after_since_returns_true() -> None:
+    before = time.monotonic()
+    record_reply(thread_id=12345)
+    assert was_replied_since(thread_id=12345, since=before) is True
+
+
+def test_reply_before_since_returns_false() -> None:
+    record_reply(thread_id=12345)
+    later = time.monotonic() + 1.0
+    assert was_replied_since(thread_id=12345, since=later) is False
+
+
+def test_other_thread_isolated() -> None:
+    before = time.monotonic()
+    record_reply(thread_id=111)
+    assert was_replied_since(thread_id=222, since=before) is False
+    assert was_replied_since(thread_id=111, since=before) is True
+
+
+def test_reset_clears_state() -> None:
+    record_reply(thread_id=12345)
+    reset_tracker()
+    assert was_replied_since(thread_id=12345, since=0.0) is False

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -318,6 +318,130 @@ class TestRunClaudeInThread:
         )
 
 
+class TestNoReplyFallback:
+    """Issue #67: when Claude finishes a turn without calling discord-reply,
+    run_claude_with_config must surface a fallback notification so the user
+    isn't left staring at silence."""
+
+    @pytest.fixture
+    def thread(self) -> MagicMock:
+        t = MagicMock(spec=discord.Thread)
+        t.id = 67670001
+        t.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
+        return t
+
+    @pytest.fixture
+    def runner(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def repo(self) -> MagicMock:
+        r = MagicMock()
+        r.save = AsyncMock()
+        return r
+
+    def _make_async_gen(self, events):
+        async def gen(*args, **kwargs):
+            for e in events:
+                yield e
+
+        return gen
+
+    @pytest.mark.asyncio
+    async def test_fallback_posted_when_no_reply_call(
+        self, thread: MagicMock, runner: MagicMock, repo: MagicMock
+    ) -> None:
+        """A successful run with NO /api/reply call must post a fallback notice."""
+        from c_lord.skills.reply_tracker import reset_tracker
+
+        reset_tracker()
+
+        events = [
+            StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1"),
+            StreamEvent(
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                session_id="sess-1",
+            ),
+        ]
+        runner.run = self._make_async_gen(events)
+
+        await run_claude_in_thread(thread, runner, repo, "hello", None)
+
+        sent_strings = []
+        for call in thread.send.call_args_list:
+            for arg in call.args:
+                if isinstance(arg, str):
+                    sent_strings.append(arg)
+            if "content" in call.kwargs and isinstance(call.kwargs["content"], str):
+                sent_strings.append(call.kwargs["content"])
+
+        assert any("discord-reply" in s for s in sent_strings), (
+            f"Expected fallback notice mentioning discord-reply, got sends: {sent_strings}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_reply_was_called(
+        self, thread: MagicMock, runner: MagicMock, repo: MagicMock
+    ) -> None:
+        """If /api/reply was called during the turn, no fallback notice is sent."""
+        from c_lord.skills.reply_tracker import record_reply, reset_tracker
+
+        reset_tracker()
+
+        async def gen_with_reply(*args, **kwargs):
+            yield StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1")
+            # Simulate Claude calling /api/reply mid-turn.
+            record_reply(thread.id)
+            yield StreamEvent(
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                session_id="sess-1",
+            )
+
+        runner.run = gen_with_reply
+
+        await run_claude_in_thread(thread, runner, repo, "hello", None)
+
+        for call in thread.send.call_args_list:
+            for arg in call.args:
+                if isinstance(arg, str):
+                    assert "discord-reply" not in arg
+            content = call.kwargs.get("content")
+            if isinstance(content, str):
+                assert "discord-reply" not in content
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_on_error(
+        self, thread: MagicMock, runner: MagicMock, repo: MagicMock
+    ) -> None:
+        """Errors already produce their own embed; the fallback must not pile on."""
+        from c_lord.skills.reply_tracker import reset_tracker
+
+        reset_tracker()
+
+        events = [
+            StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1"),
+            StreamEvent(
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                error="Timed out after 300 seconds",
+                session_id="sess-1",
+            ),
+        ]
+        runner.run = self._make_async_gen(events)
+
+        await run_claude_in_thread(thread, runner, repo, "hello", None)
+
+        for call in thread.send.call_args_list:
+            for arg in call.args:
+                if isinstance(arg, str):
+                    assert "discord-reply" not in arg
+            content = call.kwargs.get("content")
+            if isinstance(content, str):
+                assert "discord-reply" not in content
+
+
 class TestMakeErrorEmbed:
     """Unit tests for the _make_error_embed router function."""
 


### PR DESCRIPTION
## Summary
- #58 以降、Claude の最終応答は `discord-reply` Skill 経由でのみ Discord に届く。Claude が Skill を呼び忘れるとユーザは沈黙だけを目にする (only "No activity 30s" 警告) — これが #67 の症状。
- ターン単位で `/api/reply` 呼び出しを追跡し、未呼び出しのまま Claude が完了した場合に Discord スレへフォールバック通知を投稿。

## Changes
- `c_lord/skills/reply_tracker.py` (new): プロセス内 in-memory tracker。`record_reply(thread_id)` / `was_replied_since(thread_id, since)`。
- `c_lord/ext/api_server.py`: `POST /api/reply` 成功時に `record_reply()`。
- `c_lord/cogs/_run_helper.py`: `run_claude_with_config` でターン開始時刻を `time.monotonic()` で記録、エラー/AskUserQuestion 以外のクリーン完了時に未呼び出しなら `"-# ⚠️ Claude finished without calling the \`discord-reply\` skill. ..."` を `thread.send` する。

## TDD
RED→GREEN を 3 層で確認:
- `tests/test_reply_tracker.py` (5 test): tracker 単体
- `tests/test_api_server.py::TestReplyEndpoint::test_successful_reply_records_in_tracker` + `test_failed_reply_does_not_record`: api_server が成功時のみ record する
- `tests/test_run_helper.py::TestNoReplyFallback` (3 test): fallback 投稿 / 呼び出し済みなら投稿しない / エラー時は重ねない

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/e2e` — 830 passed
- [x] `uv run ruff check c_lord/` — clean
- [x] `uv run ruff format --check` — clean
- [ ] staging で E2E 確認: Claude セッションに「`discord-reply` を呼ばずに終わるプロンプト」を投げて、フォールバック通知が届くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)