### PR TITLE
feat: embed Discord attachment URLs in prompt instead of downloading (#79)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -51,10 +51,13 @@ _ALLOWED_MIME_PREFIXES = (
 )
 _IMAGE_MIME_PREFIXES = ("image/",)
 _MAX_ATTACHMENT_BYTES = 50_000  # 50 KB per file
-_MAX_IMAGE_BYTES = 5_000_000  # 5 MB per image
 _MAX_TOTAL_BYTES = 100_000  # 100 KB across all text attachments
 _MAX_ATTACHMENTS = 5
-_MAX_IMAGES = 4  # Claude supports up to 4 images per prompt
+
+# Discord CDN URLs are signed and valid for ~24 hours.
+_ATTACHMENT_URL_NOTE = (
+    "(This is a signed CDN URL valid for ~24 hours. Use the WebFetch tool or curl to retrieve it.)"
+)
 
 
 class ClaudeChatCog(commands.Cog):
@@ -606,69 +609,49 @@ class ClaudeChatCog(commands.Cog):
         return prompt
 
     async def _build_prompt_and_images(self, message: discord.Message) -> tuple[str, list[str]]:
-        """Build the prompt string and download image attachments to tempfiles.
+        """Build the prompt string from message content and attachments.
 
         Text attachments (text/*, application/json, application/xml) are appended
-        inline to the prompt.  Image attachments (image/*) are downloaded to
-        temporary files and returned as paths for the ``--image`` flag.
+        inline to the prompt.
 
-        Both binary-file types that exceed size limits and unsupported types are
-        silently skipped — never raise an error to the user.
+        Image and other binary attachments are embedded as CDN URLs with a note
+        explaining that Claude can fetch them via WebFetch or curl.  Discord CDN
+        URLs are signed and valid for ~24 hours — no download or tempfile needed.
 
         Returns:
-            (prompt_text, image_temp_paths) — callers must delete tempfiles.
+            (prompt_text, []) — image_paths is always empty (URL embedding, not
+            local download).  The second element is kept for API compatibility.
         """
-        import tempfile
-
         prompt = message.content or ""
         if not message.attachments:
             return prompt, []
 
         total_bytes = 0
         sections: list[str] = []
-        image_paths: list[str] = []
 
         for attachment in message.attachments[:_MAX_ATTACHMENTS]:
             content_type = attachment.content_type or ""
 
-            # ---- Image attachments → tempfile for --image flag ----
-            if content_type.startswith(_IMAGE_MIME_PREFIXES):
-                if len(image_paths) >= _MAX_IMAGES:
-                    logger.debug("Skipping image %s: max images reached", attachment.filename)
-                    continue
-                if attachment.size > _MAX_IMAGE_BYTES:
-                    logger.debug(
-                        "Skipping image %s: too large (%d bytes)",
-                        attachment.filename,
-                        attachment.size,
-                    )
-                    continue
-                try:
-                    data = await attachment.read()
-                    suffix = f"_{attachment.filename}"
-                    with tempfile.NamedTemporaryFile(
-                        delete=False, suffix=suffix, prefix="clord_img_"
-                    ) as f:
-                        f.write(data)
-                        image_paths.append(f.name)
-                    logger.debug("Downloaded image %s → %s", attachment.filename, f.name)
-                except Exception:
-                    logger.debug("Failed to download image %s", attachment.filename, exc_info=True)
+            # ---- Image and binary attachments → embed CDN URL in prompt ----
+            if content_type.startswith(_IMAGE_MIME_PREFIXES) or not content_type.startswith(
+                _ALLOWED_MIME_PREFIXES
+            ):
+                sections.append(
+                    f"\n\n--- Attached file: {attachment.filename} ---\n"
+                    f"URL: {attachment.url}\n"
+                    f"{_ATTACHMENT_URL_NOTE}"
+                )
+                logger.debug(
+                    "Embedded attachment URL for %s (%s)", attachment.filename, content_type
+                )
                 continue
 
-            # ---- Text attachments → inline in prompt ----
+            # ---- Text attachments → inline content in prompt ----
             if attachment.size > _MAX_ATTACHMENT_BYTES:
                 logger.debug(
                     "Skipping attachment %s: too large (%d bytes)",
                     attachment.filename,
                     attachment.size,
-                )
-                continue
-            if not content_type.startswith(_ALLOWED_MIME_PREFIXES):
-                logger.debug(
-                    "Skipping attachment %s: unsupported type %s",
-                    attachment.filename,
-                    content_type,
                 )
                 continue
             total_bytes += attachment.size
@@ -683,7 +666,7 @@ class ClaudeChatCog(commands.Cog):
                 logger.debug("Failed to read attachment %s", attachment.filename, exc_info=True)
                 continue
 
-        return prompt + "".join(sections), image_paths
+        return prompt + "".join(sections), []
 
     async def _run_claude(
         self,

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -195,11 +195,13 @@ class TestBuildPrompt:
         content_type: str = "text/plain",
         size: int = 100,
         content: bytes = b"hello world",
+        url: str = "https://cdn.discordapp.com/attachments/123/456/test.txt?ex=abc&is=def&hm=xyz",
     ) -> MagicMock:
         att = MagicMock(spec=discord.Attachment)
         att.filename = filename
         att.content_type = content_type
         att.size = size
+        att.url = url
         att.read = AsyncMock(return_value=content)
         return att
 
@@ -230,45 +232,88 @@ class TestBuildPrompt:
         assert "file content here" in result
 
     @pytest.mark.asyncio
-    async def test_image_attachment_not_inlined_in_prompt(self) -> None:
-        """Images are downloaded to tempfiles, NOT inlined into the prompt text."""
-        import os
-
+    async def test_image_attachment_url_embedded_in_prompt(self) -> None:
+        """Images are NOT downloaded; their CDN URL is embedded in the prompt."""
+        image_url = "https://cdn.discordapp.com/attachments/1/2/image.png?ex=abc&is=def&hm=xyz"
         cog = _make_cog()
         att = self._make_attachment(
             filename="image.png",
             content_type="image/png",
             size=100,
             content=b"\x89PNG...",
+            url=image_url,
         )
         msg = self._make_message(content="see image", attachments=[att])
 
         prompt, image_paths = await cog._build_prompt_and_images(msg)
 
-        # Prompt text stays clean — no image content inlined.
-        assert prompt == "see image"
-        # One tempfile created for the image.
-        assert len(image_paths) == 1
-        assert os.path.exists(image_paths[0])
-        # Clean up.
-        for p in image_paths:
-            os.unlink(p)
+        # URL is embedded in the prompt text.
+        assert image_url in prompt
+        assert "image.png" in prompt
+        # No tempfiles — images are not downloaded.
+        assert image_paths == []
+        att.read.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_binary_non_image_skipped(self) -> None:
-        """Non-image binary files (e.g. zip) are still silently skipped."""
+    async def test_binary_non_image_url_embedded(self) -> None:
+        """Non-image binary files (e.g. zip, PDF) have their URL embedded."""
+        file_url = "https://cdn.discordapp.com/attachments/1/2/archive.zip?ex=abc&is=def&hm=xyz"
         cog = _make_cog()
         att = self._make_attachment(
             filename="archive.zip",
             content_type="application/zip",
             content=b"PK...",
+            url=file_url,
         )
         msg = self._make_message(content="see zip", attachments=[att])
 
         result = await cog._build_prompt(msg)
 
-        assert result == "see zip"
+        assert file_url in result
+        assert "archive.zip" in result
         att.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_multiple_images_all_urls_embedded(self) -> None:
+        """Multiple image attachments all get their URLs embedded."""
+        cog = _make_cog()
+        images = [
+            self._make_attachment(
+                filename=f"img{i}.png",
+                content_type="image/png",
+                url=f"https://cdn.discordapp.com/attachments/1/2/img{i}.png?ex=abc",
+            )
+            for i in range(3)
+        ]
+        msg = self._make_message(content="three images", attachments=images)
+
+        prompt, image_paths = await cog._build_prompt_and_images(msg)
+
+        for i in range(3):
+            assert f"img{i}.png" in prompt
+            assert f"img{i}.png?ex=abc" in prompt
+        assert image_paths == []
+        for att in images:
+            att.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_image_and_text_attachment_combined(self) -> None:
+        """Image URL + text file content both appear in the prompt."""
+        image_url = "https://cdn.discordapp.com/attachments/1/2/photo.jpg?ex=abc"
+        cog = _make_cog()
+        img_att = self._make_attachment(
+            filename="photo.jpg",
+            content_type="image/jpeg",
+            url=image_url,
+        )
+        txt_att = self._make_attachment(filename="notes.txt", content=b"my notes")
+        msg = self._make_message(content="check these", attachments=[img_att, txt_att])
+
+        prompt, image_paths = await cog._build_prompt_and_images(msg)
+
+        assert image_url in prompt
+        assert "my notes" in prompt
+        assert image_paths == []
 
     @pytest.mark.asyncio
     async def test_oversized_attachment_skipped(self) -> None:


### PR DESCRIPTION
## Summary

- Discord 画像・バイナリ添付の CDN URL をプロンプトテキストに埋め込むことで、Claude が WebFetch / curl で取得できるようにした (issue #79 Phase 1)
- 既存の tempfile ダウンロードパスは `TmuxClaudeRunner.run()` が `image_paths` を受け取らないため実質デッドコードだったので削除
- テキスト添付（text/*, application/json 等）はこれまで通りインライン展開

## 埋め込みフォーマット

\`\`\`
--- Attached file: image.png ---
URL: https://cdn.discordapp.com/attachments/...?ex=...&is=...&hm=...
(This is a signed CDN URL valid for ~24 hours. Use the WebFetch tool or curl to retrieve it.)
\`\`\`

## Test plan

- [x] 新テスト 4 件追加（RED→GREEN TDD）
  - `test_image_attachment_url_embedded_in_prompt` — 画像 URL がプロンプトに含まれること
  - `test_binary_non_image_url_embedded` — zip 等バイナリも URL 埋め込み
  - `test_multiple_images_all_urls_embedded` — 複数画像全て埋め込み
  - `test_image_and_text_attachment_combined` — 画像 URL + テキスト内容の共存
- [x] 876 テスト全パス
- [x] ruff check / ruff format clean
- [ ] staging E2E: 画像付きメッセージ送信 → Claude が URL を認識して WebFetch で取得

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)