### PR TITLE
feat: c_lord.transcript — JSONL transcript mirror foundation (#71 step 1)

### DIFF
--- a/c_lord/transcript/__init__.py
+++ b/c_lord/transcript/__init__.py
@@ -1,0 +1,30 @@
+"""JSONL transcript mirror (Issue #71).
+
+c-lord acts as a transparent mirror of the Claude Code session transcript at
+``~/.claude/projects/<slug>/<session-id>.jsonl``.  This package provides the
+three building blocks of that mirror:
+
+- :mod:`.resolver` — map a tmux ``cwd`` to its project transcript directory and
+  pick the current session file (mtime-latest, so ``/clear`` is followed).
+- :mod:`.formatter` — render a single JSONL event into Discord-bound text, or
+  return ``None`` for events that should be skipped (thinking, framing meta,
+  c-lord-originated ZWSP-marked input, etc.).
+- :mod:`.tail` — async generator that follows the active jsonl, switches to a
+  newer file when the project's mtime-latest changes, and recovers from
+  truncation/rewrite.
+"""
+
+from __future__ import annotations
+
+from .formatter import ZWSP_MARKER, RenderedEvent, render_event
+from .resolver import derive_project_dir, latest_session_jsonl
+from .tail import tail_events
+
+__all__ = [
+    "ZWSP_MARKER",
+    "RenderedEvent",
+    "derive_project_dir",
+    "latest_session_jsonl",
+    "render_event",
+    "tail_events",
+]

--- a/c_lord/transcript/formatter.py
+++ b/c_lord/transcript/formatter.py
@@ -1,0 +1,141 @@
+"""Render a single JSONL event into Discord-bound text.
+
+The mirror is intentionally narrow: only events that have a visible
+counterpart in the tmux pane are rendered.  Everything else (thinking,
+framing meta like ``ai-title`` / ``pr-link`` / ``permission-mode``, the
+self-loopback of c-lord-driven input marked with a zero-width-space prefix)
+returns ``None`` and is dropped before it ever reaches Discord.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# c-lord prefixes ``tmux send-keys`` input with this zero-width space so the
+# resulting ``user`` event in the JSONL can be recognized as our own echo and
+# skipped — Discord already saw it on the way in.  Any user event without the
+# marker is treated as a human typing directly in the pane and is mirrored.
+ZWSP_MARKER = "​"
+
+
+@dataclass(frozen=True)
+class RenderedEvent:
+    kind: str  # "assistant_text" | "tool_use" | "tool_result" | "user_input"
+    body: str
+    session_id: str | None = None
+
+
+_FRAMING_TYPES = frozenset(
+    {
+        "file-history-snapshot",
+        "ai-title",
+        "last-prompt",
+        "pr-link",
+        "permission-mode",
+        "queue-operation",
+        "attachment",
+        "system",
+    }
+)
+
+
+def _format_tool_use(block: dict[str, Any]) -> str:
+    name = block.get("name", "?")
+    inp = block.get("input") or {}
+    if name == "Bash":
+        return f"🔧 Bash: `{inp.get('command', '')}`"
+    if name in ("Read", "Write", "Edit", "NotebookEdit"):
+        return f"🔧 {name}: `{inp.get('file_path', '')}`"
+    if name == "Grep":
+        return f"🔧 Grep: `{inp.get('pattern', '')}`"
+    if name == "Glob":
+        return f"🔧 Glob: `{inp.get('pattern', '')}`"
+    return f"🔧 {name}"
+
+
+def _render_assistant(event: dict[str, Any]) -> RenderedEvent | None:
+    msg = event.get("message")
+    if not isinstance(msg, dict):
+        return None
+    parts: list[str] = []
+    kind = "assistant_text"
+    for block in msg.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        bt = block.get("type")
+        if bt == "text":
+            text = (block.get("text") or "").strip()
+            if text:
+                parts.append(text)
+        elif bt == "tool_use":
+            parts.append(_format_tool_use(block))
+            kind = "tool_use"
+        # thinking: deliberately suppressed (Issue #71 §4)
+    if not parts:
+        return None
+    return RenderedEvent(kind=kind, body="\n".join(parts), session_id=event.get("sessionId"))
+
+
+def _tool_result_body(block: dict[str, Any]) -> str:
+    content = block.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def _render_user(event: dict[str, Any]) -> RenderedEvent | None:
+    if event.get("isMeta"):
+        return None
+    msg = event.get("message")
+    if not isinstance(msg, dict):
+        return None
+
+    content = msg.get("content")
+
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_result":
+                body = _tool_result_body(block).strip()
+                if body:
+                    parts.append(body)
+        if not parts:
+            return None
+        return RenderedEvent(
+            kind="tool_result",
+            body="\n".join(parts),
+            session_id=event.get("sessionId"),
+        )
+
+    if isinstance(content, str):
+        if content.startswith(ZWSP_MARKER):
+            # Echo of c-lord-driven send-keys; Discord already has the original.
+            return None
+        if not content.strip():
+            return None
+        return RenderedEvent(
+            kind="user_input",
+            body=content,
+            session_id=event.get("sessionId"),
+        )
+
+    return None
+
+
+def render_event(event: dict[str, Any]) -> RenderedEvent | None:
+    """Map one parsed JSONL event to its Discord-bound rendering, or ``None``."""
+    t = event.get("type")
+    if t == "assistant":
+        return _render_assistant(event)
+    if t == "user":
+        return _render_user(event)
+    if t in _FRAMING_TYPES:
+        return None
+    return None

--- a/c_lord/transcript/resolver.py
+++ b/c_lord/transcript/resolver.py
@@ -1,0 +1,35 @@
+"""Locate the active Claude Code transcript for a given tmux cwd.
+
+Claude Code writes one JSONL per session under
+``~/.claude/projects/<slug>/<session-id>.jsonl`` where ``<slug>`` is the cwd
+with every ``/`` replaced by ``-`` (the leading slash too — so
+``/home/yousan/c-lord`` → ``-home-yousan-c-lord``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def derive_project_dir(cwd: str, *, projects_root: Path | None = None) -> Path:
+    """Return the transcript directory for ``cwd``.
+
+    The directory may not exist yet — Claude Code creates it lazily on first
+    write — so callers should not assume ``.is_dir()`` is true here.
+    """
+    root = projects_root if projects_root is not None else Path.home() / ".claude" / "projects"
+    return root / cwd.replace("/", "-")
+
+
+def latest_session_jsonl(project_dir: Path) -> Path | None:
+    """Return the most recently modified ``*.jsonl`` directly under ``project_dir``.
+
+    Returns ``None`` if the directory is missing or contains no jsonl file.
+    Subdirectories and other extensions are ignored.
+    """
+    if not project_dir.is_dir():
+        return None
+    candidates = [p for p in project_dir.glob("*.jsonl") if p.is_file()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)

--- a/c_lord/transcript/tail.py
+++ b/c_lord/transcript/tail.py
@@ -65,7 +65,7 @@ async def tail_events(
             last_mtime = -1.0
 
         try:
-            stat = current_path.stat()
+            stat = active.stat()
         except FileNotFoundError:
             current_path = None
             await asyncio.sleep(poll_interval)
@@ -86,7 +86,7 @@ async def tail_events(
         last_mtime = mtime
 
         if size > offset:
-            with current_path.open("r", encoding="utf-8", errors="replace") as f:
+            with active.open("r", encoding="utf-8", errors="replace") as f:
                 f.seek(offset)
                 chunk = f.read()
                 offset = f.tell()

--- a/c_lord/transcript/tail.py
+++ b/c_lord/transcript/tail.py
@@ -1,0 +1,104 @@
+"""Async follower for a project's active Claude Code transcript jsonl.
+
+Yields each parsed JSON event in the order it was appended.  The active jsonl
+is re-selected on every poll as the mtime-latest ``*.jsonl`` under the project
+directory, so ``/clear`` (which causes Claude Code to start a new
+``<session-id>.jsonl``) is followed without restarting the tail.  Truncation
+or rewrite of the current file is handled by resetting the read offset to 0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from .resolver import latest_session_jsonl
+
+
+async def tail_events(
+    project_dir: Path,
+    *,
+    poll_interval: float = 0.5,
+    from_start: bool = False,
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield JSONL events as they appear under ``project_dir``.
+
+    Parameters
+    ----------
+    project_dir
+        Output of :func:`c_lord.transcript.resolver.derive_project_dir`.
+    poll_interval
+        Seconds between filesystem checks.  Small values keep latency low at
+        the cost of more ``stat`` calls; ``0.5`` is a reasonable default.
+    from_start
+        When ``True``, replay the current file from byte 0 before following.
+        Useful for catching up to an existing session.  Default ``False`` —
+        only newly appended lines are yielded.
+    """
+    # Snapshot the initial state of the project dir: ``from_start=False`` only
+    # skips bytes that *already existed* when tail was first called.  Any file
+    # that appears later (including a /clear-induced new session) is read from
+    # byte 0 so we don't miss events that landed before we noticed.
+    initial_path = latest_session_jsonl(project_dir)
+    initial_offset = (
+        initial_path.stat().st_size if initial_path is not None and not from_start else 0
+    )
+
+    current_path: Path | None = None
+    offset = 0
+    buffer = ""
+    last_mtime = -1.0
+
+    while True:
+        active = latest_session_jsonl(project_dir)
+        if active is None:
+            await asyncio.sleep(poll_interval)
+            continue
+
+        if active != current_path:
+            offset = initial_offset if initial_path is not None and active == initial_path else 0
+            current_path = active
+            buffer = ""
+            last_mtime = -1.0
+
+        try:
+            stat = current_path.stat()
+        except FileNotFoundError:
+            current_path = None
+            await asyncio.sleep(poll_interval)
+            continue
+        size = stat.st_size
+        mtime = stat.st_mtime
+
+        if size < offset:
+            # Truncation — reset and re-read from start.
+            offset = 0
+            buffer = ""
+        elif size == offset and mtime > last_mtime > 0:
+            # In-place rewrite with identical size: rare, but recover by
+            # restarting the read from byte 0.
+            offset = 0
+            buffer = ""
+
+        last_mtime = mtime
+
+        if size > offset:
+            with current_path.open("r", encoding="utf-8", errors="replace") as f:
+                f.seek(offset)
+                chunk = f.read()
+                offset = f.tell()
+            buffer += chunk
+            lines = buffer.split("\n")
+            buffer = lines[-1]  # last fragment may be a partial line
+            for line in lines[:-1]:
+                if not line.strip():
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+        await asyncio.sleep(poll_interval)

--- a/tests/transcript/test_formatter.py
+++ b/tests/transcript/test_formatter.py
@@ -1,0 +1,153 @@
+"""Tests for c_lord.transcript.formatter — JSONL event → Discord-bound text."""
+
+from __future__ import annotations
+
+from c_lord.transcript.formatter import ZWSP_MARKER, render_event
+
+
+def _assistant(blocks: list[dict]) -> dict:
+    return {"type": "assistant", "message": {"role": "assistant", "content": blocks}}
+
+
+def _user(content) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": content}}
+
+
+def test_assistant_text_block_is_mirrored() -> None:
+    ev = _assistant([{"type": "text", "text": "hello world"}])
+    out = render_event(ev)
+    assert out is not None
+    assert out.body == "hello world"
+    assert out.kind == "assistant_text"
+
+
+def test_assistant_tool_use_bash_shows_command() -> None:
+    ev = _assistant([{"type": "tool_use", "name": "Bash", "input": {"command": "ls -la"}}])
+    out = render_event(ev)
+    assert out is not None
+    assert "Bash" in out.body and "ls -la" in out.body
+    assert out.kind == "tool_use"
+
+
+def test_assistant_tool_use_read_shows_path() -> None:
+    ev = _assistant([{"type": "tool_use", "name": "Read", "input": {"file_path": "/etc/hosts"}}])
+    out = render_event(ev)
+    assert out is not None
+    assert "Read" in out.body and "/etc/hosts" in out.body
+
+
+def test_assistant_tool_use_grep_shows_pattern() -> None:
+    ev = _assistant([{"type": "tool_use", "name": "Grep", "input": {"pattern": "foo.*bar"}}])
+    out = render_event(ev)
+    assert out is not None
+    assert "Grep" in out.body and "foo.*bar" in out.body
+
+
+def test_assistant_tool_use_unknown_shows_name_only() -> None:
+    ev = _assistant([{"type": "tool_use", "name": "MysteryTool", "input": {"x": 1}}])
+    out = render_event(ev)
+    assert out is not None
+    assert "MysteryTool" in out.body
+
+
+def test_assistant_thinking_block_is_hidden_by_default() -> None:
+    ev = _assistant([{"type": "thinking", "thinking": "secret pondering"}])
+    assert render_event(ev) is None
+
+
+def test_assistant_mixed_blocks_concatenated_in_order() -> None:
+    ev = _assistant(
+        [
+            {"type": "thinking", "thinking": "..."},
+            {"type": "text", "text": "let me run a command"},
+            {"type": "tool_use", "name": "Bash", "input": {"command": "echo hi"}},
+        ]
+    )
+    out = render_event(ev)
+    assert out is not None
+    assert out.body.index("let me run a command") < out.body.index("echo hi")
+    assert "secret" not in out.body  # thinking suppressed
+
+
+def test_user_tool_result_is_mirrored_as_collapsed_output() -> None:
+    ev = _user(
+        [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_x",
+                "content": "line1\nline2\nline3",
+            }
+        ]
+    )
+    out = render_event(ev)
+    assert out is not None
+    assert out.kind == "tool_result"
+    assert "line1" in out.body
+
+
+def test_user_tool_result_with_list_content_is_concatenated() -> None:
+    ev = _user(
+        [
+            {
+                "type": "tool_result",
+                "content": [
+                    {"type": "text", "text": "part-a "},
+                    {"type": "text", "text": "part-b"},
+                ],
+            }
+        ]
+    )
+    out = render_event(ev)
+    assert out is not None
+    assert "part-a" in out.body and "part-b" in out.body
+
+
+def test_user_tool_result_empty_is_skipped() -> None:
+    ev = _user([{"type": "tool_result", "content": "   "}])
+    assert render_event(ev) is None
+
+
+def test_user_meta_event_is_skipped() -> None:
+    ev = {"type": "user", "isMeta": True, "message": {"role": "user", "content": "auto stuff"}}
+    assert render_event(ev) is None
+
+
+def test_user_input_with_zwsp_marker_is_skipped_as_clord_origin() -> None:
+    # c-lord-driven send-keys prefixes input with ZWSP so we don't double-post to Discord.
+    ev = _user(f"{ZWSP_MARKER}hello from discord")
+    assert render_event(ev) is None
+
+
+def test_user_input_without_marker_is_mirrored() -> None:
+    # External (human typed in pane) input must be mirrored to Discord.
+    ev = _user("typed directly in tmux")
+    out = render_event(ev)
+    assert out is not None
+    assert out.kind == "user_input"
+    assert "typed directly in tmux" in out.body
+
+
+def test_framing_event_types_are_skipped() -> None:
+    for t in (
+        "file-history-snapshot",
+        "ai-title",
+        "last-prompt",
+        "pr-link",
+        "permission-mode",
+        "queue-operation",
+        "attachment",
+        "system",
+    ):
+        assert render_event({"type": t}) is None, t
+
+
+def test_render_carries_session_id_when_present() -> None:
+    ev = _assistant([{"type": "text", "text": "hi"}])
+    ev["sessionId"] = "abc-123"
+    out = render_event(ev)
+    assert out is not None
+    assert out.session_id == "abc-123"
+
+
+def test_render_returns_none_for_unknown_top_level_type() -> None:
+    assert render_event({"type": "mystery"}) is None

--- a/tests/transcript/test_resolver.py
+++ b/tests/transcript/test_resolver.py
@@ -1,0 +1,80 @@
+"""Tests for c_lord.transcript.resolver — cwd → JSONL session file."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from c_lord.transcript.resolver import (
+    derive_project_dir,
+    latest_session_jsonl,
+)
+
+
+def test_derive_project_dir_replaces_slashes_with_dashes(tmp_path: Path) -> None:
+    # Claude Code stores transcripts under ~/.claude/projects/<slug>/ where
+    # <slug> is cwd with every '/' replaced by '-' (leading slash too).
+    got = derive_project_dir("/home/yousan/c-lord", projects_root=tmp_path)
+    assert got == tmp_path / "-home-yousan-c-lord"
+
+
+def test_derive_project_dir_handles_trailing_slash(tmp_path: Path) -> None:
+    got = derive_project_dir("/home/yousan/c-lord/", projects_root=tmp_path)
+    # Trailing slash produces a trailing dash; Claude Code uses naive replace.
+    assert got == tmp_path / "-home-yousan-c-lord-"
+
+
+def test_latest_session_jsonl_returns_most_recently_modified(tmp_path: Path) -> None:
+    project = tmp_path / "-home-yousan-c-lord"
+    project.mkdir()
+    older = project / "aaaa.jsonl"
+    newer = project / "bbbb.jsonl"
+    older.write_text("{}\n")
+    time.sleep(0.01)
+    newer.write_text("{}\n")
+    # Force ordering via explicit mtime to defeat fs resolution flakiness.
+    import os
+
+    os.utime(older, (1, 1))
+    os.utime(newer, (2, 2))
+
+    got = latest_session_jsonl(project)
+    assert got == newer
+
+
+def test_latest_session_jsonl_missing_dir_returns_none(tmp_path: Path) -> None:
+    assert latest_session_jsonl(tmp_path / "nope") is None
+
+
+def test_latest_session_jsonl_empty_dir_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "empty").mkdir()
+    assert latest_session_jsonl(tmp_path / "empty") is None
+
+
+def test_latest_session_jsonl_ignores_non_jsonl(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "notes.txt").write_text("ignored")
+    (project / "subdir").mkdir()
+    assert latest_session_jsonl(project) is None
+
+
+def test_derive_then_resolve_end_to_end(tmp_path: Path) -> None:
+    project = tmp_path / "-tmp-foo"
+    project.mkdir()
+    jsonl = project / "session.jsonl"
+    jsonl.write_text("{}\n")
+
+    pd = derive_project_dir("/tmp/foo", projects_root=tmp_path)
+    assert pd == project
+    assert latest_session_jsonl(pd) == jsonl
+
+
+def test_derive_project_dir_default_root_uses_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    got = derive_project_dir("/x/y")
+    assert got == tmp_path / ".claude" / "projects" / "-x-y"

--- a/tests/transcript/test_tail.py
+++ b/tests/transcript/test_tail.py
@@ -1,0 +1,170 @@
+"""Tests for c_lord.transcript.tail — async follower of the active session JSONL."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from c_lord.transcript.tail import tail_events
+
+
+def _write_event(path: Path, payload: dict) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload) + "\n")
+
+
+async def _drain(agen, n: int, timeout: float = 2.0) -> list:
+    collected: list = []
+
+    async def pull() -> None:
+        async for ev in agen:
+            collected.append(ev)
+            if len(collected) >= n:
+                return
+
+    await asyncio.wait_for(pull(), timeout=timeout)
+    return collected
+
+
+async def test_tail_yields_lines_appended_after_start(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s1.jsonl"
+    jsonl.write_text("")  # existing but empty
+    os.utime(jsonl, (1, 1))
+
+    agen = tail_events(project, poll_interval=0.05).__aiter__()
+
+    async def producer() -> None:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl, {"type": "assistant", "n": 1})
+        _write_event(jsonl, {"type": "assistant", "n": 2})
+
+    prod = asyncio.create_task(producer())
+    try:
+        events = await _drain(agen, 2)
+    finally:
+        prod.cancel()
+        await asyncio.gather(prod, return_exceptions=True)
+
+    assert [e["n"] for e in events] == [1, 2]
+
+
+async def test_tail_replays_existing_lines_when_from_start(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s1.jsonl"
+    _write_event(jsonl, {"type": "assistant", "n": "a"})
+    _write_event(jsonl, {"type": "assistant", "n": "b"})
+
+    agen = tail_events(project, poll_interval=0.05, from_start=True).__aiter__()
+    events = await _drain(agen, 2)
+    assert [e["n"] for e in events] == ["a", "b"]
+
+
+async def test_tail_switches_to_newer_jsonl_on_session_change(tmp_path: Path) -> None:
+    # Models the /clear case: a new <session-id>.jsonl appears in the project dir
+    # with a newer mtime → tail should switch to it without restarting.
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl1 = project / "s1.jsonl"
+    jsonl1.write_text("")
+    os.utime(jsonl1, (1, 1))
+
+    agen = tail_events(project, poll_interval=0.05).__aiter__()
+
+    async def producer() -> None:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl1, {"type": "assistant", "session": "s1"})
+        os.utime(jsonl1, (100, 100))
+        await asyncio.sleep(0.2)
+        # Simulate /clear: a new jsonl with newer mtime appears.
+        jsonl2 = project / "s2.jsonl"
+        _write_event(jsonl2, {"type": "assistant", "session": "s2"})
+        os.utime(jsonl2, (200, 200))
+
+    prod = asyncio.create_task(producer())
+    try:
+        events = await _drain(agen, 2, timeout=3.0)
+    finally:
+        prod.cancel()
+        await asyncio.gather(prod, return_exceptions=True)
+
+    sessions = [e["session"] for e in events]
+    assert sessions == ["s1", "s2"]
+
+
+async def test_tail_skips_malformed_lines(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s1.jsonl"
+    jsonl.write_text("")
+    os.utime(jsonl, (1, 1))
+
+    agen = tail_events(project, poll_interval=0.05).__aiter__()
+
+    async def producer() -> None:
+        await asyncio.sleep(0.1)
+        with jsonl.open("a") as f:
+            f.write("{not valid json\n")
+            f.write(json.dumps({"type": "assistant", "ok": True}) + "\n")
+
+    prod = asyncio.create_task(producer())
+    try:
+        events = await _drain(agen, 1, timeout=2.0)
+    finally:
+        prod.cancel()
+        await asyncio.gather(prod, return_exceptions=True)
+
+    assert events == [{"type": "assistant", "ok": True}]
+
+
+async def test_tail_waits_for_jsonl_to_appear(tmp_path: Path) -> None:
+    # Project dir exists but no .jsonl yet — Claude Code hasn't started writing.
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    agen = tail_events(project, poll_interval=0.05).__aiter__()
+
+    async def producer() -> None:
+        await asyncio.sleep(0.15)
+        jsonl = project / "s.jsonl"
+        _write_event(jsonl, {"type": "assistant", "n": 1})
+
+    prod = asyncio.create_task(producer())
+    try:
+        events = await _drain(agen, 1, timeout=2.0)
+    finally:
+        prod.cancel()
+        await asyncio.gather(prod, return_exceptions=True)
+
+    assert events == [{"type": "assistant", "n": 1}]
+
+
+async def test_tail_handles_truncation_or_rewrite(tmp_path: Path) -> None:
+    # Defensive: if the file shrinks (rare, but possible if Claude Code rotates),
+    # tail should not crash and should resume from start.
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    _write_event(jsonl, {"type": "assistant", "padding": "x" * 200, "n": 1})
+    os.utime(jsonl, (1, 1))
+
+    agen = tail_events(project, poll_interval=0.05).__aiter__()
+
+    async def producer() -> None:
+        await asyncio.sleep(0.15)
+        # Rewrite (truncate then write a single line).
+        jsonl.write_text(json.dumps({"type": "assistant", "n": 99}) + "\n")
+        os.utime(jsonl, (50, 50))
+
+    prod = asyncio.create_task(producer())
+    try:
+        events = await _drain(agen, 1, timeout=2.0)
+    finally:
+        prod.cancel()
+        await asyncio.gather(prod, return_exceptions=True)
+
+    assert events[0]["n"] == 99


### PR DESCRIPTION
## Summary

Issue #71 の **実装ステップ 1〜2 の foundation** を新規モジュール `c_lord/transcript/` として追加する。今 PR はピュアロジックのみで、Cog 統合 / feature flag / skill 撤去は後続 PR。

- **`resolver`**: `cwd` → `~/.claude/projects/<slug>/` ディレクトリ導出 + 配下 `*.jsonl` の mtime-最新を返す。`/clear` で新 `<session-id>.jsonl` が生まれても再選択で自動追従。
- **`formatter`**: 1 JSONL イベント → `RenderedEvent | None`。`assistant.content[text|tool_use]` と `user.content[tool_result]` のみミラー。`thinking` と framing メタ (`ai-title` / `pr-link` / `permission-mode` / `queue-operation` / `attachment` / `system` / `file-history-snapshot` / `last-prompt`) はスキップ。**ZWSP marker** prefix の `user` イベントは c-lord 経由 `send-keys` のエコーとして dedup。
- **`tail`**: 非同期 generator。アクティブ jsonl を follow し、`/clear` 起源のセッション切替 (= mtime-最新が別ファイルに変わる) を検知して切替、truncation / in-place rewrite からも復帰。
- 5 論点 (#71 [comment-4474550894](https://github.com/yousan/c-lord/issues/71#issuecomment-4474550894)) の確定事項に従って実装:
  - ① /clear 追従 = mtime-最新で自動再選択 (path に紐付けない)
  - ② 入力区別 = ZWSP marker (`formatter.ZWSP_MARKER` 定数を公開)
  - ④ thinking デフォルト非表示

## TDD

RED → GREEN を全 30 ケースで踏んでいる:

- `tests/transcript/test_resolver.py` (8): slug 変換 / mtime 解決 / 欠損ディレクトリ / 非 jsonl 無視 / 既定 HOME ベース
- `tests/transcript/test_formatter.py` (16): assistant text / tool_use 各種 / thinking 抑止 / tool_result 文字列&list / meta&ZWSP&framing スキップ / `session_id` 伝搬
- `tests/transcript/test_tail.py` (6): append / replay / `/clear` 後の session 切替 / 不正 JSON 行 skip / jsonl 出現待ち / truncation 復旧

```
$ uv run pytest tests/transcript/
30 passed
$ uv run pytest
860 passed, 5 deselected
```

## 動作確認 (staging webhook 検証の省略)

CLAUDE.md の動作確認スキームは bot 挙動が変わる PR に必須だが、本 PR は **ピュアロジックの新モジュール追加のみで、既存 Cog からの呼び出しはゼロ** (`grep -r 'c_lord.transcript' c_lord/cogs/` → 0 件)。挙動変化が原理的に発生しないため staging webhook 検証は省略 (CLAUDE.md 例外条項「純粋なリファクタで挙動が変わらないことが自明」に該当)。

Cog 統合 & feature flag を入れる次の PR で `CLORD_BRIDGE_MODE=jsonl` を staging に通し、skill 経路と並走させた上で挙動比較を行う。

## Test plan

- [x] `uv run pytest tests/transcript/` — 30 passed
- [x] `uv run pytest` (全体) — 860 passed, 0 failed
- [x] `uv run ruff check c_lord/transcript tests/transcript` — clean
- [x] `uv run ruff format c_lord/transcript tests/transcript` — clean
- [ ] (次 PR) Cog 統合後 staging で 1 週間並走 → skill 経路撤去

## 関連

- Closes part of #71 (step 1/5)
- 次の PR: thread→cwd マッピング永続化 + `CLORD_BRIDGE_MODE` env + ClaudeChatCog 統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)