### PR TITLE
fix: cap progress.txt size and add markdown-table regression test (#86)

### DIFF
--- a/c_lord/transcript/mirror.py
+++ b/c_lord/transcript/mirror.py
@@ -38,6 +38,19 @@ FileSink = Callable[[str, str], Awaitable[None]]
 # Kinds that are buffered (not posted individually) in minimal mode.
 _BUFFERED_KINDS = frozenset({"tool_use", "tool_result"})
 
+# Maximum byte size for progress.txt content.  Caps runaway tool output so
+# that progress.txt stays well within Discord's 8 MB file-upload limit.
+_PROGRESS_MAX_BYTES = 50_000  # 50 KB
+
+
+def _truncate_progress(content: str) -> str:
+    """Truncate *content* to ``_PROGRESS_MAX_BYTES`` bytes if needed."""
+    encoded = content.encode("utf-8")
+    if len(encoded) <= _PROGRESS_MAX_BYTES:
+        return content
+    truncated = encoded[: _PROGRESS_MAX_BYTES - 30].decode("utf-8", errors="ignore")
+    return truncated + "\n… [truncated]"
+
 
 def bridge_mode_jsonl() -> bool:
     """Return True iff ``CLORD_BRIDGE_MODE`` is set to ``jsonl``."""
@@ -159,7 +172,7 @@ class TranscriptMirror:
                 delete=False,
                 encoding="utf-8",
             ) as f:
-                f.write("\n".join(progress_buf))
+                f.write(_truncate_progress("\n".join(progress_buf)))
                 tmp_path = f.name
             try:
                 await self._file_sink(body, tmp_path)

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -427,3 +427,92 @@ async def test_mirror_minimal_clears_buffer_after_assistant_text(tmp_path: Path)
     # file_sink only called once (turn 1), not for turn 2 (no buffered tools)
     assert len(file_sink_calls) == 1
     assert file_sink_calls[0][0] == "turn1 done"
+
+
+# ---------------------------------------------------------------------------
+# Issue #86: regression tests for markdown-table + tool events scenario
+# ---------------------------------------------------------------------------
+
+
+async def test_mirror_minimal_markdown_table_with_tools_reaches_file_sink(
+    tmp_path: Path,
+) -> None:
+    """Issue #86 regression: markdown table in assistant_text after tool events
+    must reach file_sink (not be silently dropped)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    sink_calls: list[str] = []
+    file_sink_calls: list[tuple[str, str]] = []
+
+    async def sink(text: str) -> None:
+        sink_calls.append(text)
+
+    async def file_sink(text: str, file_path: str) -> None:
+        file_sink_calls.append((text, file_path))
+
+    mirror = TranscriptMirror(
+        thread_id=1,
+        project_dir=project,
+        sink=sink,
+        file_sink=file_sink,
+        verbosity="minimal",
+        poll_interval=0.05,
+    )
+    mirror.start()
+    markdown_table_body = (
+        "まとめると：\n\n"
+        "| テーブル | フィールド | 件数 | 内容 |\n"
+        "|---|---|---|---|\n"
+        "| `konishis_postmeta` | `mw-wp-form` | 1件 | **設定** |\n\n"
+        "進めますか？"
+    )
+    try:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl, _assistant_tool_use("Bash", "mysql -e 'SELECT ...'"))
+        _write_event(jsonl, _user_tool_result("<persisted-output>\nOutput too large (301KB)."))
+        _write_event(jsonl, _assistant_tool_use("Bash", "mysql -e 'SELECT tbl ...'"))
+        _write_event(jsonl, _user_tool_result("tbl\tfield\nextra\t1"))
+        _write_event(
+            jsonl,
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": markdown_table_body}],
+                },
+            },
+        )
+        await asyncio.sleep(0.5)
+    finally:
+        await mirror.stop()
+
+    # The markdown table body must have reached file_sink (not been dropped)
+    assert len(file_sink_calls) == 1, f"expected 1 file_sink call, got {len(file_sink_calls)}"
+    assert markdown_table_body in file_sink_calls[0][0]
+    # Progress file must exist (or have existed) and contain tool output
+    assert not sink_calls or not any(markdown_table_body in c for c in sink_calls)
+
+
+def test_progress_content_truncated_when_over_limit(tmp_path: Path) -> None:
+    """Progress buffer content must be truncated to _PROGRESS_MAX_BYTES to
+    prevent oversized progress.txt from causing 413 errors."""
+    from c_lord.transcript.mirror import _PROGRESS_MAX_BYTES, _truncate_progress
+
+    large_content = "x" * (_PROGRESS_MAX_BYTES + 1000)
+    result = _truncate_progress(large_content)
+    assert len(result.encode()) <= _PROGRESS_MAX_BYTES
+    assert "[truncated]" in result or len(result) < len(large_content)
+
+
+def test_progress_content_not_truncated_when_within_limit(tmp_path: Path) -> None:
+    """Small progress content must pass through unchanged."""
+    from c_lord.transcript.mirror import _truncate_progress
+
+    small = "tool output line"
+    assert _truncate_progress(small) == small


### PR DESCRIPTION
## 根本原因

2026-05-18 23:53:26 JST の Discord 消失は `file_sink` の `contextlib.suppress(discord.HTTPException)` が HTTPException を握りつぶしていたことが原因（#85 で修正済み）。

Direct Discord API テストで同一コンテンツ（マークダウン表 323 chars + progress.txt）は正常に送信できることを確認 → コンテンツ自体は問題なし。

## この PR の追加防御措置

1. **progress.txt サイズ上限 50 KB** (`_truncate_progress()`): 大量ツール出力（実例: 301 KB の persisted output）が progress.txt に流れ込んで Discord の file-upload 制限に引っかかるケースを防ぐ
2. **リグレッションテスト**: マークダウン表 + Bash×2 tool events のシナリオで `file_sink` が確実に呼ばれることを検証

## staging E2E

- RED: 旧コード(main) に `_truncate_progress` なし → 確認
- GREEN: 新コードで 55,000 chars 入力 → 49,986 bytes 出力（上限 50,000 以下）+ `[truncated]` 付与 → 確認

## Test plan

- [x] TDD: 3 テスト追加（RED→GREEN）
- [x] 954 テスト全パス
- [x] ruff check / format clean
- [x] staging E2E RED/GREEN 確認済み

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)