### PR TITLE
feat: per-thread repository binding via /clord-thread-init

### DIFF
--- a/c_lord/__init__.py
+++ b/c_lord/__init__.py
@@ -26,6 +26,7 @@ from .database.notification_repo import NotificationRepository
 from .database.repository import SessionRepository
 from .database.settings_repo import SettingsRepository
 from .database.task_repo import TaskRepository as ScheduledTaskRepository
+from .database.thread_repo import ThreadRepository
 from .discord_ui.embeds import (
     error_embed,
     session_complete_embed,
@@ -45,6 +46,7 @@ __all__ = [
     "ClaudeChatCog",
     "ChannelRepoCog",
     "ChannelRepository",
+    "ThreadRepository",
     "RunConfig",
     "EventProcessor",
     # Concurrency

--- a/c_lord/cogs/channel_repo.py
+++ b/c_lord/cogs/channel_repo.py
@@ -2,12 +2,15 @@
 
 Provides ``/clord-init`` to dynamically bind a Discord channel to a git
 repository so that each channel can have its own SessionDirManager.
+Provides ``/clord-thread-init`` to override the binding for a specific thread.
 
 Usage::
 
     /clord-init repo:https://github.com/org/project.git
     /clord-init remove:True
-    /clord-init                       # show current bindings
+    /clord-init                              # show current bindings (channel + thread)
+    /clord-thread-init repo:https://github.com/org/other.git
+    /clord-thread-init remove:True
 """
 
 from __future__ import annotations
@@ -22,6 +25,7 @@ from discord.ext import commands
 
 if TYPE_CHECKING:
     from ..database.channel_repo import ChannelRepository
+    from ..database.thread_repo import ThreadRepository
 
 from ..database.channel_repo import derive_session_name
 from ..session_dir import SessionDirManager
@@ -31,37 +35,62 @@ logger = logging.getLogger(__name__)
 
 
 class ChannelRepoCog(commands.Cog):
-    """Manages per-channel repository bindings and SessionDirManager cache."""
+    """Manages per-channel and per-thread repository bindings and SessionDirManager cache."""
 
     def __init__(
         self,
         bot: commands.Bot,
         *,
         repo: ChannelRepository,
+        thread_repo: ThreadRepository | None = None,
         allowed_user_ids: set[int] | None = None,
         session_dir_base: str | None = None,
         allowed_role_name: str | None = None,
     ) -> None:
         self.bot = bot
         self._repo = repo
+        self._thread_repo = thread_repo
         self._allowed_user_ids = allowed_user_ids
         self._allowed_role_name = allowed_role_name
         self._session_dir_base = session_dir_base
         self._manager_cache: dict[int, SessionDirManager] = {}
+        self._thread_manager_cache: dict[int, SessionDirManager] = {}
         self._tmux_cache: dict[int, TmuxSessionManager] = {}
 
     # ------------------------------------------------------------------
     # Public API (used by ClaudeChatCog)
     # ------------------------------------------------------------------
 
-    async def resolve_manager(self, channel_id: int) -> SessionDirManager | None:
-        """Resolve a SessionDirManager for the given channel.
+    async def resolve_manager(
+        self, channel_id: int, thread_id: int | None = None
+    ) -> SessionDirManager | None:
+        """Resolve a SessionDirManager for the given channel (and optional thread).
 
         Lookup order:
-          1. In-memory cache
-          2. DB binding → create manager and cache it
+          1. Thread-level: in-memory thread cache → DB thread binding
+          2. Channel-level: in-memory channel cache → DB channel binding
           3. None (caller should fall back to global bot.session_dir_manager)
+
+        When thread_id is provided and a thread binding exists, the returned
+        manager uses the thread's source_repo instead of the channel's.
+        tmux session name is always derived from the channel binding (unchanged).
         """
+        # --- Thread-level override ---
+        if thread_id is not None and self._thread_repo is not None:
+            if thread_id in self._thread_manager_cache:
+                return self._thread_manager_cache[thread_id]
+
+            thread_binding = await self._thread_repo.get(thread_id)
+            if thread_binding is not None:
+                base = self._session_dir_base or "data/sessions"
+                manager = SessionDirManager(
+                    base_dir=str(Path(base) / str(channel_id)),
+                    source_repo=thread_binding["source_repo"],
+                )
+                self._thread_manager_cache[thread_id] = manager
+                return manager
+
+        # --- Channel-level fallback ---
         if channel_id in self._manager_cache:
             return self._manager_cache[channel_id]
 
@@ -98,9 +127,13 @@ class ChannelRepoCog(commands.Cog):
         return manager
 
     def evict_cache(self, channel_id: int) -> None:
-        """Remove a cached manager (called on bind/unbind)."""
+        """Remove a cached channel manager (called on bind/unbind)."""
         self._manager_cache.pop(channel_id, None)
         self._tmux_cache.pop(channel_id, None)
+
+    def evict_thread_cache(self, thread_id: int) -> None:
+        """Remove a cached thread manager (called on thread bind/unbind)."""
+        self._thread_manager_cache.pop(thread_id, None)
 
     # ------------------------------------------------------------------
     # Authorization
@@ -170,17 +203,23 @@ class ChannelRepoCog(commands.Cog):
 
         # --- Show bindings (no args) ---
         if repo is None:
-            bindings = await self._repo.list_all()
-            if not bindings:
+            channel_bindings = await self._repo.list_all()
+            thread_bindings = (
+                await self._thread_repo.list_all() if self._thread_repo is not None else []
+            )
+            if not channel_bindings and not thread_bindings:
                 await interaction.response.send_message(
                     "No channel-repo bindings configured.", ephemeral=True
                 )
                 return
 
             lines = []
-            for b in bindings:
+            for b in channel_bindings:
                 tmux_name = derive_session_name(b["source_repo"])
                 lines.append(f"<#{b['channel_id']}> → `{b['source_repo']}` (tmux: `{tmux_name}`)")
+            for b in thread_bindings:
+                ch_ref = f" (channel <#{b['channel_id']}>)" if b.get("channel_id") else ""
+                lines.append(f"  thread <#{b['thread_id']}>{ch_ref} → `{b['source_repo']}`")
             await interaction.response.send_message("\n".join(lines), ephemeral=True)
             return
 
@@ -191,4 +230,72 @@ class ChannelRepoCog(commands.Cog):
         tmux_display = derive_session_name(repo)
         await interaction.response.send_message(
             f"Bound <#{channel_id}> → `{repo}` (tmux: `{tmux_display}`)", ephemeral=True
+        )
+
+    @app_commands.command(
+        name="clord-thread-init",
+        description="Bind this thread to a git repository (overrides channel binding)",
+    )
+    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.describe(
+        repo="Git repository URL to clone for this thread's sessions",
+        remove="Set True to remove the thread-level binding",
+    )
+    async def clord_thread_init(
+        self,
+        interaction: discord.Interaction,
+        repo: str | None = None,
+        remove: bool = False,
+    ) -> None:
+        """Bind / unbind a thread-level repo override."""
+        if not self._is_allowed(interaction.user):
+            await interaction.response.send_message(
+                "You are not authorized to use this command.", ephemeral=True
+            )
+            return
+
+        if self._thread_repo is None:
+            await interaction.response.send_message(
+                "Thread-level bindings are not enabled on this bot.", ephemeral=True
+            )
+            return
+
+        thread_id = interaction.channel_id
+        assert thread_id is not None
+        channel_id = (
+            interaction.channel.parent_id
+            if isinstance(interaction.channel, discord.Thread)
+            else thread_id
+        )
+
+        # --- Remove binding ---
+        if remove:
+            deleted = await self._thread_repo.delete(thread_id)
+            self.evict_thread_cache(thread_id)
+            if deleted:
+                await interaction.response.send_message(
+                    f"Removed thread repository binding for <#{thread_id}>.", ephemeral=True
+                )
+            else:
+                await interaction.response.send_message("No thread binding found.", ephemeral=True)
+            return
+
+        # --- Show current thread binding (no args) ---
+        if repo is None:
+            binding = await self._thread_repo.get(thread_id)
+            if binding is None:
+                await interaction.response.send_message(
+                    "No thread-level binding for this thread.", ephemeral=True
+                )
+            else:
+                await interaction.response.send_message(
+                    f"Thread <#{thread_id}> → `{binding['source_repo']}`", ephemeral=True
+                )
+            return
+
+        # --- Bind thread to repo ---
+        await self._thread_repo.save(thread_id=thread_id, source_repo=repo, channel_id=channel_id)
+        self.evict_thread_cache(thread_id)
+        await interaction.response.send_message(
+            f"Bound thread <#{thread_id}> → `{repo}`", ephemeral=True
         )

--- a/c_lord/database/models.py
+++ b/c_lord/database/models.py
@@ -66,6 +66,15 @@ CREATE TABLE IF NOT EXISTS channel_repo_bindings (
     created_at         TEXT    NOT NULL DEFAULT (datetime('now', 'localtime')),
     updated_at         TEXT    NOT NULL DEFAULT (datetime('now', 'localtime'))
 );
+
+-- Per-thread repository bindings (overrides channel binding for that thread)
+CREATE TABLE IF NOT EXISTS thread_repo_bindings (
+    thread_id   INTEGER PRIMARY KEY,
+    source_repo TEXT    NOT NULL,
+    channel_id  INTEGER,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now', 'localtime')),
+    updated_at  TEXT    NOT NULL DEFAULT (datetime('now', 'localtime'))
+);
 """
 
 # Migrations for existing databases that lack new columns.
@@ -106,6 +115,15 @@ _MIGRATIONS = [
     # Drop unused columns (requires SQLite 3.35.0+; suppressed on older versions)
     "ALTER TABLE channel_repo_bindings DROP COLUMN clone_branch",
     "ALTER TABLE channel_repo_bindings DROP COLUMN tmux_session_name",
+    # thread_repo_bindings added for /clord-thread-init (per-thread repo override)
+    (
+        "CREATE TABLE IF NOT EXISTS thread_repo_bindings ("
+        "thread_id INTEGER PRIMARY KEY, "
+        "source_repo TEXT NOT NULL, "
+        "channel_id INTEGER, "
+        "created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')), "
+        "updated_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')))"
+    ),
 ]
 
 

--- a/c_lord/database/thread_repo.py
+++ b/c_lord/database/thread_repo.py
@@ -1,0 +1,106 @@
+"""ThreadRepository — CRUD for thread_repo_bindings table.
+
+Maps Discord thread IDs to source repositories, enabling per-thread
+session directory override via /clord-thread-init.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+THREAD_REPO_SCHEMA = """
+CREATE TABLE IF NOT EXISTS thread_repo_bindings (
+    thread_id   INTEGER PRIMARY KEY,
+    source_repo TEXT    NOT NULL,
+    channel_id  INTEGER,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now', 'localtime')),
+    updated_at  TEXT    NOT NULL DEFAULT (datetime('now', 'localtime'))
+);
+"""
+
+
+class ThreadRepository:
+    """Async CRUD for thread_repo_bindings table."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    async def init_db(self) -> None:
+        """Initialize the thread_repo_bindings schema."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.executescript(THREAD_REPO_SCHEMA)
+            await db.commit()
+        logger.info("Thread repo DB initialized at %s", self.db_path)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    async def get(self, thread_id: int) -> dict | None:
+        """Return a binding for the given thread, or None."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM thread_repo_bindings WHERE thread_id = ?",
+                (thread_id,),
+            )
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    async def list_by_channel(self, channel_id: int) -> list[dict]:
+        """Return all thread bindings for a given channel."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM thread_repo_bindings WHERE channel_id = ? ORDER BY created_at",
+                (channel_id,),
+            )
+            rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    async def list_all(self) -> list[dict]:
+        """Return all thread-repo bindings."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute("SELECT * FROM thread_repo_bindings ORDER BY created_at")
+            rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    async def save(
+        self,
+        thread_id: int,
+        source_repo: str,
+        channel_id: int | None = None,
+    ) -> None:
+        """Insert or replace a thread-repo binding."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """INSERT OR REPLACE INTO thread_repo_bindings
+                   (thread_id, source_repo, channel_id,
+                    created_at, updated_at)
+                   VALUES (?, ?, ?, datetime('now', 'localtime'),
+                           datetime('now', 'localtime'))""",
+                (thread_id, source_repo, channel_id),
+            )
+            await db.commit()
+        logger.info("Saved thread binding: thread=%d repo=%s", thread_id, source_repo)
+
+    async def delete(self, thread_id: int) -> bool:
+        """Delete a binding. Returns True if a row was deleted."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "DELETE FROM thread_repo_bindings WHERE thread_id = ?",
+                (thread_id,),
+            )
+            await db.commit()
+            return cursor.rowcount > 0

--- a/c_lord/setup.py
+++ b/c_lord/setup.py
@@ -133,6 +133,7 @@ async def setup_bridge(
     from .database.resume_repo import PendingResumeRepository
     from .database.settings_repo import SettingsRepository
     from .database.task_repo import TaskRepository
+    from .database.thread_repo import ThreadRepository
 
     # Role-based access control — auto-read from env var if not explicitly provided
     if allowed_role_name is None:
@@ -201,12 +202,15 @@ async def setup_bridge(
     await bot.add_cog(session_manage_cog)
     logger.info("Registered SessionManageCog")
 
-    # --- ChannelRepoCog (per-channel repo bindings, zero-config) ---
+    # --- ChannelRepoCog (per-channel and per-thread repo bindings, zero-config) ---
     channel_repo = ChannelRepository(session_db_path)
     await channel_repo.init_db()
+    thread_repo = ThreadRepository(session_db_path)
+    await thread_repo.init_db()
     channel_repo_cog = ChannelRepoCog(
         bot,
         repo=channel_repo,
+        thread_repo=thread_repo,
         allowed_user_ids=allowed_user_ids,
         allowed_role_name=allowed_role_name,
         session_dir_base=session_dir_base,

--- a/tests/test_channel_repo.py
+++ b/tests/test_channel_repo.py
@@ -1,4 +1,4 @@
-"""Tests for ChannelRepository and ChannelRepoCog."""
+"""Tests for ChannelRepository, ThreadRepository, and ChannelRepoCog."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import pytest
 
 from c_lord.cogs.channel_repo import ChannelRepoCog
 from c_lord.database.channel_repo import ChannelRepository, derive_session_name
+from c_lord.database.thread_repo import ThreadRepository
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -21,6 +22,13 @@ async def repo(tmp_path) -> ChannelRepository:
     return r
 
 
+@pytest.fixture
+async def thread_repo(tmp_path) -> ThreadRepository:
+    r = ThreadRepository(str(tmp_path / "thread.db"))
+    await r.init_db()
+    return r
+
+
 def _make_bot() -> MagicMock:
     bot = MagicMock()
     bot.loop = MagicMock()
@@ -29,10 +37,11 @@ def _make_bot() -> MagicMock:
 
 
 @pytest.fixture
-def cog(repo: ChannelRepository, tmp_path) -> ChannelRepoCog:
+def cog(repo: ChannelRepository, thread_repo: ThreadRepository, tmp_path) -> ChannelRepoCog:
     return ChannelRepoCog(
         _make_bot(),
         repo=repo,
+        thread_repo=thread_repo,
         allowed_user_ids=None,
         session_dir_base=str(tmp_path / "sessions"),
     )
@@ -196,3 +205,150 @@ class TestChannelRepoCogEvictCache:
         assert 100 in cog._tmux_cache
         cog.evict_cache(100)
         assert 100 not in cog._tmux_cache
+
+
+# ===========================================================================
+# ThreadRepository tests
+# ===========================================================================
+
+
+class TestThreadRepoSave:
+    async def test_save_and_get(self, thread_repo: ThreadRepository) -> None:
+        await thread_repo.save(
+            thread_id=999, source_repo="https://github.com/org/repo.git", channel_id=100
+        )
+        binding = await thread_repo.get(999)
+        assert binding is not None
+        assert binding["thread_id"] == 999
+        assert binding["source_repo"] == "https://github.com/org/repo.git"
+        assert binding["channel_id"] == 100
+
+    async def test_save_upsert(self, thread_repo: ThreadRepository) -> None:
+        await thread_repo.save(thread_id=111, source_repo="https://github.com/org/old.git")
+        await thread_repo.save(thread_id=111, source_repo="https://github.com/org/new.git")
+        binding = await thread_repo.get(111)
+        assert binding is not None
+        assert binding["source_repo"] == "https://github.com/org/new.git"
+
+    async def test_save_without_channel_id(self, thread_repo: ThreadRepository) -> None:
+        await thread_repo.save(thread_id=222, source_repo="https://github.com/org/repo.git")
+        binding = await thread_repo.get(222)
+        assert binding is not None
+        assert binding["channel_id"] is None
+
+
+class TestThreadRepoGet:
+    async def test_get_nonexistent(self, thread_repo: ThreadRepository) -> None:
+        binding = await thread_repo.get(9999)
+        assert binding is None
+
+
+class TestThreadRepoDelete:
+    async def test_delete_existing(self, thread_repo: ThreadRepository) -> None:
+        await thread_repo.save(thread_id=333, source_repo="https://github.com/org/repo.git")
+        deleted = await thread_repo.delete(333)
+        assert deleted is True
+        assert await thread_repo.get(333) is None
+
+    async def test_delete_nonexistent(self, thread_repo: ThreadRepository) -> None:
+        deleted = await thread_repo.delete(9999)
+        assert deleted is False
+
+
+class TestThreadRepoListByChannel:
+    async def test_list_empty(self, thread_repo: ThreadRepository) -> None:
+        bindings = await thread_repo.list_by_channel(100)
+        assert bindings == []
+
+    async def test_list_by_channel(self, thread_repo: ThreadRepository) -> None:
+        await thread_repo.save(
+            thread_id=1001, source_repo="https://github.com/org/a.git", channel_id=100
+        )
+        await thread_repo.save(
+            thread_id=1002, source_repo="https://github.com/org/b.git", channel_id=100
+        )
+        await thread_repo.save(
+            thread_id=2001, source_repo="https://github.com/org/c.git", channel_id=200
+        )
+        bindings = await thread_repo.list_by_channel(100)
+        assert len(bindings) == 2
+        ids = {b["thread_id"] for b in bindings}
+        assert ids == {1001, 1002}
+
+
+# ===========================================================================
+# Thread-aware resolve_manager tests
+# ===========================================================================
+
+
+class TestResolveManagerThreadOverride:
+    async def test_channel_only_no_thread_id(
+        self, cog: ChannelRepoCog, repo: ChannelRepository
+    ) -> None:
+        await repo.save(channel_id=100, source_repo="https://github.com/org/channel.git")
+        manager = await cog.resolve_manager(channel_id=100)
+        assert manager is not None
+        assert manager.source_repo == "https://github.com/org/channel.git"
+
+    async def test_channel_only_with_thread_id_no_thread_bind(
+        self, cog: ChannelRepoCog, repo: ChannelRepository
+    ) -> None:
+        await repo.save(channel_id=100, source_repo="https://github.com/org/channel.git")
+        manager = await cog.resolve_manager(channel_id=100, thread_id=999)
+        assert manager is not None
+        assert manager.source_repo == "https://github.com/org/channel.git"
+
+    async def test_thread_override(
+        self,
+        cog: ChannelRepoCog,
+        repo: ChannelRepository,
+        thread_repo: ThreadRepository,
+    ) -> None:
+        await repo.save(channel_id=100, source_repo="https://github.com/org/channel.git")
+        await thread_repo.save(
+            thread_id=999,
+            source_repo="https://github.com/org/thread.git",
+            channel_id=100,
+        )
+        manager = await cog.resolve_manager(channel_id=100, thread_id=999)
+        assert manager is not None
+        assert manager.source_repo == "https://github.com/org/thread.git"
+
+    async def test_thread_bind_without_channel_bind(
+        self, cog: ChannelRepoCog, thread_repo: ThreadRepository
+    ) -> None:
+        await thread_repo.save(
+            thread_id=999, source_repo="https://github.com/org/thread.git"
+        )
+        manager = await cog.resolve_manager(channel_id=100, thread_id=999)
+        assert manager is not None
+        assert manager.source_repo == "https://github.com/org/thread.git"
+
+    async def test_no_binding_returns_none(self, cog: ChannelRepoCog) -> None:
+        manager = await cog.resolve_manager(channel_id=100, thread_id=999)
+        assert manager is None
+
+    async def test_thread_manager_cached(
+        self,
+        cog: ChannelRepoCog,
+        thread_repo: ThreadRepository,
+    ) -> None:
+        await thread_repo.save(
+            thread_id=999, source_repo="https://github.com/org/thread.git"
+        )
+        m1 = await cog.resolve_manager(channel_id=100, thread_id=999)
+        m2 = await cog.resolve_manager(channel_id=100, thread_id=999)
+        assert m1 is m2
+
+    async def test_evict_thread_cache(
+        self,
+        cog: ChannelRepoCog,
+        thread_repo: ThreadRepository,
+    ) -> None:
+        await thread_repo.save(
+            thread_id=999, source_repo="https://github.com/org/thread.git"
+        )
+        await cog.resolve_manager(channel_id=100, thread_id=999)
+        assert 999 in cog._thread_manager_cache
+        cog.evict_thread_cache(999)
+        assert 999 not in cog._thread_manager_cache


### PR DESCRIPTION
Closes #73

## Summary

- `ThreadRepository` — `thread_repo_bindings` テーブルの CRUD
- `resolve_manager(channel_id, thread_id=None)` — thread bind があれば優先、なければ channel bind にフォールバック
- `/clord-thread-init repo:<URL>` — スレッド限定の repo bind コマンド
- `setup.py` でゼロコンフィグ自動 wire-up（`ThreadRepository` を `ChannelRepoCog` に注入）
- tmux session 構造は変更なし（channel=session, thread=window）

## Test plan

- [x] `uv run pytest tests/ -q` → 875 passed（新規 15 ケース含む）
- [x] `uv run ruff check c_lord/` → All checks passed
- [x] staging bot 再起動 → `Synced 15 slash commands`（14→15 で `/clord-thread-init` 追加確認）
- [x] staging DB に `thread_repo_bindings` テーブル作成確認
- [x] staging で `resolve_manager` の channel-only / thread-override / thread-fallback を Python スクリプトで動作確認
- [ ] `/clord-thread-init` の Discord UI からの実呼び出し（スラッシュコマンドのため手動確認が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)