### PR TITLE
fix: /clear 後の通常メッセージが無視される問題を修正 (#117)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -359,7 +359,7 @@ class ClaudeChatCog(commands.Cog):
         if isinstance(channel, discord.Thread):
             # Continue in existing thread
             record = await self.repo.get(channel.id)
-            session_id = record.session_id if record else None
+            session_id = (record.session_id or None) if record else None
             seed_message = await channel.send(prompt)
             await self._run_claude(seed_message, channel, prompt=prompt, session_id=session_id)
             await interaction.followup.send("Session completed.", silent=True)
@@ -479,8 +479,8 @@ class ClaudeChatCog(commands.Cog):
             await runner.kill()
             del self._active_runners[interaction.channel.id]
 
-        deleted = await self.repo.delete(interaction.channel.id)
-        if deleted:
+        reset = await self.repo.reset(interaction.channel.id)
+        if reset:
             await interaction.response.send_message(
                 "\U0001f504 Session cleared. Next message will start a fresh session."
             )
@@ -681,7 +681,7 @@ class ClaudeChatCog(commands.Cog):
         lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
         async with lock:
             record = await self.repo.get(thread.id)
-            session_id = record.session_id if record else None
+            session_id = (record.session_id or None) if record else None
             prompt, image_paths = await self._build_prompt_and_images(message)
 
             # Interrupt any active session in this thread before starting a new one.

--- a/c_lord/database/repository.py
+++ b/c_lord/database/repository.py
@@ -105,6 +105,22 @@ class SessionRepository:
             await db.commit()
             return cursor.rowcount > 0
 
+    async def reset(self, thread_id: int) -> bool:
+        """Clear the session_id but keep the row, so the next message starts fresh.
+
+        Used by /clear: the row's existence is what allows on_message to route
+        future messages into _handle_thread_reply (issue #117).
+        Returns True if a row was updated, False if no row existed.
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "UPDATE sessions SET session_id = '', last_used_at = datetime('now', 'localtime')"
+                " WHERE thread_id = ?",
+                (thread_id,),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
     # ── Issue #95: thread naming redesign helpers ─────────────────────
 
     async def get_by_thread_id(self, thread_id: int) -> SessionRecord | None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -54,6 +54,32 @@ class TestSessionRepository:
     async def test_delete_nonexistent(self, repo):
         assert await repo.delete(99999) is False
 
+    # ── Issue #117: reset (clear) ─────────────────────────────────────
+
+    async def test_reset_clears_session_id(self, repo):
+        """reset() keeps the row but empties session_id so next message starts fresh."""
+        await repo.save(thread_id=500, session_id="sess-active")
+        result = await repo.reset(500)
+        assert result is True
+        record = await repo.get(500)
+        # Row still exists (on_message can find it)
+        assert record is not None
+        # session_id is falsy — treated as "no active session" by callers
+        assert not record.session_id
+
+    async def test_reset_nonexistent(self, repo):
+        """reset() on a row that does not exist returns False."""
+        assert await repo.reset(99999) is False
+
+    async def test_reset_preserves_other_fields(self, repo):
+        """reset() keeps working_dir and model intact."""
+        await repo.save(thread_id=600, session_id="sess-1", working_dir="/proj", model="opus")
+        await repo.reset(600)
+        record = await repo.get(600)
+        assert record is not None
+        assert record.working_dir == "/proj"
+        assert record.model == "opus"
+
     async def test_cleanup_old(self, repo):
         # Create a session (it will be "now")
         await repo.save(thread_id=400, session_id="recent")


### PR DESCRIPTION
## Summary

- `SessionRepository.reset(thread_id)` を追加 — 行を残したまま `session_id = ''` にリセット
- `/clear` コマンドを `repo.delete()` → `repo.reset()` に変更
- `_handle_thread_reply` と `/clord` ハンドラで `record.session_id or None` と正規化（空文字列 = fresh start 扱い）

## Root cause

`/clear` が `repo.delete()` でセッション行を削除していたため、`on_message` の条件 `repo.get() is not None` が False になり、次のメッセージが黙って捨てられていた。返信メッセージの「次のメッセージで新規セッション開始」と実挙動が食い違っていた。

## Approach (B案: 返信通りの挙動に)

行を削除せず `session_id = ''` にリセットすることで:
- `repo.get()` は引き続き行を返す → `on_message` の条件を通過
- `session_id or None` → `None` → `_run_claude` が fresh session を開始
- 休眠スレッドへの誤爆リスクなし（c-lord が作ったスレッドのみが行を持つ）

## Test plan

- [x] `test_reset_clears_session_id`: reset() 後も行が存在し session_id が falsy
- [x] `test_reset_nonexistent`: 存在しない行には False
- [x] `test_reset_preserves_other_fields`: working_dir / model は保持される
- [x] 全テスト: 1003 passed, 5 skipped
- [x] lint/format: clean

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)