### PR TITLE
fix: log HTTPException in TranscriptMirror sink instead of suppressing (#85)

### DIFF
--- a/c_lord/cogs/transcript_mirror.py
+++ b/c_lord/cogs/transcript_mirror.py
@@ -114,13 +114,29 @@ class TranscriptMirrorCog(commands.Cog):
                     type(channel).__name__,
                 )
                 return
-            with contextlib.suppress(discord.HTTPException):
+            try:
                 await send(body)
+            except discord.HTTPException as exc:
+                logger.warning(
+                    "TranscriptMirror sink failed: thread=%d body_len=%d status=%s — %s",
+                    thread_id,
+                    len(body),
+                    getattr(exc, "status", "?"),
+                    exc,
+                    exc_info=True,
+                )
 
         return sink
 
     def _make_file_sink(self, thread_id: int):
-        """Return an awaitable callable that posts text + progress.txt attachment."""
+        """Return an awaitable callable that posts text + progress.txt attachment.
+
+        Fallback strategy:
+        1. Send with progress.txt attached.
+        2. If that raises HTTPException (e.g. 413 Payload Too Large), retry
+           with plain text only and log a warning.
+        3. If the plain-text retry also fails, log a warning.
+        """
         bot = self.bot
 
         async def file_sink(text: str, file_path: str) -> None:
@@ -131,8 +147,32 @@ class TranscriptMirrorCog(commands.Cog):
             send = getattr(channel, "send", None)
             if send is None:
                 return
-            with contextlib.suppress(discord.HTTPException):
+            try:
                 await send(body, file=discord.File(file_path, filename="progress.txt"))
+                return
+            except discord.HTTPException as exc:
+                logger.warning(
+                    "TranscriptMirror file_sink failed (with attachment): "
+                    "thread=%d body_len=%d status=%s — retrying without attachment — %s",
+                    thread_id,
+                    len(body),
+                    getattr(exc, "status", "?"),
+                    exc,
+                    exc_info=True,
+                )
+            # Fallback: plain text without attachment
+            try:
+                await send(body)
+            except discord.HTTPException as exc:
+                logger.warning(
+                    "TranscriptMirror file_sink fallback also failed: "
+                    "thread=%d body_len=%d status=%s — %s",
+                    thread_id,
+                    len(body),
+                    getattr(exc, "status", "?"),
+                    exc,
+                    exc_info=True,
+                )
 
         return file_sink
 

--- a/tests/test_transcript_mirror_cog.py
+++ b/tests/test_transcript_mirror_cog.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 
 from c_lord.cogs.transcript_mirror import TranscriptMirrorCog
@@ -160,3 +161,107 @@ async def test_end_to_end_jsonl_event_posts_to_discord(
     assert channel.send.called
     sent_bodies = [c[0][0] for c in channel.send.call_args_list]
     assert any("via cog" in b for b in sent_bodies)
+
+
+# ---------------------------------------------------------------------------
+# Issue #85: observability — sink failures must be logged, not suppressed
+# ---------------------------------------------------------------------------
+
+
+async def test_sink_logs_warning_on_http_exception(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """HTTPException in sink must produce a WARNING log, not be silently swallowed."""
+    import logging
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(status=403), "Forbidden"))
+    bot.get_channel.return_value = channel
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    sink = cog._make_sink(42)
+
+    with caplog.at_level(logging.WARNING, logger="c_lord.cogs.transcript_mirror"):
+        await sink("test message")
+
+    assert any("42" in r.message for r in caplog.records), "thread_id missing from log"
+    assert any(r.levelno >= logging.WARNING for r in caplog.records), "no WARNING logged"
+
+
+async def test_sink_log_includes_body_length(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Log message should include body length so we can triage truncation issues."""
+    import logging
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(status=400), "Bad"))
+    bot.get_channel.return_value = channel
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    sink = cog._make_sink(99)
+
+    with caplog.at_level(logging.WARNING, logger="c_lord.cogs.transcript_mirror"):
+        await sink("hello world")
+
+    combined = " ".join(r.message for r in caplog.records)
+    assert "99" in combined, "thread_id not in log"
+
+
+async def test_file_sink_falls_back_to_plain_on_http_exception(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When file attachment send fails, file_sink must retry with plain text."""
+    bot = MagicMock()
+    channel = MagicMock()
+    call_count = 0
+
+    async def send_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if "file" in kwargs:
+            raise discord.HTTPException(MagicMock(status=413), "Too large")
+        # Plain text succeeds
+
+    channel.send = AsyncMock(side_effect=send_side_effect)
+    bot.get_channel.return_value = channel
+
+    progress_file = tmp_path / "progress.txt"
+    progress_file.write_text("tool output")
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    file_sink = cog._make_file_sink(10)
+    await file_sink("final answer", str(progress_file))
+
+    # send called twice: once with file (failed), once without (fallback)
+    assert call_count == 2
+    # Last call was plain text (no file kwarg)
+    last_kwargs = channel.send.call_args_list[-1][1]
+    assert "file" not in last_kwargs
+
+
+async def test_file_sink_logs_warning_on_http_exception(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """HTTPException in file_sink must produce a WARNING log."""
+    import logging
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(status=500), "Error"))
+    bot.get_channel.return_value = channel
+
+    progress_file = tmp_path / "progress.txt"
+    progress_file.write_text("some tool output")
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    file_sink = cog._make_file_sink(77)
+
+    with caplog.at_level(logging.WARNING, logger="c_lord.cogs.transcript_mirror"):
+        await file_sink("body", str(progress_file))
+
+    assert any(r.levelno >= logging.WARNING for r in caplog.records)
+    combined = " ".join(r.message for r in caplog.records)
+    assert "77" in combined, "thread_id missing from log"


### PR DESCRIPTION
## Summary

- `sink`: `contextlib.suppress(discord.HTTPException)` を外し、`thread_id` / `body_len` / HTTP ステータスを含む WARNING ログに変更
- `file_sink`: 添付送信失敗時にプレーンテキストでリトライ、それも失敗した場合も WARNING ログ
- これで `grep "TranscriptMirror.*failed"` / `grep "thread=<id>"` で Discord 投稿失敗を即時特定可能

## 変更箇所

`c_lord/cogs/transcript_mirror.py`
- `_make_sink`: HTTPException → `logger.warning(thread=%d body_len=%d status=%s)`
- `_make_file_sink`: 添付失敗 → 警告ログ + プレーンテキスト再送、再送失敗 → 警告ログ

## Test plan

- [x] TDD: 4 テスト追加（RED→GREEN）
- [x] 951 テスト全パス
- [x] ruff check / format clean
- [x] `test_sink_logs_warning_on_http_exception`
- [x] `test_sink_log_includes_body_length`
- [x] `test_file_sink_falls_back_to_plain_on_http_exception`
- [x] `test_file_sink_logs_warning_on_http_exception`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)