### PR TITLE
fix: tmux server restart 後の thread↔window mapping を pane path から復元 (#69)

### DIFF
--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -11,7 +11,12 @@ When tmux is not installed, operations degrade gracefully (log warning, skip).
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
+
+# Discord snowflake IDs are 17–19 digits. Require ≥10 to avoid matching
+# unrelated trailing-numeric path components (PIDs, ports, etc.).
+_THREAD_ID_FROM_PATH_RE = re.compile(r"(\d{10,})/*$")
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +132,13 @@ class TmuxSessionManager:
     def _rebuild_mapping(self) -> None:
         """Rebuild ``_thread_to_window`` from live tmux state.
 
+        Primary key is the ``@thread_id`` window option. When that option
+        is missing — which happens after a tmux server restart, because
+        tmux-resurrect (and similar) restore window names but not user
+        options — fall back to extracting the thread_id from the pane's
+        current path (``<session_dir_base>/<thread_id>``) and repair the
+        ``@thread_id`` option so future lookups stay cheap. (Issue #69.)
+
         Also updates ``_next_work_id`` to be one past the highest existing
         work window number.
         """
@@ -139,18 +151,24 @@ class TmuxSessionManager:
                 "-t",
                 self.session_name,
                 "-F",
-                "#{window_name}",
+                "#{window_name}\t#{pane_current_path}",
             ]
         )
         if result.returncode != 0:
             return
 
         max_id = 0
-        for window_name in result.stdout.strip().splitlines():
+        for line in result.stdout.strip().splitlines():
+            if not line:
+                continue
+            parts = line.split("\t", 1)
+            window_name = parts[0]
+            pane_path = parts[1] if len(parts) > 1 else ""
             if not window_name:
                 continue
 
-            # Read the @thread_id option for this window
+            thread_id: int | None = None
+
             opt_result = _run(
                 [
                     "tmux",
@@ -165,9 +183,33 @@ class TmuxSessionManager:
             if opt_result.returncode == 0:
                 tid_str = opt_result.stdout.strip()
                 if tid_str.isdigit():
-                    self._thread_to_window[int(tid_str)] = window_name
+                    thread_id = int(tid_str)
 
-            # Track highest work ID
+            if thread_id is None and pane_path:
+                m = _THREAD_ID_FROM_PATH_RE.search(pane_path)
+                if m:
+                    thread_id = int(m.group(1))
+                    _run(
+                        [
+                            "tmux",
+                            "set-option",
+                            "-w",
+                            "-t",
+                            f"{self.session_name}:{window_name}",
+                            "@thread_id",
+                            str(thread_id),
+                        ]
+                    )
+                    logger.info(
+                        "Recovered thread_id %d for window %s from pane path %s",
+                        thread_id,
+                        window_name,
+                        pane_path,
+                    )
+
+            if thread_id is not None:
+                self._thread_to_window[thread_id] = window_name
+
             if window_name.startswith(WINDOW_PREFIX):
                 suffix = window_name[len(WINDOW_PREFIX) :]
                 if suffix.isdigit():

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -275,6 +275,58 @@ class TestTmuxSessionManager:
         assert mgr._thread_to_window == {111: "work1", 333: "work3"}
         assert mgr._next_work_id == 4  # one past highest (3)
 
+    def test_rebuild_mapping_recovers_from_pane_path(self) -> None:
+        """When @thread_id is missing (e.g. after tmux server restart wiped
+        user options), thread_id is recovered from the pane's current path.
+
+        Regression for #69: tmux-resurrect restores window names but not
+        ``@thread_id`` window options, so the lookup had to fall back to
+        the working directory, which contains the thread ID by convention
+        (``<base>/<thread_id>``).
+        """
+        mgr = TmuxSessionManager()
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                # list-windows with pane_current_path
+                MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "work1\t/home/u/c-lord-sessions/999/1501841644457300038\n"
+                        "work2\t/home/u/other\n"
+                    ),
+                ),
+                # show-option @thread_id for work1 → option unset (rc=1)
+                MagicMock(returncode=1, stdout=""),
+                # set-option to repair @thread_id for work1
+                MagicMock(returncode=0),
+                # show-option @thread_id for work2 → option unset (rc=1)
+                MagicMock(returncode=1, stdout=""),
+            ]
+            mgr._rebuild_mapping()
+
+        # Recovered from path
+        assert mgr._thread_to_window == {1501841644457300038: "work1"}
+        # work2 has no recoverable thread_id → not mapped
+        assert 2 not in mgr._thread_to_window
+
+    def test_rebuild_mapping_prefers_option_over_path(self) -> None:
+        """When @thread_id is set, it wins over pane_current_path inference."""
+        mgr = TmuxSessionManager()
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout="work1\t/home/u/c-lord-sessions/999/1501841644457300038\n",
+                ),
+                # show-option returns the authoritative thread_id
+                MagicMock(returncode=0, stdout="42\n"),
+            ]
+            mgr._rebuild_mapping()
+
+        assert mgr._thread_to_window == {42: "work1"}
+
     def test_rebuild_mapping_empty(self) -> None:
         """_rebuild_mapping with no windows results in empty state."""
         mgr = TmuxSessionManager()


### PR DESCRIPTION
## Summary

- `TmuxSessionManager._rebuild_mapping` を強化: `@thread_id` window option が無いときは `pane_current_path` の末尾セグメント (session_dir 規約 `<base>/<thread_id>`) から thread_id を復元し、`@thread_id` を書き戻して以後のルックアップを高速化
- 既存 window の `@thread_id` option がある場合は従来どおりそちらを優先

## Why

tmux-resurrect 等は window 名を復元するが user-option (`@thread_id`) は復元しないため、tmux サーバ再起動後に c-lord は既存 thread を見つけられず新規 workN を作って Claude セッションを孤立させていた (#69)。Discord thread 名にも `workN:` prepend が累積する副作用あり。

c-lord bot プロセス再起動だけなら従来コードでも復元できていたが、WSL リブート / `tmux kill-server` / マシン再起動を跨ぐと option が消えて再構築不可になっていた。

## Test plan

- [x] TDD: 失敗テスト 2 件追加 → 実装で green
  - `test_rebuild_mapping_recovers_from_pane_path`: @thread_id 不在 + pane_current_path 末尾の Discord ID から復元 + repair (set-option)
  - `test_rebuild_mapping_prefers_option_over_path`: @thread_id がある場合は path より優先
- [x] `uv run pytest tests/` 832 passed
- [x] `uv run ruff check / format --check` 変更ファイル green

## Notes

副次バグ「Discord thread 名に `workN:` prepend が累積」は本 PR の修正によって再起動経路では発生しなくなる (新規 workN が作られなくなるため)。既に汚染された thread 名は手動でリネームが必要。完全に prepend を廃止するかは別 Issue で判断。

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)