### PR TITLE
fix: surface suppressed sink failures in TranscriptMirror (#85, #86)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -799,8 +799,14 @@ class ClaudeChatCog(commands.Cog):
             # without going through the discord-reply skill.  No-op otherwise.
             transcript_cog = getattr(self.bot, "transcript_mirror_cog", None)
             if transcript_cog is not None and working_dir:
-                with contextlib.suppress(Exception):
+                try:
                     transcript_cog.start_for(thread.id, working_dir)
+                except Exception:
+                    logger.warning(
+                        "Failed to start TranscriptMirror for thread=%d",
+                        thread.id,
+                        exc_info=True,
+                    )
 
             stop_view = StopView(runner)
             if window_name:

--- a/c_lord/cogs/transcript_mirror.py
+++ b/c_lord/cogs/transcript_mirror.py
@@ -17,7 +17,6 @@ Lifecycle:
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -98,8 +97,14 @@ class TranscriptMirrorCog(commands.Cog):
             channel = bot.get_channel(thread_id)
             if channel is None:
                 # Thread may not be in cache after a restart — try fetching.
-                with contextlib.suppress(discord.HTTPException, discord.NotFound):
+                try:
                     channel = await bot.fetch_channel(thread_id)
+                except (discord.HTTPException, discord.NotFound) as exc:
+                    logger.warning(
+                        "TranscriptMirror sink: fetch_channel %d failed: %s",
+                        thread_id,
+                        exc,
+                    )
             if channel is None:
                 logger.warning(
                     "TranscriptMirror sink: channel %d not found, dropping post",
@@ -119,7 +124,6 @@ class TranscriptMirrorCog(commands.Cog):
                     type(channel).__name__,
                 )
                 return
-            with contextlib.suppress(discord.HTTPException):
-                await send(body)
+            await send(body)
 
         return sink

--- a/tests/test_transcript_mirror_cog.py
+++ b/tests/test_transcript_mirror_cog.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 
 from c_lord.cogs.transcript_mirror import TranscriptMirrorCog
@@ -160,3 +162,39 @@ async def test_end_to_end_jsonl_event_posts_to_discord(
     assert channel.send.called
     sent_bodies = [c[0][0] for c in channel.send.call_args_list]
     assert any("via cog" in b for b in sent_bodies)
+
+
+async def test_sink_http_exception_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTPException from send() must propagate out of the sink so _run() can log it."""
+    monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+    resp = MagicMock()
+    resp.status = 400
+    resp.reason = "Bad Request"
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock(side_effect=discord.HTTPException(resp, "bad"))
+    bot.get_channel.return_value = channel
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    sink = cog._make_sink(7)
+    with pytest.raises(discord.HTTPException):
+        await sink("hello")
+
+
+async def test_sink_fetch_failure_is_logged(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """fetch_channel failure must be logged, not silently dropped."""
+    monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+    resp = MagicMock()
+    resp.status = 404
+    resp.reason = "Not Found"
+    bot = MagicMock()
+    bot.get_channel.return_value = None
+    bot.fetch_channel = AsyncMock(side_effect=discord.NotFound(resp, "not found"))
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    sink = cog._make_sink(7)
+    with caplog.at_level(logging.WARNING, logger="c_lord.cogs.transcript_mirror"):
+        await sink("hello")
+    assert any("fetch_channel" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Removes `contextlib.suppress(discord.HTTPException)` from `_make_sink`'s `send(body)` call — `HTTPException` now propagates to `TranscriptMirror._run()`'s existing `except Exception: logger.warning(..., exc_info=True)` handler
- Replaces `suppress(HTTPException, NotFound)` on `fetch_channel` with `try/except + logger.warning` so fetch failures appear in logs
- Replaces `suppress(Exception)` around `start_for()` in `claude_chat.py` with `try/except + logger.warning(exc_info=True)`

Closes #85, Closes #86

## Root cause

The sink in `transcript_mirror.py` wrapped `await send(body)` in `contextlib.suppress(discord.HTTPException)`. `TranscriptMirror._run()` already had a correct `except Exception: logger.warning(..., exc_info=True)` handler — but it never fired because the sink consumed the exception first. Discord rejections (e.g. 400 for a message containing a markdown table) were silently dropped with no trace.

## Test plan

- [x] `test_sink_http_exception_propagates` — confirms HTTPException propagates out of sink (RED before fix, GREEN after)
- [x] `test_sink_fetch_failure_is_logged` — confirms fetch_channel failure emits WARNING log (RED before fix, GREEN after)
- [x] 928 tests passed, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)