### PR TITLE
fix: --continue fallback for bot-restart context recovery (#123 Part 2)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -41,6 +41,12 @@ _STARTUP_TIMEOUT = 30.0
 # Delay after startup before polling begins (seconds).
 _POST_STARTUP_DELAY = 1.0
 
+# How long to wait after sending ``claude --continue`` before checking whether
+# Claude actually started (issue #123 Part 2).  If Claude is still not running
+# after this delay, ``--continue`` failed (no session to resume) and we fall
+# back to a plain fresh start.
+_CONTINUE_CHECK_DELAY = 3.0
+
 # Patterns that indicate a trust/safety prompt that needs Enter to dismiss.
 _TRUST_PROMPT_MARKERS = (
     "Yes, I trust this folder",
@@ -231,6 +237,9 @@ class TmuxClaudeRunner:
                 )
                 return
         else:
+            # Try --continue first to recover context after a bot restart.
+            # If Claude exits immediately (no session to resume), fall back to
+            # a plain fresh start (issue #123 Part 2).
             ok = await asyncio.to_thread(
                 self._tmux.start_claude,
                 self._thread_id,
@@ -238,6 +247,7 @@ class TmuxClaudeRunner:
                 self.model,
                 permission_mode=self._permission_mode,
                 dangerously_skip_permissions=self._dangerously_skip_permissions,
+                try_continue=True,
             )
             if not ok:
                 yield StreamEvent(
@@ -247,6 +257,34 @@ class TmuxClaudeRunner:
                     error="Failed to start Claude in tmux",
                 )
                 return
+
+            # Wait briefly and check whether --continue actually started Claude.
+            await asyncio.sleep(_CONTINUE_CHECK_DELAY)
+            still_running = await asyncio.to_thread(self._tmux.is_claude_running, self._thread_id)
+            if not still_running:
+                # --continue failed (no session to resume); start fresh.
+                logger.info(
+                    "start_claude --continue found no session for thread %d; "
+                    "falling back to fresh start",
+                    self._thread_id,
+                )
+                ok = await asyncio.to_thread(
+                    self._tmux.start_claude,
+                    self._thread_id,
+                    prompt,
+                    self.model,
+                    permission_mode=self._permission_mode,
+                    dangerously_skip_permissions=self._dangerously_skip_permissions,
+                    try_continue=False,
+                )
+                if not ok:
+                    yield StreamEvent(
+                        raw={},
+                        message_type=MessageType.RESULT,
+                        is_complete=True,
+                        error="Failed to start Claude in tmux",
+                    )
+                    return
 
             # Handle trust prompt if it appears.
             await self._handle_startup_prompts()

--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -672,6 +672,7 @@ class TmuxSessionManager:
         *,
         permission_mode: str = "acceptEdits",
         dangerously_skip_permissions: bool = False,
+        try_continue: bool = False,
     ) -> bool:
         """Start Claude Code inside the tmux window for *thread_id*.
 
@@ -698,7 +699,10 @@ class TmuxSessionManager:
             return False
 
         target = f"{self.session_name}:{window}"
-        cmd_parts = ["env", "-u", "CLAUDECODE", "claude", "--model", model]
+        cmd_parts = ["env", "-u", "CLAUDECODE", "claude"]
+        if try_continue:
+            cmd_parts.append("--continue")
+        cmd_parts.extend(["--model", model])
         if dangerously_skip_permissions:
             cmd_parts.append("--dangerously-skip-permissions")
         else:

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -464,6 +464,43 @@ class TestTmuxSessionManager:
         # Single quote should be escaped
         assert "'" in cmd_str
 
+    def test_start_claude_with_try_continue_flag(self) -> None:
+        """start_claude with try_continue=True includes --continue in the command."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0),  # send-keys
+            ]
+            result = mgr.start_claude(12345, "hello", try_continue=True)
+
+        assert result is True
+        cmd_call = mock_run.call_args_list[1]
+        args = cmd_call[0][0]
+        cmd_str = " ".join(args[3:])
+        assert "--continue" in cmd_str
+
+    def test_start_claude_default_no_try_continue(self) -> None:
+        """start_claude by default does NOT include --continue (fresh start)."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0),  # send-keys
+            ]
+            mgr.start_claude(12345, "hello")
+
+        cmd_call = mock_run.call_args_list[1]
+        args = cmd_call[0][0]
+        cmd_str = " ".join(args[3:])
+        assert "--continue" not in cmd_str
+
     def test_send_input_sends_text_and_enter(self) -> None:
         mgr = TmuxSessionManager(mapping_path="")
         mgr._available = True

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -952,7 +952,11 @@ class TestTmuxClaudeRunnerRun:
 
     @pytest.mark.asyncio
     async def test_start_claude_fresh(self, runner, tmux_manager) -> None:
-        """When Claude is not running, start_claude is called."""
+        """When Claude is not running, start_claude(try_continue=True) is called first.
+
+        If --continue succeeds (is_claude_running returns True after the delay),
+        only one start_claude call is made.
+        """
         pane = _make_pane(["● Hello!"])
         call_idx = 0
 
@@ -965,7 +969,8 @@ class TestTmuxClaudeRunnerRun:
             return pane
 
         tmux_manager.capture_pane.side_effect = capture_fn
-        tmux_manager.is_claude_running.return_value = False
+        # Simulate: cold start (not running) → --continue succeeds
+        tmux_manager.is_claude_running.side_effect = [False, True]
         tmux_manager._find_window_for_thread.return_value = "work1"
 
         events = []
@@ -974,16 +979,19 @@ class TestTmuxClaudeRunnerRun:
             patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
             patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
             patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+            patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
         ):
             async for event in runner.run("test prompt"):
                 events.append(event)
 
+        # Only one start_claude call (--continue succeeded)
         tmux_manager.start_claude.assert_called_once_with(
             12345,
             "test prompt",
             "sonnet",
             permission_mode="acceptEdits",
             dangerously_skip_permissions=False,
+            try_continue=True,
         )
         assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)
 
@@ -1371,3 +1379,135 @@ class TestExtractResponsePreservesHyperlinks:
         result = TmuxClaudeRunner._extract_response(pane)
         assert "#271" in result
         assert "https://github.com/foo/bar/issues/271" in result
+
+
+class TestContinueFallback:
+    """Tests for the --continue → fresh-start fallback (issue #123 Part 2).
+
+    When Claude is not running in the tmux window (e.g. after a bot restart),
+    run() first tries ``claude --continue <prompt>`` to recover context.
+    If that fails (Claude exits immediately — no session to continue), it falls
+    back to a plain fresh ``claude <prompt>``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_continue_called_first_on_cold_start(
+        self, runner, tmux_manager
+    ) -> None:
+        """run() calls start_claude(try_continue=True) first when Claude is not running."""
+        tmux_manager.is_claude_running.side_effect = [
+            False,  # initial check — Claude not running
+            True,   # after --continue delay — Claude started successfully
+        ]
+        pane = _make_pane(["● Resumed."])
+        tmux_manager.capture_pane.return_value = pane
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+            patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
+        ):
+            async for event in runner.run("hello"):
+                events.append(event)
+
+        # First call must use try_continue=True
+        first_call = tmux_manager.start_claude.call_args_list[0]
+        assert first_call.kwargs.get("try_continue") is True or (
+            len(first_call.args) >= 4 and "--continue" in str(first_call)
+        ), f"Expected try_continue=True in first call, got: {first_call}"
+        # Only one start_claude call (--continue succeeded)
+        assert tmux_manager.start_claude.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_fresh_when_continue_fails(
+        self, runner, tmux_manager
+    ) -> None:
+        """Issue #123 Part 2: when --continue fails, fresh start is used as fallback.
+
+        --continue failure is detected by is_claude_running returning False after
+        _CONTINUE_CHECK_DELAY seconds (Claude exited immediately).
+        """
+        pane = _make_pane(["● Fresh start response."])
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            if call_idx <= 2:
+                return "Loading..."
+            return pane
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+        tmux_manager.is_claude_running.side_effect = [
+            False,  # initial check — not running
+            False,  # after --continue delay — still not running (--continue failed)
+        ]
+        tmux_manager._find_window_for_thread.return_value = "work1"
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+            patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
+        ):
+            async for event in runner.run("hello"):
+                events.append(event)
+
+        assert tmux_manager.start_claude.call_count == 2
+        # First call: try_continue=True
+        first_call = tmux_manager.start_claude.call_args_list[0]
+        assert first_call.kwargs.get("try_continue") is True
+        # Second call: try_continue=False (fresh)
+        second_call = tmux_manager.start_claude.call_args_list[1]
+        assert second_call.kwargs.get("try_continue") is False
+        assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)
+
+    @pytest.mark.asyncio
+    async def test_clear_path_uses_fresh_only(self, runner, tmux_manager) -> None:
+        """Regression: /clear kills the window; next run() must use fresh, NOT --continue.
+
+        After kill_session, create_session creates a NEW window with no conversation
+        history. --continue would fail immediately and fallback to fresh anyway —
+        but this test verifies the fallback path is correctly triggered (not that
+        --continue is skipped altogether, since the try-then-fallback is structural).
+        The key regression check: the final start_claude call uses try_continue=False
+        (fresh) so a cleared session always starts fresh.
+        """
+        # Simulate: window exists but Claude not running (new window after /clear)
+        pane = _make_pane(["● Hello, I'm fresh!"])
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            if call_idx <= 2:
+                return "Loading..."
+            return pane
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+        tmux_manager.is_claude_running.side_effect = [
+            False,  # initial check — not running (new window)
+            False,  # after --continue delay — failed (no history)
+        ]
+        tmux_manager._find_window_for_thread.return_value = "work1"
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+            patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
+        ):
+            async for event in runner.run("hello"):
+                events.append(event)
+
+        # Final (second) start_claude call MUST be fresh (try_continue=False)
+        final_call = tmux_manager.start_claude.call_args_list[-1]
+        assert final_call.kwargs.get("try_continue") is False
+        assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)


### PR DESCRIPTION
## Summary

**Problem**: After a bot restart, the tmux window survives but the Claude process dies. The next message called `start_claude` with a plain fresh `claude <prompt>`, discarding conversation context even when Claude had a resumable session.

**Fix**: `TmuxClaudeRunner.run()` now uses a `--continue` → fresh-start fallback:

1. When `is_claude_running` is False (bot restart, or new window), send `claude --continue <prompt>` first
2. Wait `_CONTINUE_CHECK_DELAY` (3s) and re-check `is_claude_running`
3. If still False (no session to resume — `--continue` exited immediately), fall back to fresh `claude <prompt>`
4. If True, `--continue` recovered context — proceed normally

**`/clear` regression safety**: `clear_session` (from PR #124) calls `kill_session` which destroys the window. `create_session` makes a NEW window for the next message. In that window `--continue` fails immediately → fallback to fresh. End result: correct fresh start, same as before.

## Changes

- `c_lord/tmux.py`: `start_claude` gains `try_continue: bool = False` — inserts `--continue` flag when True
- `c_lord/claude/tmux_runner.py`: `run()` cold-start path uses try_continue=True + `_CONTINUE_CHECK_DELAY` check + fallback to try_continue=False
- `tests/test_tmux.py`: 2 new tests for `try_continue` flag presence/absence
- `tests/test_tmux_runner.py`: `TestContinueFallback` class (3 tests) + updated `test_start_claude_fresh`

## Test plan

- [x] RED: 4 new tests fail before implementation (TypeError / assertion failures)
- [x] GREEN: all 5 new tests pass after implementation
- [x] Full suite: 1012 passed, 5 skipped (no regressions)
- [x] Lint: `ruff check` + `ruff format --check` clean
- [ ] Staging: bot restart simulation — send message, bot restart, send next message in same thread, verify context continues

## Staging verification

_Staging env has an unrelated DB schema issue (`trigger_message_id` column) causing `thread_state_sync` errors, but the `/clear` and message-routing paths are unaffected. Staging verification of the `--continue` fallback requires a live Claude session to verify context recovery; results will be noted below._

**Bot-restart scenario** (to verify in staging):
1. Send message in thread → Claude responds
2. Restart staging bot: `pgrep -f c-lord-parallel-3 | xargs kill; nohup uv run python -m c_lord.main ...`
3. Send next message in same thread
4. Expected: Claude continues with prior context (not fresh)
5. Grep staging log for `--continue found no session` — should NOT appear

**`/clear` regression check**:
1. Send message → wait for idle
2. `/clear`
3. Send next message
4. Expected: fresh Claude session (no continuation)
5. Grep log for `--continue found no session` — SHOULD appear (fallback triggered)

_Results will be added after staging run._

🤖 Generated with [Claude Code](https://claude.com/claude-code)