### PR TITLE
fix: limit --continue to restart-resume path only

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -184,6 +184,7 @@ class TmuxClaudeRunner:
         timeout_seconds: int = 300,
         permission_mode: str = "acceptEdits",
         dangerously_skip_permissions: bool = False,
+        try_continue: bool = False,
     ) -> None:
         self._tmux = tmux_manager
         self._thread_id = thread_id
@@ -192,6 +193,10 @@ class TmuxClaudeRunner:
         self.timeout_seconds = timeout_seconds
         self._permission_mode = permission_mode
         self._dangerously_skip_permissions = dangerously_skip_permissions
+        # True only for the restart-resume path (on_ready → pending_resumes).
+        # /clear and normal new threads must remain False to prevent --continue
+        # from recovering cleared conversation history (issue #123 Part 2 fix).
+        self._try_continue = try_continue
         self._stopped = False
         self._silent_stop = False
         self._last_capture: str = ""
@@ -237,37 +242,59 @@ class TmuxClaudeRunner:
                 )
                 return
         else:
-            # Try --continue first to recover context after a bot restart.
-            # If Claude exits immediately (no session to resume), fall back to
-            # a plain fresh start (issue #123 Part 2).
-            ok = await asyncio.to_thread(
-                self._tmux.start_claude,
-                self._thread_id,
-                prompt,
-                self.model,
-                permission_mode=self._permission_mode,
-                dangerously_skip_permissions=self._dangerously_skip_permissions,
-                try_continue=True,
-            )
-            if not ok:
-                yield StreamEvent(
-                    raw={},
-                    message_type=MessageType.RESULT,
-                    is_complete=True,
-                    error="Failed to start Claude in tmux",
-                )
-                return
-
-            # Wait briefly and check whether --continue actually started Claude.
-            await asyncio.sleep(_CONTINUE_CHECK_DELAY)
-            still_running = await asyncio.to_thread(self._tmux.is_claude_running, self._thread_id)
-            if not still_running:
-                # --continue failed (no session to resume); start fresh.
-                logger.info(
-                    "start_claude --continue found no session for thread %d; "
-                    "falling back to fresh start",
+            if self._try_continue:
+                # Restart-resume path only (on_ready → pending_resumes).
+                # Try --continue first; if Claude exits immediately (no session),
+                # fall back to a fresh start (issue #123 Part 2).
+                ok = await asyncio.to_thread(
+                    self._tmux.start_claude,
                     self._thread_id,
+                    prompt,
+                    self.model,
+                    permission_mode=self._permission_mode,
+                    dangerously_skip_permissions=self._dangerously_skip_permissions,
+                    try_continue=True,
                 )
+                if not ok:
+                    yield StreamEvent(
+                        raw={},
+                        message_type=MessageType.RESULT,
+                        is_complete=True,
+                        error="Failed to start Claude in tmux",
+                    )
+                    return
+
+                # Wait briefly; if Claude still not running, --continue failed.
+                await asyncio.sleep(_CONTINUE_CHECK_DELAY)
+                still_running = await asyncio.to_thread(
+                    self._tmux.is_claude_running, self._thread_id
+                )
+                if not still_running:
+                    logger.info(
+                        "start_claude --continue found no session for thread %d; "
+                        "falling back to fresh start",
+                        self._thread_id,
+                    )
+                    ok = await asyncio.to_thread(
+                        self._tmux.start_claude,
+                        self._thread_id,
+                        prompt,
+                        self.model,
+                        permission_mode=self._permission_mode,
+                        dangerously_skip_permissions=self._dangerously_skip_permissions,
+                        try_continue=False,
+                    )
+                    if not ok:
+                        yield StreamEvent(
+                            raw={},
+                            message_type=MessageType.RESULT,
+                            is_complete=True,
+                            error="Failed to start Claude in tmux",
+                        )
+                        return
+            else:
+                # Normal cold start: /clear, new thread, any non-resume path.
+                # Always fresh — never --continue (would recover cleared history).
                 ok = await asyncio.to_thread(
                     self._tmux.start_claude,
                     self._thread_id,

--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -669,6 +669,7 @@ class ClaudeChatCog(commands.Cog):
                         thread,
                         resume_prompt,
                         session_id=entry.session_id,
+                        try_continue=True,
                     )
                 )
             except Exception:
@@ -783,6 +784,7 @@ class ClaudeChatCog(commands.Cog):
         prompt: str,
         session_id: str | None,
         image_paths: list[str] | None = None,
+        try_continue: bool = False,
     ) -> None:
         """Execute Claude Code CLI and stream results to the thread."""
         # Unbound channel check: verify /clord-init or /clord-thread-init binding
@@ -884,6 +886,7 @@ class ClaudeChatCog(commands.Cog):
                 working_dir=working_dir,
                 timeout_seconds=self.runner.timeout_seconds,
                 dangerously_skip_permissions=True,
+                try_continue=try_continue,
             )
 
             self._active_runners[thread.id] = runner

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -952,25 +952,19 @@ class TestTmuxClaudeRunnerRun:
 
     @pytest.mark.asyncio
     async def test_start_claude_fresh(self, runner, tmux_manager) -> None:
-        """When Claude is not running, start_claude(try_continue=True) is called first.
-
-        If --continue succeeds (is_claude_running returns True after the delay),
-        only one start_claude call is made.
-        """
+        """Default runner: when Claude is not running, start_claude with try_continue=False."""
         pane = _make_pane(["● Hello!"])
         call_idx = 0
 
         def capture_fn(tid):
             nonlocal call_idx
             call_idx += 1
-            # First few calls are during _handle_startup_prompts.
             if call_idx <= 2:
                 return "Loading..."
             return pane
 
         tmux_manager.capture_pane.side_effect = capture_fn
-        # Simulate: cold start (not running) → --continue succeeds
-        tmux_manager.is_claude_running.side_effect = [False, True]
+        tmux_manager.is_claude_running.return_value = False
         tmux_manager._find_window_for_thread.return_value = "work1"
 
         events = []
@@ -979,19 +973,18 @@ class TestTmuxClaudeRunnerRun:
             patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
             patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
             patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
-            patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
         ):
             async for event in runner.run("test prompt"):
                 events.append(event)
 
-        # Only one start_claude call (--continue succeeded)
+        # Exactly one start_claude call with try_continue=False (direct fresh)
         tmux_manager.start_claude.assert_called_once_with(
             12345,
             "test prompt",
             "sonnet",
             permission_mode="acceptEdits",
             dangerously_skip_permissions=False,
-            try_continue=True,
+            try_continue=False,
         )
         assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)
 
@@ -1382,21 +1375,28 @@ class TestExtractResponsePreservesHyperlinks:
 
 
 class TestContinueFallback:
-    """Tests for the --continue → fresh-start fallback (issue #123 Part 2).
+    """Tests for the --continue → fresh-start fallback (issue #123 Part 2, fix #128).
 
-    When Claude is not running in the tmux window (e.g. after a bot restart),
-    run() first tries ``claude --continue <prompt>`` to recover context.
-    If that fails (Claude exits immediately — no session to continue), it falls
-    back to a plain fresh ``claude <prompt>``.
+    --continue is ONLY used when the runner is explicitly constructed with
+    try_continue=True (restart-resume path, triggered from on_ready).
+
+    Normal cold starts (new threads, post-/clear) always use fresh start.
     """
 
+    # ── Restart-resume path (try_continue=True) ────────────────────────
+
     @pytest.mark.asyncio
-    async def test_continue_called_first_on_cold_start(
-        self, runner, tmux_manager
-    ) -> None:
-        """run() calls start_claude(try_continue=True) first when Claude is not running."""
+    async def test_restart_resume_uses_continue(self, tmux_manager) -> None:
+        """Restart-resume runner (try_continue=True) sends --continue first."""
+        resume_runner = TmuxClaudeRunner(
+            tmux_manager=tmux_manager,
+            thread_id=12345,
+            model="sonnet",
+            timeout_seconds=10,
+            try_continue=True,
+        )
         tmux_manager.is_claude_running.side_effect = [
-            False,  # initial check — Claude not running
+            False,  # initial check
             True,   # after --continue delay — Claude started successfully
         ]
         pane = _make_pane(["● Resumed."])
@@ -1410,88 +1410,38 @@ class TestContinueFallback:
             patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
             patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
         ):
-            async for event in runner.run("hello"):
+            async for event in resume_runner.run("hello"):
                 events.append(event)
 
-        # First call must use try_continue=True
-        first_call = tmux_manager.start_claude.call_args_list[0]
-        assert first_call.kwargs.get("try_continue") is True or (
-            len(first_call.args) >= 4 and "--continue" in str(first_call)
-        ), f"Expected try_continue=True in first call, got: {first_call}"
-        # Only one start_claude call (--continue succeeded)
-        assert tmux_manager.start_claude.call_count == 1
+        # Only one start_claude call: try_continue=True (--continue succeeded)
+        tmux_manager.start_claude.assert_called_once_with(
+            12345, "hello", "sonnet",
+            permission_mode="acceptEdits",
+            dangerously_skip_permissions=False,
+            try_continue=True,
+        )
 
     @pytest.mark.asyncio
-    async def test_fallback_to_fresh_when_continue_fails(
-        self, runner, tmux_manager
-    ) -> None:
-        """Issue #123 Part 2: when --continue fails, fresh start is used as fallback.
-
-        --continue failure is detected by is_claude_running returning False after
-        _CONTINUE_CHECK_DELAY seconds (Claude exited immediately).
-        """
+    async def test_restart_resume_fallback_when_continue_fails(self, tmux_manager) -> None:
+        """If --continue fails (no session), restart-resume runner falls back to fresh."""
+        resume_runner = TmuxClaudeRunner(
+            tmux_manager=tmux_manager,
+            thread_id=12345,
+            model="sonnet",
+            timeout_seconds=10,
+            try_continue=True,
+        )
         pane = _make_pane(["● Fresh start response."])
         call_idx = 0
 
         def capture_fn(tid):
             nonlocal call_idx
             call_idx += 1
-            if call_idx <= 2:
-                return "Loading..."
-            return pane
+            return "Loading..." if call_idx <= 2 else pane
 
         tmux_manager.capture_pane.side_effect = capture_fn
         tmux_manager.is_claude_running.side_effect = [
-            False,  # initial check — not running
-            False,  # after --continue delay — still not running (--continue failed)
-        ]
-        tmux_manager._find_window_for_thread.return_value = "work1"
-
-        events = []
-        with (
-            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
-            patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
-            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
-            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
-            patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
-        ):
-            async for event in runner.run("hello"):
-                events.append(event)
-
-        assert tmux_manager.start_claude.call_count == 2
-        # First call: try_continue=True
-        first_call = tmux_manager.start_claude.call_args_list[0]
-        assert first_call.kwargs.get("try_continue") is True
-        # Second call: try_continue=False (fresh)
-        second_call = tmux_manager.start_claude.call_args_list[1]
-        assert second_call.kwargs.get("try_continue") is False
-        assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)
-
-    @pytest.mark.asyncio
-    async def test_clear_path_uses_fresh_only(self, runner, tmux_manager) -> None:
-        """Regression: /clear kills the window; next run() must use fresh, NOT --continue.
-
-        After kill_session, create_session creates a NEW window with no conversation
-        history. --continue would fail immediately and fallback to fresh anyway —
-        but this test verifies the fallback path is correctly triggered (not that
-        --continue is skipped altogether, since the try-then-fallback is structural).
-        The key regression check: the final start_claude call uses try_continue=False
-        (fresh) so a cleared session always starts fresh.
-        """
-        # Simulate: window exists but Claude not running (new window after /clear)
-        pane = _make_pane(["● Hello, I'm fresh!"])
-        call_idx = 0
-
-        def capture_fn(tid):
-            nonlocal call_idx
-            call_idx += 1
-            if call_idx <= 2:
-                return "Loading..."
-            return pane
-
-        tmux_manager.capture_pane.side_effect = capture_fn
-        tmux_manager.is_claude_running.side_effect = [
-            False,  # initial check — not running (new window)
+            False,  # initial check
             False,  # after --continue delay — failed (no history)
         ]
         tmux_manager._find_window_for_thread.return_value = "work1"
@@ -1504,10 +1454,56 @@ class TestContinueFallback:
             patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
             patch("c_lord.claude.tmux_runner._CONTINUE_CHECK_DELAY", 0.01),
         ):
+            async for event in resume_runner.run("hello"):
+                events.append(event)
+
+        assert tmux_manager.start_claude.call_count == 2
+        assert tmux_manager.start_claude.call_args_list[0].kwargs["try_continue"] is True
+        assert tmux_manager.start_claude.call_args_list[1].kwargs["try_continue"] is False
+        assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)
+
+    # ── Default (fresh) path — /clear, new threads ─────────────────────
+
+    @pytest.mark.asyncio
+    async def test_default_runner_never_uses_continue(self, runner, tmux_manager) -> None:
+        """Issue #123 fix: default runner (try_continue=False) must NOT send --continue.
+
+        This is the regression test for the /clear path. After /clear, the window is
+        killed and recreated. In the new window, --continue would find ~/.claude history
+        and successfully resume the supposedly-cleared context. The fix prevents this
+        by never attaching --continue unless the runner was explicitly constructed with
+        try_continue=True (restart-resume path only).
+        """
+        pane = _make_pane(["● Hello, I'm fresh!"])
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            return "Loading..." if call_idx <= 2 else pane
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+        # Only ONE is_claude_running call expected (no --continue check delay)
+        tmux_manager.is_claude_running.return_value = False
+        tmux_manager._find_window_for_thread.return_value = "work1"
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.05),
+            patch("c_lord.claude.tmux_runner._STARTUP_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.09),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+        ):
             async for event in runner.run("hello"):
                 events.append(event)
 
-        # Final (second) start_claude call MUST be fresh (try_continue=False)
-        final_call = tmux_manager.start_claude.call_args_list[-1]
-        assert final_call.kwargs.get("try_continue") is False
+        # Exactly ONE start_claude call — direct fresh, no --continue attempt
+        tmux_manager.start_claude.assert_called_once_with(
+            12345, "hello", "sonnet",
+            permission_mode="acceptEdits",
+            dangerously_skip_permissions=False,
+            try_continue=False,
+        )
+        # Only one is_claude_running call (no post-continue check)
+        assert tmux_manager.is_claude_running.call_count == 1
         assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)


### PR DESCRIPTION
## Summary

- PR #127 が `try_continue=True` を全コールドスタートに適用したため、`/clear` 後に `--continue` が成功して旧コンテキストが復元されてしまう (#124 回帰)
- `try_continue` を `TmuxClaudeRunner` のコンストラクタパラメータ (default `False`) に移動し、`on_ready` → `pending_resumes` の再起動再開パスでのみ `True` を渡すよう修正

## Changes

- `c_lord/claude/tmux_runner.py`: `try_continue: bool = False` コンストラクタ引数を追加。コールドスタートを `if self._try_continue:` (再起動再開) と `else:` (通常) に分岐
- `c_lord/cogs/claude_chat.py`: `_run_claude(try_continue=False)` デフォルト、`on_ready` の再起動再開パスでのみ `try_continue=True` を渡す
- `tests/test_tmux_runner.py`: `TestContinueFallback` を全面書き換え — `try_continue=False` の構造的保証で `/clear` 回帰をテスト

## Staging verification logs

### GREEN: `/clear` → 次のメッセージで fresh start

テスト手順:
1. コンテキスト確立: 「マジックナンバーは 42」を Claude に記憶させた
2. `/clear` を模擬: tmux window kill + DB reset (session_id='', state='idle')
3. 次のメッセージを送信: 「マジックナンバーを教えてください」

tmux コマンド確認 (new window `work2`):
```
$ unalias claude 2>/dev/null; env -u CLAUDECODE claude --model sonnet \
  --dangerously-skip-permissions '[STAGING-TEST] マジックナンバーを教えてください。'
```

**`--continue` なし** → fresh start confirmed ✅

Claude の応答:
```
「マジックナンバー」が具体的に何を指しているか教えていただけますか?
考えられる解釈:
1. コード内のマジックナンバー — ハードコードされた定数値
2. テスト用の特定の値 — staging テストで使う識別子や認証コード
...
```
42 を覚えていない → 旧コンテキスト復元なし ✅

ボットログ:
```
13:45:07 c_lord.tmux: Created tmux window: work2 (thread=1508274772641972374)
13:45:08 c_lord.cogs._run_helper: [thread=1508274772641972374] run_claude: enter (prompt=32 chars)
13:45:09 c_lord.tmux: start_claude: sent command to c-lord-parallel-3:work2
```

---

### GREEN: ボット再起動 → コンテキスト維持

1. Claude がアクティブ実行中に SIGTERM でボットをシャットダウン
2. `pending_resumes` に記録:
```
13:47:21 c_lord.cogs.claude_chat: Shutdown detected: marking 1 active session(s) for restart-resume
13:47:21 c_lord.cogs.claude_chat: Marked thread 1508274772641972374 for restart-resume (session=tmux-1508274772641972374)
```
3. ボット再起動後の `on_ready`:
```
13:47:34 c_lord.cogs.claude_chat: Found 1 pending session resume(s) on startup
13:47:34 c_lord.cogs.claude_chat: Resuming session in thread 1508274772641972374 (session_id=tmux-1508274772641972374, reason=bot_shutdown)
13:47:40 c_lord.cogs._run_helper: [thread=1508274772641972374 session=tmux-1508274772641972374] run_claude: enter (prompt=43 chars)
```
→ 再開パスが正常に動作 ✅

---

## Test results

```
1028 passed, 5 skipped — ruff clean
```

## Checklist

- [x] `/clear` → fresh start confirmed on staging (no `--continue` in tmux command)
- [x] bot restart → `pending_resumes` populated → `on_ready` resumes session
- [x] `try_continue=False` structural test — no mocking needed
- [x] `Refs #123` (not `Closes`)

Refs #123