### PR TITLE
fix: surface suppressed sink failures in TranscriptMirror (#85, #86)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -882,8 +882,14 @@ class ClaudeChatCog(commands.Cog):
             # without going through the discord-reply skill.  No-op otherwise.
             transcript_cog = getattr(self.bot, "transcript_mirror_cog", None)
             if transcript_cog is not None and working_dir:
-                with contextlib.suppress(Exception):
+                try:
                     transcript_cog.start_for(thread.id, working_dir)
+                except Exception:
+                    logger.warning(
+                        "Failed to start TranscriptMirror for thread=%d",
+                        thread.id,
+                        exc_info=True,
+                    )
 
             stop_view = StopView(runner)
             if window_name:

--- a/tests/test_transcript_mirror_cog.py
+++ b/tests/test_transcript_mirror_cog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock


### PR DESCRIPTION
Replaces the silent `contextlib.suppress` calls in TranscriptMirror sink and related code with explicit `try/except + logger.warning(exc_info=True)` so failures are visible in logs.

- Remove `suppress` from `send(body)` in `_make_sink` — HTTPException propagates to `_run()`'s existing except handler
- Replace `suppress(HTTPException, NotFound)` on `fetch_channel` with `try/except + logger.warning`
- Replace `suppress(Exception)` around `start_for()` in `claude_chat.py` with `try/except + logger.warning(exc_info=True)`

Adds two new tests: `test_sink_http_exception_propagates` and `test_sink_fetch_failure_is_logged`.

Closes #85, #86

Re-opens #104 (was closed without merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)