### PR TITLE
docs: 完了の定義(DoD)を集約し PRテンプレ・Issueルールを厳格化

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,15 +4,43 @@
 
 ## Why?
 
-<!-- What problem does this solve? Link to issue if applicable: Fixes #123 -->
+<!-- What problem does this solve? -->
+<!-- Link the issue. Use "Closes #N" ONLY if this PR satisfies 100% of that
+     issue's Acceptance Criteria. Otherwise use "Refs #N" and keep it open. -->
 
-## How to test
+## Acceptance Criteria (copied from the issue)
 
-<!-- Steps to verify the change works -->
+<!-- Paste EVERY AC from the linked issue here and check them. Not "most" — every one. -->
 
-## Checklist
+- [ ] AC 1: …
+- [ ] AC 2: …
 
-- [ ] Tests pass: `uv run pytest tests/ -v`
-- [ ] Lint passes: `uv run ruff check c_lord/`
-- [ ] New functionality has tests
-- [ ] README updated (if applicable)
+## Staging Evidence
+
+<!-- REQUIRED for behavior changes (bug fixes / features).
+     Skip ONLY for pure-docs or provably no-behavior-change refactors —
+     and if you skip, write the reason here.
+     Paste log excerpts: RED = problem reproduced before the fix,
+     GREEN = problem gone after the fix, on the staging bot. -->
+
+<!-- RED (before):
+```
+<log excerpt showing the problem on staging>
+```
+GREEN (after):
+```
+<log excerpt showing it fixed on staging>
+```
+-->
+
+## Definition of Done checklist
+
+See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked:
+
+- [ ] Every Acceptance Criterion above is checked
+- [ ] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
+- [ ] `uv run pytest tests/ -v` passes
+- [ ] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
+- [ ] Staging Evidence above is filled in (or a skip reason is written)
+- [ ] No unrelated changes in the diff; self-review done
+- [ ] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,41 @@ CONTRIBUTING.md          # Contribution guidelines
 2. Export from `__init__.py` if it's part of the public API
 3. Test edge cases (empty strings, very long strings, Unicode, code blocks)
 
+## Definition of Done (DoD) — single source of truth
+
+**A change is "done" only when every box below is checked. This list is the one
+authoritative completion definition; the PR template
+(`.github/pull_request_template.md`) mirrors it verbatim. If the two ever
+disagree, this section wins — fix the template.**
+
+Why this exists: CI only runs `ruff` + `pyright` + `pytest`, all of which pass
+with mocked tests. Real behavior (tmux, Discord, restart continuity) is **not**
+exercised by CI. So "green CI" ≠ "works". The boxes below force the evidence CI
+cannot produce. See `docs/DESIGN_DECISIONS.md` → "DoD & merge gate" for the
+incident that motivated this.
+
+A PR may be merged only when:
+
+- [ ] **Every Acceptance Criterion of the linked Issue is copied into the PR body and checked.** Not "most" — every one.
+- [ ] **TDD evidence**: the new test failed before the change (RED) and passes after (GREEN). Paste the RED failure line.
+- [ ] **`pytest` + `ruff check` + `ruff format --check` + `pyright` all green** (CI covers this).
+- [ ] **Staging behavior verified** (unless the [skip exceptions](#動作確認スキーム-必須) apply): RED reproduced + GREEN confirmed on staging, with log excerpts pasted under a `## Staging Evidence` heading. **An empty Staging Evidence section = not done.**
+- [ ] **No unrelated changes** in the diff; self-review done.
+- [ ] **Closes gating**: use `Closes #N` **only if this PR satisfies 100% of that Issue's ACs**. If any AC is deferred, use `Refs #N` instead and leave the Issue open with a comment naming what remains. Never let a partial PR auto-close an Issue.
+
+If you cannot check a box, the change is not done — do not merge. State the
+blocker in the PR instead of silently dropping it.
+
+### Issue authoring rules (write the Issue so it *can't* be half-done)
+
+Most "completed but actually missing half" failures start at the Issue, not the
+PR. When you (or Opus) author an Issue:
+
+- **One Issue = one concern.** Do not bundle a bug fix with a design/enhancement task, or two unrelated behaviors, in one Issue. Bundling lets an agent satisfy the easy/testable half, write `Closes`, and auto-close the rest into oblivion. Split into separate Issues.
+- **Acceptance Criteria must be binary and unambiguous** — each AC is a checkbox that is objectively true or false (a command to run, an observable output, a state to assert). No "should probably", no "consider", no open options ("A案 or B案") left in the AC. Decide before filing; move discussion out of the AC list.
+- **Keep scope narrow.** If the Issue's title needs an "and", it is probably two Issues. A wide守備範囲 is where definitions go soft and items leak.
+- **Deferred work is escalated, never implied.** If something is explicitly out of scope, say so in the Issue and link the follow-up. Silence is not a decision.
+
 ## Git & PR Workflow
 
 - **Branch from `main`**: `feature/description`, `fix/description`, `docs/description`
@@ -342,7 +377,7 @@ Issue → branch → PR → **動作確認 + セルフレビュー** → merge �
 3. **PR 作成** — Closes #N で Issue と連動、CI green を確認
 4. **動作確認 (E2E on staging)** ← **必須** — 下記のスキーム
 5. **セルフレビュー** — diff を読み返す / 不要な変更がないか / セキュリティ監査 (`security-audit` skill)
-6. **Merge** (squash + delete branch)
+6. **Merge** (squash + delete branch) — **only after every [Definition of Done](#definition-of-done-dod--single-source-of-truth) box is checked.** A green CI is necessary but not sufficient.
 7. **Prod redeploy** — `cd /home/yousan/c-lord && git pull && pgrep -f c_lord.main | xargs -r kill && sleep 3 && nohup uv run python -m c_lord.main > /tmp/clord-bot.log 2>&1 &`
 
 ### 動作確認スキーム (必須)

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -179,3 +179,38 @@ This document captures the "why" behind key architectural choices. Each decision
 - **Network issues**: If the subprocess hangs or the stream stalls, stall indicators help distinguish "thinking" from "broken"
 - **Soft vs hard**: Two levels let users know the difference between "this is taking a while" and "something might be wrong"
 - **Non-blocking**: The stall monitor runs as an asyncio task alongside the event stream, not blocking any I/O
+
+## 12. DoD & merge gate (single source of truth)
+
+**Decision:** CLAUDE.md carries one authoritative "Definition of Done" list,
+the PR template mirrors it verbatim, and a PR may close an Issue only when 100%
+of that Issue's Acceptance Criteria are met. Issues must be one-concern with
+binary, unambiguous ACs.
+
+**Why (the incident that motivated this):**
+
+While fixing `/clear`, we filed Issue #123 bundling two things: a concrete bug
+(Part 1: `/clear` left the tmux window alive on idle threads, so the next
+message resumed old context) and an open-ended design task (Part 2: bot-restart
+loses context because `start_claude` never uses `--resume`/`--continue`, and the
+stored `session_id` is a synthetic `tmux-{thread_id}` so `--resume` cannot work
+anyway). PR #124 fixed Part 1 only, wrote `Closes #123`, and on merge GitHub
+auto-closed the Issue as "completed". Part 2 silently vanished.
+
+Root cause was **not** lax rules in prose — CLAUDE.md already said staging
+verification was mandatory. The cause was a gap between the *enforced* gate and
+the *aspirational* prose:
+
+- The only hard gate (CI) runs `ruff`/`pyright`/`pytest`, all of which pass with
+  **mocked** tests. Real tmux/Discord behavior is never exercised. Green CI ≠ works.
+- Staging verification was honor-system, and the **PR template didn't even list
+  it** — so the artifact the author actually fills out never surfaced it.
+- The Definition of Done was scattered across the TDD section, the flow section,
+  the staging section, and the PR template, and they disagreed. The weakest one won.
+- A single multi-concern Issue + `Closes #N` auto-close let a partial PR mark the
+  whole Issue done with no check that all ACs were satisfied.
+
+**Fix:** Move the strictness from prose into the artifact the author touches.
+One DoD list; the PR template is a verbatim copy; ACs are copied into the PR and
+all must be checked; `Closes` is gated on 100% AC completion (else `Refs`);
+Issues are kept one-concern with binary ACs so they cannot be half-satisfied.


### PR DESCRIPTION
## What does this PR do?

文書のみの変更。「完了の定義(Definition of Done, DoD)」を1箇所に集約し、PRテンプレをそれと逐語一致させ、Issue起票ルール（1 Issue=1 concern / AC は二値・曖昧さなし）を明文化する。

- `CLAUDE.md`: `## Definition of Done (DoD)` を新設（単一の正本）＋ Issue authoring rules。Merge ステップから DoD へリンク。
- `.github/pull_request_template.md`: DoD を反映。`Acceptance Criteria（Issueから全項目を転記）` と `Staging Evidence`（空欄＝未完了）セクションを追加。`Closes` ゲートを明記。
- `docs/DESIGN_DECISIONS.md`: 動機となった事故（#123/#124）を「12. DoD & merge gate」として記録。

## Why?

オーナーとの会話で実際に踏んだ事故が動機です。**今こういうことで困っている、という具体**を残します：

`/clear` 修正の流れで Issue #123 を立てた際、**1枚のIssueに2件**を同居させてしまいました：
- **Part 1（バグ）**: `/clear` がアイドルなスレッドで tmux window を kill せず、次メッセージが旧文脈を継続してしまう
- **Part 2（設計）**: bot 再起動で文脈が失われる。`start_claude` は `--resume`/`--continue` を使わず毎回 fresh 起動で、保存している `session_id` も合成値 `tmux-{thread_id}` なので `--resume` はそもそも不可。復元には `--continue`→無ければfresh のフォールバックが要る

PR #124 は **Part 1 だけ**直して `Closes #123` を付け、マージで GitHub が #123 を「completed」自動クローズ → **Part 2 が静かに消滅**しました。

根本原因は「ルールが緩い」ではありません。CLAUDE.md は staging 検証を必須と明記済みでした。問題は **強制される所と、文章だけの所のギャップ** です：

- 唯一の強制ゲート(CI)は `ruff`/`pyright`/`pytest` で、**全部モックで通る**。tmux/Discord の実挙動は一切走らない＝**green CI ≠ 動く**
- staging 検証は良心まかせで、**PRテンプレにその欄が存在しなかった**（著者が実際に埋める紙に出てこない）
- DoD が TDD節 / フロー節 / staging節 / PRテンプレに散在して矛盾。**弱い方が勝つ**
- 多論点 Issue ＋ `Closes #N` 自動クローズで、**部分PRが全体を「完了」化**し、AC達成チェックが無い

→ 対策は「文章の厳しさを、著者が触る成果物（PRテンプレ）に降ろす」。本PRはその第一弾（文書）です。

### 本PRに含めない（意図的にスコープを狭く保つ — まさにこのPRが説く原則の実践）
- ② PR本文をパースして Staging Evidence 空欄を CI で赤にする機械ゲート
- ③ 挙動変更PRの自己マージ禁止（別レビュアーによる AC×diff×ログ突合）

これらは挙動を持つ変更なので、文書PRと混ぜず別Issue/別PRに分けます。

## Acceptance Criteria (copied from the issue)

本PRは文書ルール整備で対応Issueは無いため、自己定義のACで判定：

- [x] CLAUDE.md に単一の DoD セクションが存在し、Merge ステップがそこへリンクしている
- [x] PRテンプレが DoD を反映し、`Acceptance Criteria` と `Staging Evidence` セクションを持つ
- [x] `Closes` を 100% AC 達成時のみ許可するルールが両方に明記されている
- [x] Issue authoring rules（1 Issue=1 concern / 二値AC / スコープ限定）が明記されている
- [x] 事故の経緯が DESIGN_DECISIONS.md に記録されている

## Staging Evidence

スキップ（理由）：純粋な文書のみの変更（`CLAUDE.md` / PRテンプレ / `docs`）。コード挙動の変更なし＝CLAUDE.md の staging 検証スキップ例外に該当。`ruff`/`pytest` 対象のコードは触っていない。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [N/A] TDD: 文書のみ、対応するコードテストなし
- [x] `uv run pytest tests/ -v` passes（コード未変更、影響なし）
- [x] lint 対象のコード変更なし
- [x] Staging Evidence にスキップ理由を記載
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` は使用しない（対応Issue無し）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
