### PR TITLE
feat: タイトル自動再要約 — AI丸投げ+verbatim強制+差分時のみAPI (#121)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -20,6 +20,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from .. import topic as topic_module
 from ..claude.config import ClaudeConfig
 from ..claude.tmux_runner import TmuxClaudeRunner
 from ..concurrency import SessionRegistry
@@ -230,7 +231,6 @@ class ClaudeChatCog(commands.Cog):
         on truly unexpected programmer mistakes.
         """
         from ..thread_name import build_name, parse_topic_from_name
-        from ..topic import generate_topic, heuristic_topic
 
         record = await self.repo.get(thread.id)
         topic = record.topic if record else None
@@ -259,13 +259,27 @@ class ClaudeChatCog(commands.Cog):
         else:
             window_index = None
 
-        # Derive topic if missing and not locked.
+        # Re-summarize title on subsequent messages (#121).
+        # Only runs when a topic already exists and the thread is not manually
+        # renamed (locked).  Returns None when the LLM deems the current topic
+        # still valid (verbatim match) — so no rename API call is triggered.
+        if topic and not locked:
+            with contextlib.suppress(Exception):
+                new_topic = await topic_module.maybe_retitle(first_message or "", topic)
+                if new_topic is not None:
+                    if record is not None:
+                        await self.repo.set_topic(thread.id, new_topic, source="llm_retitle")
+                    else:
+                        self._pending_topic[thread.id] = (new_topic, "llm_retitle")
+                    topic = new_topic
+
+        # Derive topic if missing and not locked (first message).
         if not topic and not locked:
             try:
-                topic, source = await generate_topic(first_message or "")
+                topic, source = await topic_module.generate_topic(first_message or "")
             except Exception:
                 logger.warning("topic generation failed", exc_info=True)
-                topic, source = heuristic_topic(first_message or ""), "heuristic"
+                topic, source = topic_module.heuristic_topic(first_message or ""), "heuristic"
             if record is not None:
                 await self.repo.set_topic(thread.id, topic, source=source)
             else:

--- a/c_lord/topic.py
+++ b/c_lord/topic.py
@@ -1,4 +1,4 @@
-"""Stable-topic generator for Discord threads (Issue #95).
+"""Stable-topic generator for Discord threads (Issue #95, #121).
 
 Given the first user message of a new thread, derive a short Japanese
 topic body (≤20 chars) that will be stored as the thread's stable
@@ -12,6 +12,14 @@ identity.  Two paths:
 The caller stores the returned ``(topic, source)`` tuple in the
 ``sessions`` table — ``source`` is one of ``"llm"`` / ``"heuristic"``
 and is kept for debugging.
+
+Re-summarization (#121):
+``maybe_retitle(message, current_topic)`` runs on subsequent messages
+to detect work changes.  It:
+  1. Gates on instruction-like messages (skips questions / short replies).
+  2. Asks haiku to return the current topic verbatim if still applicable,
+     or a new ≤20-char topic if the work changed.
+  3. Returns None when the output equals ``current_topic`` (no rename needed).
 """
 
 from __future__ import annotations
@@ -30,6 +38,12 @@ _LLM_TIMEOUT_SECONDS = 10.0
 _LLM_PROMPT_TEMPLATE = (
     "次の発言を20字以内の日本語トピックに要約してください。記号や絵文字は使わず簡潔に。: {msg}"
 )
+_RETITLE_PROMPT_TEMPLATE = (
+    "前のタイトル「{current_topic}」。"
+    "次のメッセージを見て、このWorkのタイトルとしてまだ適切なら「{current_topic}」を一字一句そのまま返せ。"
+    "Workの内容が根本的に変わった場合のみ20字以内の日本語で新タイトルを返せ。"
+    "余計な説明・記号・絵文字は不要。タイトルだけ返せ。: {msg}"
+)
 
 _URL_RE = re.compile(r"https?://\S+")
 _MENTION_RE = re.compile(r"<[@#!&][^>]+>|@\w+")
@@ -37,6 +51,9 @@ _CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`]*`")
 _WHITESPACE_RE = re.compile(r"\s+")
 _FALLBACK_TOPIC = "新しいスレッド"
+
+# Minimum length for a message to be considered instruction-like.
+_INSTRUCTION_MIN_LEN = 15
 
 
 def heuristic_topic(first_message: str) -> str:
@@ -57,13 +74,26 @@ def heuristic_topic(first_message: str) -> str:
     return text[:_TOPIC_MAX_LEN]
 
 
-async def _invoke_claude_haiku(first_message: str) -> str | None:
-    """Call ``claude -p --model haiku`` and return its trimmed stdout.
+def _looks_like_instruction(message: str) -> bool:
+    """Return True when the message is instruction-like (not a question/short reply).
 
-    Returns None on any failure (non-zero exit, timeout, empty output,
-    OSError when the binary is missing, etc.). Never raises.
+    Used as a lightweight gate before invoking the retitle LLM — skips
+    short messages and clear questions so the LLM is not called on every
+    back-and-forth exchange.
     """
-    prompt = _LLM_PROMPT_TEMPLATE.format(msg=first_message)
+    msg = message.strip()
+    if len(msg) < _INSTRUCTION_MIN_LEN:
+        return False
+    # Questions typically end with ? or ？
+    return not (msg.endswith("?") or msg.endswith("？"))
+
+
+async def _call_claude_p(prompt: str) -> str | None:
+    """Call ``claude -p --model haiku`` with the given raw prompt string.
+
+    Returns the trimmed, quote-stripped response or None on any failure.
+    Never raises.
+    """
     try:
         proc = await asyncio.create_subprocess_exec(
             "claude",
@@ -96,13 +126,21 @@ async def _invoke_claude_haiku(first_message: str) -> str | None:
         return None
 
     raw = (stdout or b"").decode("utf-8", errors="replace").strip()
-    # The model sometimes wraps output in quotes or adds trailing punctuation.
     raw = raw.strip("「」\"' \n\r\t　。.")
     if not raw:
         return None
-    # Collapse any internal whitespace and clip to the limit.
     raw = _WHITESPACE_RE.sub(" ", raw)
     return raw[:_TOPIC_MAX_LEN]
+
+
+async def _invoke_claude_haiku(first_message: str) -> str | None:
+    """Call ``_call_claude_p`` with the standard topic-generation prompt.
+
+    Returns None on any failure.  Preserved as a named function so that
+    existing tests can patch it by name.
+    """
+    prompt = _LLM_PROMPT_TEMPLATE.format(msg=first_message)
+    return await _call_claude_p(prompt)
 
 
 async def generate_topic(first_message: str) -> tuple[str, str]:
@@ -123,3 +161,29 @@ async def generate_topic(first_message: str) -> tuple[str, str]:
     if llm:
         return llm, "llm"
     return heuristic_topic(first_message), "heuristic"
+
+
+async def maybe_retitle(message: str, current_topic: str) -> str | None:
+    """Return a new topic if the message warrants a retitle, else None (#121).
+
+    Gate: skips short messages and questions (returns None immediately).
+    LLM: asked to return ``current_topic`` verbatim if still applicable,
+    or a new ≤20-char topic when the work has fundamentally changed.
+    Comparison: returns None when LLM output equals ``current_topic``
+    byte-for-byte (no Discord rename needed).
+
+    On any LLM failure, returns None (no retitle — safe default).
+    """
+    if not _looks_like_instruction(message):
+        return None
+
+    prompt = _RETITLE_PROMPT_TEMPLATE.format(current_topic=current_topic, msg=message)
+    try:
+        new_topic = await _call_claude_p(prompt)
+    except Exception:
+        logger.debug("maybe_retitle: LLM call failed", exc_info=True)
+        return None
+
+    if not new_topic or new_topic == current_topic:
+        return None
+    return new_topic

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1524,3 +1524,103 @@ class TestClearCommand:
 
         interaction.response.send_message.assert_called_once()
         assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+class TestApplyThreadNamingRetitle:
+    """Unit tests for the auto-retitle hook in _apply_thread_naming (#121)."""
+
+    def _make_cog_with_repo(self, record):
+        """Return (cog, thread, tmux_manager) with a pre-configured repo record."""
+        from unittest.mock import patch as _patch
+
+        cog = _make_cog()
+        cog.repo.get = AsyncMock(return_value=record)
+        cog.repo.set_topic = AsyncMock()
+        cog.repo.set_tmux_window_id = AsyncMock()
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 55555
+        thread.name = "🟢 W1 │ 認証リファクタ"
+
+        tmux_manager = MagicMock()
+        tmux_manager.get_window_info = MagicMock(return_value=("@1", 1))
+
+        return cog, thread, tmux_manager
+
+    def _make_record(self, *, topic, locked=0, state="running"):
+        record = MagicMock()
+        record.topic = topic
+        record.auto_topic_locked = locked
+        record.state = state
+        record.tmux_window_id = "@1"
+        return record
+
+    @pytest.mark.asyncio
+    async def test_retitle_updates_topic_and_renames_when_changed(self):
+        """When maybe_retitle returns a new topic, DB is updated and thread renamed."""
+        from unittest.mock import patch
+
+        from c_lord.cogs import claude_chat as cc_module
+
+        record = self._make_record(topic="認証リファクタ")
+        cog, thread, tmux = self._make_cog_with_repo(record)
+        thread.name = "🟢 W1 │ 認証リファクタ"
+
+        instruction = "次はDockerfileを最適化してCI/CDを改善してください"
+
+        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value="Dockerfileの最適化")):
+            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message=instruction)
+
+        cog.repo.set_topic.assert_awaited_once_with(55555, "Dockerfileの最適化", source="llm_retitle")
+        thread.edit.assert_awaited_once()
+        call_name = thread.edit.await_args.kwargs.get("name", thread.edit.await_args.args[0] if thread.edit.await_args.args else "")
+        assert "Dockerfileの最適化" in call_name
+
+    @pytest.mark.asyncio
+    async def test_retitle_skips_rename_when_verbatim(self):
+        """When maybe_retitle returns None (verbatim), DB and rename are not called."""
+        from unittest.mock import patch
+
+        from c_lord.cogs import claude_chat as cc_module
+
+        record = self._make_record(topic="認証リファクタ")
+        cog, thread, tmux = self._make_cog_with_repo(record)
+        thread.name = "🟢 W1 │ 認証リファクタ"
+
+        instruction = "認証リファクタを引き続きお願いします"
+
+        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value=None)):
+            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message=instruction)
+
+        cog.repo.set_topic.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retitle_skips_when_locked(self):
+        """When auto_topic_locked=1, maybe_retitle must not be called."""
+        from unittest.mock import patch
+
+        from c_lord.cogs import claude_chat as cc_module
+
+        record = self._make_record(topic="認証リファクタ", locked=1)
+        cog, thread, tmux = self._make_cog_with_repo(record)
+
+        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value="new")) as mock_retitle:
+            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="何か作業してください")
+
+        mock_retitle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retitle_skips_when_no_existing_topic(self):
+        """First message (no existing topic) should use initial generation, not retitle."""
+        from unittest.mock import patch
+
+        from c_lord.cogs import claude_chat as cc_module
+
+        record = self._make_record(topic=None)
+        cog, thread, tmux = self._make_cog_with_repo(record)
+
+        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock()) as mock_retitle, \
+             patch.object(cc_module.topic_module, "generate_topic", new=AsyncMock(return_value=("初回トピック", "llm"))):
+            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="初回メッセージです")
+
+        mock_retitle.assert_not_awaited()

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -87,5 +87,94 @@ async def test_generate_topic_never_raises_on_internal_exception():
     assert body
 
 
+# ── _looks_like_instruction tests ─────────────────────────────────────────────
+
+def test_looks_like_instruction_short_returns_false():
+    assert topic._looks_like_instruction("OK") is False
+    assert topic._looks_like_instruction("ありがとう") is False
+    assert topic._looks_like_instruction("わかった") is False
+
+
+def test_looks_like_instruction_question_ending_returns_false():
+    assert topic._looks_like_instruction("この部分はどういう意味ですか？") is False
+    assert topic._looks_like_instruction("what does this do?") is False
+
+
+def test_looks_like_instruction_long_instruction_returns_true():
+    assert topic._looks_like_instruction("認証まわりのリファクタをしてください") is True
+    assert topic._looks_like_instruction("ユーザー登録フローを実装してほしい") is True
+
+
+def test_looks_like_instruction_medium_length_instruction():
+    assert topic._looks_like_instruction("Dockerfileを修正して最適化して") is True
+
+
+# ── maybe_retitle tests ────────────────────────────────────────────────────────
+
+async def test_maybe_retitle_skips_short_message():
+    result = await topic.maybe_retitle("OK", "認証リファクタ")
+    assert result is None
+
+
+async def test_maybe_retitle_skips_question():
+    result = await topic.maybe_retitle("この実装はなぜこうなっているのですか？", "認証リファクタ")
+    assert result is None
+
+
+async def test_maybe_retitle_verbatim_returns_none():
+    # LLM returns same topic verbatim → no change
+    async def fake_call(_prompt: str) -> str | None:
+        return "認証リファクタ"
+
+    with patch.object(topic, "_call_claude_p", fake_call):
+        result = await topic.maybe_retitle("認証のリファクタを続けて進めてください", "認証リファクタ")
+    assert result is None  # verbatim → no change
+
+
+async def test_maybe_retitle_changed_returns_new_topic():
+    # LLM detects work changed → returns new topic
+    async def fake_call(_prompt: str) -> str | None:
+        return "Dockerfileの最適化"
+
+    with patch.object(topic, "_call_claude_p", fake_call):
+        result = await topic.maybe_retitle(
+            "次はDockerfileを最適化してCI/CDを改善してください", "認証リファクタ"
+        )
+    assert result == "Dockerfileの最適化"
+
+
+async def test_maybe_retitle_llm_failure_returns_none():
+    async def fake_call(_prompt: str) -> str | None:
+        return None
+
+    with patch.object(topic, "_call_claude_p", fake_call):
+        result = await topic.maybe_retitle("新しい作業に切り替えてください", "認証リファクタ")
+    assert result is None
+
+
+async def test_maybe_retitle_llm_exception_returns_none():
+    async def boom(_prompt: str) -> str | None:
+        raise RuntimeError("network error")
+
+    with patch.object(topic, "_call_claude_p", boom):
+        result = await topic.maybe_retitle("新しい作業に切り替えてください", "認証リファクタ")
+    assert result is None
+
+
+async def test_maybe_retitle_passes_current_topic_in_prompt():
+    """Verify the current topic is embedded in the retitle prompt."""
+    captured: list[str] = []
+
+    async def fake_call(prompt: str) -> str | None:
+        captured.append(prompt)
+        return "別のトピック"
+
+    with patch.object(topic, "_call_claude_p", fake_call):
+        await topic.maybe_retitle("全然違う作業をお願いしたいのですが", "認証リファクタ")
+
+    assert captured, "LLM should have been called"
+    assert "認証リファクタ" in captured[0], "current topic must appear in prompt"
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__])


### PR DESCRIPTION
## Summary
- 指示メッセージ受信時にのみ再要約判定が走る (closes #121)
- 前回トピックをプロンプトに渡し「まだ Work を説明できるなら一字一句そのまま返せ」と指示
- 返りが現トピックと**完全一致**ならリネーム API を呼ばない
- 差分がある場合のみ `set_topic` + `thread.edit` を実行

## 設計詳細
### ゲート (`_looks_like_instruction`)
- 15文字未満 → スキップ (短い返事・相槌)
- `?` / `？` 終端 → スキップ (質問の往復)
- それ以外 → LLM に投げる

### LLM 呼び出し (`maybe_retitle`)
- `claude -p --model haiku` に前回トピックを含むプロンプトを送る
- 返りが `current_topic` と完全一致 → `None` (変更なし)
- 返りが異なる → 新トピックを返す

### 統合点 (`_apply_thread_naming`)
- `topic` 存在 かつ `auto_topic_locked=False` のときのみ `maybe_retitle` を呼ぶ
- 初回メッセージ (topic=None) は従来の `generate_topic` パスを使用

## Changes
- `c_lord/topic.py`: `_call_claude_p`, `_looks_like_instruction`, `maybe_retitle` 追加
- `c_lord/cogs/claude_chat.py`: `topic_module` をモジュールレベルでインポート、retitle フック追加
- `tests/test_topic.py`: 11件のテスト追加 (21件 all pass)
- `tests/test_claude_chat.py`: `TestApplyThreadNamingRetitle` クラス追加 (4件)

## Test plan
- [ ] `uv run pytest tests/test_topic.py tests/test_claude_chat.py::TestApplyThreadNamingRetitle -v` → 25件 pass
- [ ] `uv run pytest tests/ -q` → 全件 pass
- [ ] staging: 同じ作業を続けるメッセージ → タイトル変わらない
- [ ] staging: 明らかに別の作業への切り替えメッセージ → タイトルが更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)