### PR TITLE
chore: clean up EbiBot framing in code, tests, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Discord frontend for Claude Code CLI. **This is a framework (OSS library), not a
 ## Framework vs Instance
 
 - **c-lord** (this repo) = reusable OSS framework. No personal config, no secrets, no server-specific logic.
-- Personal instances (e.g. EbiBot) install this as a package and import the Cog. The instance repo handles server-specific config, additional Cogs, and secrets.
+- Personal instances (e.g. a personal Discord bot) install this as a package and import the Cog. The instance repo handles server-specific config, additional Cogs, and secrets.
 - When adding features: if it's useful to anyone → add here. If it's personal workflow → add in the instance repo.
 
 ### Zero-Config Principle (Critical)

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ uv run pytest tests/ -v --cov=c_lord
 
 ## How This Project Was Built
 
-**This codebase is developed by [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, Anthropic's AI coding agent, under the direction of [@ebibibi](https://github.com/ebibibi). The human author defines requirements, reviews pull requests, and approves all changes — Claude Code does the implementation.
+**This codebase is developed by [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, Anthropic's AI coding agent. The original foundation, [`claude-code-discord-bridge`](https://github.com/ebibibi/claude-code-discord-bridge), was created by [@ebibibi](https://github.com/ebibibi) (Masahiko Ebisuda) and provided this project with its initial architecture under the MIT License. This derivative is now maintained by [@yousan](https://github.com/yousan), who defines requirements, reviews pull requests, and approves all changes — Claude Code does the implementation.
 
 This means:
 
@@ -636,14 +636,9 @@ The project started on 2026-02-18 and continues to evolve through iterative conv
 
 ---
 
-## Real-World Example
-
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — A personal Discord bot built on this framework. Includes automated documentation sync (English + Japanese), push notifications, Todoist watchdog, scheduled health checks, and GitHub Actions CI/CD. Use it as a reference for building your own bot.
-
----
-
 ## Inspired By
 
+- [claude-code-discord-bridge](https://github.com/ebibibi/claude-code-discord-bridge) by [@ebibibi](https://github.com/ebibibi) — The upstream foundation this project is based on. See [EbiBot](https://github.com/ebibibi/discord-bot) for ebibibi's personal bot built on the same framework (docs sync, push notifications, Todoist watchdog, scheduled health checks, GitHub Actions CI/CD).
 - [OpenClaw](https://github.com/openclaw/openclaw) — Emoji status reactions, message debouncing, fence-aware chunking
 - [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — CLI spawn + stream-json approach
 - [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Permission control patterns

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -50,7 +50,7 @@ This document captures the "why" behind key architectural choices. Each decision
 **Why shared function:**
 - **DRY without coupling**: Both Cogs call `run_claude_in_thread()` but remain independent in how they receive input (message listener vs slash command)
 - **Single place to fix bugs**: Status emoji logic, chunking, error handling — all in one place
-- **Easy to extend**: New Cogs that need Claude execution just call the same function (see EbiBot's docs-sync Cog for an example of a consumer that chose to implement its own streaming logic for different requirements)
+- **Easy to extend**: New Cogs that need Claude execution just call the same function (e.g. a consumer docs-sync Cog can implement its own streaming logic on top of the shared function for different requirements)
 
 ## 4. Emoji Reactions for Status
 
@@ -105,7 +105,7 @@ This document captures the "why" behind key architectural choices. Each decision
 - **Separation of concerns**: The framework handles Discord↔CLI bridging. The consumer handles project-specific config, secrets, and custom Cogs
 - **Upgrade path**: `uv lock --upgrade-package c-lord && uv sync` gets you the latest framework without touching your custom code
 - **No conflict**: Your bot's `pyproject.toml` pins the framework version. Multiple bots can use different versions
-- **Real-world validation**: EbiBot proves this works — it imports `ClaudeChatCog`, `ClaudeRunner`, `SkillCommandCog`, and adds its own Cogs (reminders, watchdog, docs-sync, auto-upgrade)
+- **Real-world validation**: Consumer bots demonstrate this works — they import `ClaudeChatCog`, `ClaudeRunner`, `SkillCommandCog`, and add their own Cogs (reminders, watchdog, docs-sync, auto-upgrade) without touching the framework
 
 ## 7. No Custom AI Logic
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -126,7 +126,7 @@ Both Cogs only respond to messages in the configured channel (`channel_id`) and 
 
 ## Webhook Security (Consumer Cog Pattern)
 
-When building custom Cogs that respond to webhooks (like EbiBot's docs-sync), follow this pattern:
+When building custom Cogs that respond to webhooks (for example, a docs-sync trigger), follow this pattern:
 
 ```python
 # Only respond to webhook messages

--- a/tests/test_auto_upgrade.py
+++ b/tests/test_auto_upgrade.py
@@ -25,7 +25,7 @@ def bot() -> MagicMock:
 def config() -> UpgradeConfig:
     return UpgradeConfig(
         package_name="c-lord",
-        trigger_prefix="🔄 ebibot-upgrade",
+        trigger_prefix="🔄 upgrade",
         working_dir="/home/user/bot",
     )
 
@@ -36,7 +36,7 @@ def cog(bot: MagicMock, config: UpgradeConfig) -> AutoUpgradeCog:
 
 
 def _make_message(
-    content: str = "🔄 ebibot-upgrade",
+    content: str = "🔄 upgrade",
     webhook_id: int | None = 12345,
     channel_id: int = 999,
 ) -> MagicMock:
@@ -122,7 +122,7 @@ class TestFiltering:
         cog: AutoUpgradeCog,
     ) -> None:
         """Trigger prefix must be exact match."""
-        msg = _make_message(content="🔄 ebibot-upgrade extra")
+        msg = _make_message(content="🔄 upgrade extra")
         msg.create_thread = AsyncMock()
         await cog.on_message(msg)
         msg.create_thread.assert_not_called()

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -580,7 +580,7 @@ class TestInterruptOnNewMessage:
 class TestZeroConfigCoordination:
     """_get_coordination() must work without any consumer wiring (Zero-Config Principle).
 
-    Consumers (like EbiBot) must get new features by updating the package alone —
+    Consumers must get new features by updating the package alone —
     no code changes, no bot.coordination wiring required.
     """
 

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -1,7 +1,4 @@
-"""Tests for the ThreadStatusDashboard — live session status embed.
-
-Issue: https://github.com/ebibibi/c-lord/issues/67
-"""
+"""Tests for the ThreadStatusDashboard — live session status embed."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
EbiBot (`ebibibi/discord-bot`) は c-lord の機能的な consumer ではなく、AI生成時に参考実装としてハードコードされたもの。MITライセンス上の派生元は別途 `ebibibi/claude-code-discord-bridge` で、こちらは LICENSE と README L13 の attribution で正しく扱われている。

本PRは「派生事実の attribution は保持しつつ、EbiBotとの機能カップリングを示唆する誤った framing を整理」する。

## 変更点

### README.md
- `"under the direction of @ebibibi"` → `"originally created by @ebibibi (MIT License) and now maintained by @yousan"`（上流著者への敬意を保ちつつ、この派生のメンテナを正しく明示）
- `## Real-World Example` (EbiBot) 節を削除 → `## Inspired By` の `claude-code-discord-bridge` 項目に統合してEbiBotへのリンクも残す

### 他のドキュメント
- `CLAUDE.md`: `"personal instances (e.g. EbiBot)"` → `"e.g. a personal Discord bot"`
- `docs/SECURITY.md`: `"like EbiBot's docs-sync"` → `"for example, a docs-sync trigger"`
- `docs/DESIGN_DECISIONS.md`: EbiBot固有の例示を `"consumer bots"` に抽象化

### テスト
- `tests/test_thread_dashboard.py:3`: 死URL `https://github.com/ebibibi/c-lord/issues/67` を削除（リポジトリは `yousan/c-lord`）
- `tests/test_auto_upgrade.py`: trigger prefix `🔄 ebibot-upgrade` → `🔄 upgrade`
- `tests/test_claude_chat.py:583`: コメント内 `"Consumers (like EbiBot)"` → `"Consumers"`

## 保留 (follow-up)
- `docs/{ja,ko,zh-CN,es,fr,pt-BR}/README.md` の翻訳更新（語順が異なるため別PR）

## 維持されている attribution
- `LICENSE`: `Copyright (c) 2026 Masahiko Ebisuda` (MIT License — 必須)
- `README.md` L13: "Based on claude-code-discord-bridge by @ebibibi (MIT License). Thank you for the great foundation."
- `README.md` Inspired By セクション: 上流リポジトリへのリンクとEbiBotへの参照

## Test plan
- [ ] CIで `ruff check` / `ruff format --check` / `pyright` / `pytest` がgreen
- [ ] `grep -ri "ebibot" tests/` で意図しない残骸がないこと
- [ ] README rendering を GitHub UI で確認

Refs #99