### PR TITLE
feat: ランプを状態機械化 🟢running/🟡waiting/🔴error (#120)

### DIFF
--- a/c_lord/thread_name.py
+++ b/c_lord/thread_name.py
@@ -1,15 +1,24 @@
-"""Discord thread-name builder/parser for the redesigned naming scheme (#95, #119).
+"""Discord thread-name builder/parser for the redesigned naming scheme (#95, #119, #120).
 
 Format::
 
-    <status_emoji> W<window_index> │ <topic>   (alive/pending, with window)
+    <status_emoji> W<window_index> │ <topic>   (running/waiting/error, with window)
     <status_emoji> <topic>                      (dead, or no window index)
 
 Examples::
 
-    🟢 W3 │ 認証まわりのリファクタ
-    🟠 W1 │ 絵本-イラスト発注
-    ⚪ 終わったプロジェクト
+    🟢 W3 │ 認証まわりのリファクタ   (running)
+    🟡 W2 │ 絵本-イラスト発注        (waiting for user input)
+    🔴 W1 │ エラーが発生             (error)
+    ⚪ 終わったプロジェクト           (dead)
+
+Lamp states (#120):
+* ``running``  → 🟢 — Claude is actively executing
+* ``waiting``  → 🟡 — waiting for user input (❯ prompt visible)
+* ``error``    → 🔴 — error detected in pane
+* ``dead``     → ⚪ — tmux window gone
+* ``alive``    → 🟢 — legacy alias for ``running``
+* ``pending``  → 🟠 — reserved for external setters
 
 Rules:
 * total length ≤ 30 chars (topic is truncated if needed to fit)
@@ -25,21 +34,28 @@ from __future__ import annotations
 import re
 
 STATUS_EMOJI: dict[str, str] = {
-    "alive": "🟢",
-    "pending": "🟠",
-    "dead": "⚪",
+    "running": "🟢",  # Claude is executing
+    "alive": "🟢",  # legacy alias for "running"
+    "waiting": "🟡",  # waiting for user input (❯ prompt visible)
+    "error": "🔴",  # error detected in pane
+    "pending": "🟠",  # reserved for external setters
+    "dead": "⚪",  # no tmux window
 }
 
 _MAX_NAME_LEN = 30
 
 # Matches an optional leading status emoji + space.
+# Use unique emoji values to avoid duplicate alternates in the regex.
 _LEADING_EMOJI_RE = re.compile(
-    r"^(?:" + "|".join(re.escape(e) for e in STATUS_EMOJI.values()) + r")\s*"
+    r"^(?:" + "|".join(re.escape(e) for e in dict.fromkeys(STATUS_EMOJI.values())) + r")\s*"
 )
 # Matches a leading "W<digits> │ " prefix (new format).
 _WORK_PREFIX_RE = re.compile(r"^W\d+\s*[│]\s*")
 # Matches a trailing " #<digits>" suffix (legacy backward-compat).
 _TRAILING_INDEX_RE = re.compile(r"\s*#\d+\s*$")
+
+# States that suppress the W<N> prefix (no window info shown).
+_NO_PREFIX_STATES = frozenset({"dead"})
 
 
 def build_name(
@@ -49,14 +65,14 @@ def build_name(
 ) -> str:
     """Build a thread name from its parts, capped at 30 characters.
 
-    Format: ``<emoji> W<N> │ <topic>`` when alive/pending with a window index.
+    Format: ``<emoji> W<N> │ <topic>`` when running/waiting/error with a window index.
     Drops the work prefix for dead state or when window index is unknown.
-    Unknown ``state`` falls back to the ``alive`` emoji.
+    Unknown ``state`` falls back to the ``alive``/🟢 emoji.
     When the combination is too long, only the topic is truncated.
     """
     emoji = STATUS_EMOJI.get(state, STATUS_EMOJI["alive"])
 
-    if state != "dead" and tmux_window_index is not None:
+    if state not in _NO_PREFIX_STATES and tmux_window_index is not None:
         fixed = f"{emoji} W{tmux_window_index} │ "
     else:
         fixed = f"{emoji} "

--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -1,13 +1,16 @@
-"""Periodic state-sync loop for Discord thread names (Issue #95).
+"""Periodic state-sync loop for Discord thread names (Issue #95, #120).
 
 Every ``poll_interval`` seconds:
 
 1. Snapshot the live tmux state with ``tmux list-windows -a`` —
    gives us each window's ``window_id`` (immutable), ``window_index``
-   (volatile hint), and the ``@thread_id`` window option.
+   (volatile hint), ``window_name``, ``session_name``, and the
+   ``@thread_id`` window option.
 2. For each session row in the DB, compute the new ``state``:
-   * ``alive``  → a tmux window still exists for this thread
-   * ``dead``   → no tmux window exists
+   * ``running``  → tmux window exists and Claude is actively executing
+   * ``waiting``  → tmux window exists and the ❯ input prompt is visible
+   * ``error``    → tmux window exists and error indicators found in pane
+   * ``dead``     → no tmux window exists
    * ``pending`` is reserved for explicit external setters and is
      never produced by this loop.
 3. If the state changed (or the volatile window-index moved, or the
@@ -17,7 +20,7 @@ Every ``poll_interval`` seconds:
 
 The loop deliberately never touches the ``topic`` body — that is
 the user-visible stable identity. Only the leading status emoji and
-the trailing ``#N`` window-index hint are kept fresh.
+the trailing ``W<N> │`` window-index hint are kept fresh.
 """
 
 from __future__ import annotations
@@ -39,10 +42,80 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Format: <session_name>|<window_id>|<window_index>|<@thread_id>
-_LIST_WINDOWS_FORMAT = "#{session_name}|#{window_id}|#{window_index}|#{@thread_id}"
+# Format: <session_name>|<window_id>|<window_index>|<@thread_id>|<window_name>
+_LIST_WINDOWS_FORMAT = "#{session_name}|#{window_id}|#{window_index}|#{@thread_id}|#{window_name}"
 
 _DEFAULT_INTERVAL_SECONDS = 60.0
+
+# How many bottom lines of the pane to check for prompt/error indicators.
+_PANE_PROBE_LINES = 6
+
+# Characters that indicate Claude Code's input prompt (waiting for user).
+_WAITING_PROMPTS = frozenset({"❯", ">"})
+
+# Substrings that indicate an error state (checked in the bottom pane lines).
+_ERROR_INDICATORS = (
+    "APIError",
+    "Error:",
+    "error:",
+    "Fatal error",
+    "Traceback (most recent",
+)
+
+# Number of pane lines to capture for state detection (kept small for speed).
+_PANE_CAPTURE_LINES = 20
+
+
+def _pane_lamp_state(pane_text: str) -> str:
+    """Determine lamp state from captured pane content.
+
+    Returns one of ``'running'``, ``'waiting'``, or ``'error'``.
+    Error takes highest priority; waiting is detected from the bare
+    ``❯``/``>`` prompt; otherwise the state is ``'running'``.
+    """
+    if not pane_text:
+        return "running"
+    lines = pane_text.rstrip().splitlines()
+    tail = lines[-_PANE_PROBE_LINES:]
+
+    for line in tail:
+        for indicator in _ERROR_INDICATORS:
+            if indicator in line:
+                return "error"
+
+    for line in tail:
+        if line.strip() in _WAITING_PROMPTS:
+            return "waiting"
+
+    return "running"
+
+
+def _capture_pane_text(
+    session_name: str, window_name: str, lines: int = _PANE_CAPTURE_LINES
+) -> str:
+    """Run ``tmux capture-pane`` for the given session:window and return raw text."""
+    if not session_name or not window_name:
+        return ""
+    try:
+        result = subprocess.run(
+            [
+                "tmux",
+                "capture-pane",
+                "-p",
+                "-J",
+                "-t",
+                f"{session_name}:{window_name}",
+                "-S",
+                f"-{lines}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout
 
 
 def _list_all_windows() -> list[dict[str, str]]:
@@ -72,6 +145,7 @@ def _list_all_windows() -> list[dict[str, str]]:
                 "window_id": parts[1],
                 "window_index": parts[2],
                 "thread_id": parts[3] if len(parts) > 3 else "",
+                "window_name": parts[4] if len(parts) > 4 else "",
             }
         )
     return out
@@ -151,10 +225,15 @@ class ThreadStateSyncLoop:
         window_info = by_tid.get(thread_id)
 
         if window_info is not None:
-            new_state = "alive"
             window_id = window_info["window_id"] or None
             idx_str = window_info.get("window_index") or ""
             window_index: int | None = int(idx_str) if idx_str.isdigit() else None
+
+            # Detect fine-grained lamp state from pane content (#120).
+            session_name = window_info.get("session_name", "")
+            window_name = window_info.get("window_name", "")
+            pane_text = await asyncio.to_thread(_capture_pane_text, session_name, window_name)
+            new_state = _pane_lamp_state(pane_text)
         else:
             new_state = "dead"
             window_id = record.tmux_window_id

--- a/tests/test_thread_name.py
+++ b/tests/test_thread_name.py
@@ -10,6 +10,25 @@ def test_build_name_alive_with_index():
     assert build_name("c-lord命名検討", "alive", 5) == "🟢 W5 │ c-lord命名検討"
 
 
+def test_build_name_running_with_index():
+    # "running" maps to 🟢 same as "alive"
+    assert build_name("c-lord命名検討", "running", 5) == "🟢 W5 │ c-lord命名検討"
+
+
+def test_build_name_waiting_with_index():
+    out = build_name("topic", "waiting", 3)
+    assert out.startswith(STATUS_EMOJI["waiting"])  # 🟡
+    assert "W3 │" in out
+    assert "topic" in out
+
+
+def test_build_name_error_with_index():
+    out = build_name("topic", "error", 2)
+    assert out.startswith(STATUS_EMOJI["error"])  # 🔴
+    assert "W2 │" in out
+    assert "topic" in out
+
+
 def test_build_name_pending_with_index():
     out = build_name("topic", "pending", 3)
     assert out.startswith(STATUS_EMOJI["pending"])
@@ -31,6 +50,11 @@ def test_build_name_no_index():
     assert out == "🟢 topic"
 
 
+def test_build_name_running_no_index():
+    out = build_name("topic", "running", None)
+    assert out == "🟢 topic"
+
+
 def test_build_name_truncates_long_topic():
     long = "あ" * 100
     out = build_name(long, "alive", 12)
@@ -44,10 +68,12 @@ def test_build_name_unknown_state_falls_back_to_alive_emoji():
 
 
 def test_parse_strips_leading_emoji_and_work_prefix():
-    # New format
+    # New format — includes new emojis
     assert parse_topic_from_name("🟢 W5 │ c-lord命名検討") == "c-lord命名検討"
     assert parse_topic_from_name("⚪ 絵本") == "絵本"
     assert parse_topic_from_name("🟠 W12 │ t") == "t"
+    assert parse_topic_from_name("🟡 W3 │ 入力待ちtopic") == "入力待ちtopic"
+    assert parse_topic_from_name("🔴 W1 │ エラーtopic") == "エラーtopic"
 
 
 def test_parse_handles_old_trailing_index_format():
@@ -71,6 +97,12 @@ def test_parse_returns_empty_for_emoji_only():
 def test_build_then_parse_roundtrip():
     topic = "やること整理"
     name = build_name(topic, "alive", 3)
+    assert parse_topic_from_name(name) == topic
+
+
+def test_build_then_parse_roundtrip_waiting():
+    topic = "入力待ちwork"
+    name = build_name(topic, "waiting", 2)
     assert parse_topic_from_name(name) == topic
 
 

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -12,6 +12,7 @@ from c_lord.thread_state_sync import (
     ThreadStateSyncLoop,
     _index_by_thread_id,
     _list_all_windows,
+    _pane_lamp_state,
 )
 
 
@@ -35,9 +36,9 @@ class _Rec:
 
 def test_index_by_thread_id_keeps_only_digit_tids():
     windows = [
-        {"session_name": "s", "window_id": "@1", "window_index": "0", "thread_id": "12345"},
-        {"session_name": "s", "window_id": "@2", "window_index": "1", "thread_id": ""},
-        {"session_name": "s", "window_id": "@3", "window_index": "2", "thread_id": "abc"},
+        {"session_name": "s", "window_id": "@1", "window_index": "0", "thread_id": "12345", "window_name": "work1"},
+        {"session_name": "s", "window_id": "@2", "window_index": "1", "thread_id": "", "window_name": "work2"},
+        {"session_name": "s", "window_id": "@3", "window_index": "2", "thread_id": "abc", "window_name": "work3"},
     ]
     out = _index_by_thread_id(windows)
     assert list(out.keys()) == [12345]
@@ -55,13 +56,54 @@ def test_list_all_windows_returns_empty_on_nonzero_exit():
 
 
 def test_list_all_windows_parses_pipe_format():
-    fake = MagicMock(returncode=0, stdout="clord|@7|3|12345\nother|@1|0|\n")
+    fake = MagicMock(returncode=0, stdout="clord|@7|3|12345|work1\nother|@1|0||work2\n")
     with patch.object(thread_state_sync.subprocess, "run", return_value=fake):
         out = _list_all_windows()
     assert out[0]["window_id"] == "@7"
     assert out[0]["window_index"] == "3"
     assert out[0]["thread_id"] == "12345"
+    assert out[0]["window_name"] == "work1"
+    assert out[0]["session_name"] == "clord"
 
+
+# ── _pane_lamp_state tests ────────────────────────────────────────────────────
+
+def test_pane_lamp_state_waiting_when_bare_prompt():
+    pane = "Some content\n❯\n"
+    assert _pane_lamp_state(pane) == "waiting"
+
+
+def test_pane_lamp_state_waiting_gt_prompt():
+    pane = "Some content\n>\n"
+    assert _pane_lamp_state(pane) == "waiting"
+
+
+def test_pane_lamp_state_running_when_no_prompt():
+    pane = "✻ Running bash...\n● Some response text\n"
+    assert _pane_lamp_state(pane) == "running"
+
+
+def test_pane_lamp_state_error_when_api_error():
+    pane = "Some content\nAPIError: rate limit exceeded\n❯\n"
+    assert _pane_lamp_state(pane) == "error"
+
+
+def test_pane_lamp_state_error_colon_pattern():
+    pane = "Processing...\nError: connection refused\n"
+    assert _pane_lamp_state(pane) == "error"
+
+
+def test_pane_lamp_state_empty_returns_running():
+    assert _pane_lamp_state("") == "running"
+
+
+def test_pane_lamp_state_error_takes_priority_over_waiting():
+    # Error has higher priority than waiting prompt
+    pane = "APIError: something\n❯\n"
+    assert _pane_lamp_state(pane) == "error"
+
+
+# ── _sync_one tests ───────────────────────────────────────────────────────────
 
 async def test_sync_one_marks_dead_and_renames():
     repo = MagicMock()
@@ -79,7 +121,7 @@ async def test_sync_one_marks_dead_and_renames():
     repo.set_state.assert_awaited_once_with(111, "dead")
 
 
-async def test_sync_one_alive_with_index_renames_when_name_differs():
+async def test_sync_one_running_when_no_prompt_in_pane():
     repo = MagicMock()
     repo.set_state = AsyncMock()
     repo.set_tmux_window_id = AsyncMock()
@@ -93,22 +135,79 @@ async def test_sync_one_alive_with_index_renames_when_name_differs():
     with patch.object(discord, "Thread", fake_thread.__class__):
         bot = MagicMock()
         bot.get_channel.return_value = fake_thread
-        # Force isinstance check to pass
         loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
         rec = _Rec(thread_id=222, state="dead", topic="やること", tmux_window_id=None)
-        by_tid = {222: {"window_id": "@9", "window_index": "4", "thread_id": "222"}}
+        by_tid = {222: {"window_id": "@9", "window_index": "4", "thread_id": "222",
+                        "session_name": "clord", "window_name": "work1"}}
 
-        with patch.object(thread_state_sync, "discord") as discord_mock:
+        with patch.object(thread_state_sync, "discord") as discord_mock, \
+             patch.object(thread_state_sync, "_capture_pane_text", return_value="● response text\n") as _cap:
             discord_mock.Thread = fake_thread.__class__
             discord_mock.HTTPException = Exception
             await loop._sync_one(rec, by_tid)
 
-    repo.set_state.assert_awaited_once_with(222, "alive")
+    repo.set_state.assert_awaited_once_with(222, "running")
     repo.set_tmux_window_id.assert_awaited_once_with(222, "@9")
     fake_thread.edit.assert_awaited_once()
     kwargs = fake_thread.edit.await_args.kwargs
     assert "やること" in kwargs["name"]
     assert "W4" in kwargs["name"]
+
+
+async def test_sync_one_waiting_when_prompt_visible():
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock()
+
+    import discord
+
+    with patch.object(discord, "Thread", fake_thread.__class__):
+        bot = MagicMock()
+        bot.get_channel.return_value = fake_thread
+        loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
+        rec = _Rec(thread_id=333, state="running", topic="入力待ち", tmux_window_id=None)
+        by_tid = {333: {"window_id": "@5", "window_index": "2", "thread_id": "333",
+                        "session_name": "clord", "window_name": "work2"}}
+
+        with patch.object(thread_state_sync, "discord") as discord_mock, \
+             patch.object(thread_state_sync, "_capture_pane_text", return_value="● done\n❯\n"):
+            discord_mock.Thread = fake_thread.__class__
+            discord_mock.HTTPException = Exception
+            await loop._sync_one(rec, by_tid)
+
+    repo.set_state.assert_awaited_once_with(333, "waiting")
+
+
+async def test_sync_one_error_when_error_in_pane():
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock()
+
+    import discord
+
+    with patch.object(discord, "Thread", fake_thread.__class__):
+        bot = MagicMock()
+        bot.get_channel.return_value = fake_thread
+        loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
+        rec = _Rec(thread_id=444, state="running", topic="エラー発生", tmux_window_id=None)
+        by_tid = {444: {"window_id": "@6", "window_index": "3", "thread_id": "444",
+                        "session_name": "clord", "window_name": "work3"}}
+
+        with patch.object(thread_state_sync, "discord") as discord_mock, \
+             patch.object(thread_state_sync, "_capture_pane_text", return_value="APIError: rate limit\n"):
+            discord_mock.Thread = fake_thread.__class__
+            discord_mock.HTTPException = Exception
+            await loop._sync_one(rec, by_tid)
+
+    repo.set_state.assert_awaited_once_with(444, "error")
 
 
 async def test_sync_one_skips_rename_when_no_topic():


### PR DESCRIPTION
## Summary
- スレッドタイトルのランプを状態機械化 (closes #120)
- tmuxペイン末尾6行を60秒ごとに参照し状態を判定
  - `❯` or `>` プロンプト検出 → 🟡 waiting (入力待ち)
  - `APIError:` / `Error:` 等のエラーパターン → 🔴 error
  - その他 window 存在 → 🟢 running
  - window なし → ⚪ dead
- `"alive"` は 🟢 の legacy alias として後方互換維持

## Changes
- `c_lord/thread_name.py`: STATUS_EMOJI に running/waiting/error/dead 追加
- `c_lord/thread_state_sync.py`: `_pane_lamp_state()` / `_capture_pane_text()` 追加、`_sync_one` でペイン状態検出
- `tests/test_thread_name.py`: 新状態のテスト追加 (18件)
- `tests/test_thread_state_sync.py`: `_pane_lamp_state` テスト + 統合テスト追加 (17件)

## Test plan
- [ ] `uv run pytest tests/test_thread_name.py tests/test_thread_state_sync.py -v` → 35件 pass
- [ ] `uv run pytest tests/ -q` → 全件 pass
- [ ] staging bot 再起動後、Claude実行中は 🟢、応答完了後に 🟡 に切り替わること（60秒以内）
- [ ] エラーが発生したスレッドで 🔴 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)