### PR TITLE
fix: /clear now kills idle tmux window to reset Claude's context (#123)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -473,13 +473,24 @@ class ClaudeChatCog(commands.Cog):
             )
             return
 
+        thread_id = interaction.channel.id
+
         # Kill active runner if any
-        runner = self._active_runners.get(interaction.channel.id)
+        runner = self._active_runners.get(thread_id)
         if runner:
             await runner.kill()
-            del self._active_runners[interaction.channel.id]
+            del self._active_runners[thread_id]
 
-        reset = await self.repo.reset(interaction.channel.id)
+        # Kill the tmux window unconditionally — even for idle sessions where the
+        # runner has already been removed from _active_runners (issue #123).
+        # This ensures `is_claude_running` returns False next time, preventing
+        # old context from being resumed via send_input.
+        parent_id = getattr(interaction.channel, "parent_id", None) or thread_id
+        tmux_manager = await self._resolve_tmux_manager(parent_id)
+        if tmux_manager is not None:
+            await asyncio.to_thread(tmux_manager.kill_session, thread_id)
+
+        reset = await self.repo.reset(thread_id)
         if reset:
             await interaction.response.send_message(
                 "\U0001f504 Session cleared. Next message will start a fresh session."

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1441,3 +1441,86 @@ class TestThreadLockSerialization:
         # With serialization, call_log should be [start, end, start, end]
         # Without it, it would be [start, start, end, end]
         assert call_log == ["start", "end", "start", "end"]
+
+
+class TestClearCommand:
+    """Tests for /clear command (issue #117, #123)."""
+
+    @pytest.mark.asyncio
+    async def test_clear_outside_thread_sends_ephemeral(self) -> None:
+        """/clear outside a thread sends an ephemeral error."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+
+        await cog.clear_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_clear_kills_active_runner(self) -> None:
+        """/clear kills an active runner when one is present."""
+        tmux_manager = MagicMock()
+        tmux_manager.kill_session = MagicMock(return_value=True)
+        channel_cog = _make_channel_cog_mock(tmux_manager=tmux_manager)
+        cog = _make_cog(channel_cog=channel_cog)
+        thread_id = 12345
+
+        runner = AsyncMock()
+        cog._active_runners[thread_id] = runner
+        cog.repo.reset = AsyncMock(return_value=True)
+
+        interaction = _make_thread_interaction(thread_id)
+        thread = interaction.channel
+        thread.parent_id = 999
+
+        await cog.clear_session.callback(cog, interaction)
+
+        runner.kill.assert_called_once()
+        assert thread_id not in cog._active_runners
+
+    @pytest.mark.asyncio
+    async def test_clear_kills_tmux_window_for_idle_session(self) -> None:
+        """Issue #123: /clear on idle thread (no active runner) must still kill the tmux window.
+
+        Before the fix, kill_session was only called when runner was in _active_runners.
+        After the fix, it is called unconditionally when tmux_manager is available.
+        """
+        tmux_manager = MagicMock()
+        tmux_manager.kill_session = MagicMock(return_value=True)
+        channel_cog = _make_channel_cog_mock(tmux_manager=tmux_manager)
+        cog = _make_cog(channel_cog=channel_cog)
+        thread_id = 12345
+
+        # No active runner — this is the "idle session" case
+        assert thread_id not in cog._active_runners
+        cog.repo.reset = AsyncMock(return_value=True)
+
+        interaction = _make_thread_interaction(thread_id)
+        thread = interaction.channel
+        thread.parent_id = 999
+
+        await cog.clear_session.callback(cog, interaction)
+
+        # tmux window must be killed even though there was no active runner
+        tmux_manager.kill_session.assert_called_once_with(thread_id)
+
+    @pytest.mark.asyncio
+    async def test_clear_no_session_sends_ephemeral(self) -> None:
+        """/clear when no DB row exists sends an ephemeral 'not found' reply."""
+        tmux_manager = MagicMock()
+        tmux_manager.kill_session = MagicMock(return_value=False)
+        channel_cog = _make_channel_cog_mock(tmux_manager=tmux_manager)
+        cog = _make_cog(channel_cog=channel_cog)
+        thread_id = 99999
+
+        cog.repo.reset = AsyncMock(return_value=False)
+
+        interaction = _make_thread_interaction(thread_id)
+        thread = interaction.channel
+        thread.parent_id = 999
+
+        await cog.clear_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True


### PR DESCRIPTION
## Summary

- **Root cause**: `clear_session` only called `runner.kill()` when a runner existed in `_active_runners`. After a Claude turn completes, the runner is removed in the `finally` block — so idle sessions had no runner to kill. The tmux window stayed alive, and the next message hit `send_input` (old context) instead of `start_claude` (fresh start).
- **Fix**: Added an unconditional `tmux_manager.kill_session(thread_id)` call in `clear_session`, after the active-runner kill, via `_resolve_tmux_manager`. This mirrors the pattern used by `/clord-attach`.
- **Combined with #117/#118**: `repo.reset()` keeps the DB row so routing still works; killing the window ensures `is_claude_running` returns False → fresh `start_claude` on next message.

Closes #123

## Test plan

- [x] RED: `test_clear_kills_tmux_window_for_idle_session` failed before fix (kill_session called 0 times)
- [x] GREEN: all 4 `TestClearCommand` tests pass after fix
- [x] Full suite: 1007 passed, 5 skipped
- [x] Lint: `ruff check` + `ruff format --check` clean
- [ ] Staging: send message in thread → wait for response (session goes idle) → `/clear` → send another message → confirm fresh session (no continuation of old context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)