### PR TITLE
fix: ランプ状態のデフォルトをwaiting、running検出を積極シグナル限定に変更 (Closes #130)

### DIFF
--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -50,8 +50,9 @@ _DEFAULT_INTERVAL_SECONDS = 60.0
 # How many bottom lines of the pane to check for prompt/error indicators.
 _PANE_PROBE_LINES = 6
 
-# Characters that indicate Claude Code's input prompt (waiting for user).
-_WAITING_PROMPTS = frozenset({"❯", ">"})
+# Substring that signals Claude Code is actively executing a tool/task.
+# Visible in the pane only while Claude is running (not at the input prompt).
+_RUNNING_SIGNAL = "esc to interrupt"
 
 # Substrings that indicate an error state (checked in the bottom pane lines).
 _ERROR_INDICATORS = (
@@ -70,11 +71,15 @@ def _pane_lamp_state(pane_text: str) -> str:
     """Determine lamp state from captured pane content.
 
     Returns one of ``'running'``, ``'waiting'``, or ``'error'``.
-    Error takes highest priority; waiting is detected from the bare
-    ``❯``/``>`` prompt; otherwise the state is ``'running'``.
+    Priority: error > running (positive signal) > waiting (default).
+
+    Default is ``'waiting'`` because the idle state (user prompt visible,
+    draft text in input, ``-- INSERT --`` etc.) is far more common than
+    active execution.  Only the ``'esc to interrupt'`` line — shown by
+    Claude Code while a tool/task is executing — signals ``'running'``.
     """
     if not pane_text:
-        return "running"
+        return "waiting"
     lines = pane_text.rstrip().splitlines()
     tail = lines[-_PANE_PROBE_LINES:]
 
@@ -84,10 +89,10 @@ def _pane_lamp_state(pane_text: str) -> str:
                 return "error"
 
     for line in tail:
-        if line.strip() in _WAITING_PROMPTS:
-            return "waiting"
+        if _RUNNING_SIGNAL in line.lower():
+            return "running"
 
-    return "running"
+    return "waiting"
 
 
 def _capture_pane_text(

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -36,9 +36,27 @@ class _Rec:
 
 def test_index_by_thread_id_keeps_only_digit_tids():
     windows = [
-        {"session_name": "s", "window_id": "@1", "window_index": "0", "thread_id": "12345", "window_name": "work1"},
-        {"session_name": "s", "window_id": "@2", "window_index": "1", "thread_id": "", "window_name": "work2"},
-        {"session_name": "s", "window_id": "@3", "window_index": "2", "thread_id": "abc", "window_name": "work3"},
+        {
+            "session_name": "s",
+            "window_id": "@1",
+            "window_index": "0",
+            "thread_id": "12345",
+            "window_name": "work1",
+        },
+        {
+            "session_name": "s",
+            "window_id": "@2",
+            "window_index": "1",
+            "thread_id": "",
+            "window_name": "work2",
+        },
+        {
+            "session_name": "s",
+            "window_id": "@3",
+            "window_index": "2",
+            "thread_id": "abc",
+            "window_name": "work3",
+        },
     ]
     out = _index_by_thread_id(windows)
     assert list(out.keys()) == [12345]
@@ -68,6 +86,7 @@ def test_list_all_windows_parses_pipe_format():
 
 # ── _pane_lamp_state tests ────────────────────────────────────────────────────
 
+
 def test_pane_lamp_state_waiting_when_bare_prompt():
     pane = "Some content\n❯\n"
     assert _pane_lamp_state(pane) == "waiting"
@@ -78,9 +97,22 @@ def test_pane_lamp_state_waiting_gt_prompt():
     assert _pane_lamp_state(pane) == "waiting"
 
 
-def test_pane_lamp_state_running_when_no_prompt():
-    pane = "✻ Running bash...\n● Some response text\n"
+def test_pane_lamp_state_running_when_esc_to_interrupt():
+    # Positive signal: "esc to interrupt" line present → running
+    pane = "✻ Running bash...\nesc to interrupt\n"
     assert _pane_lamp_state(pane) == "running"
+
+
+def test_pane_lamp_state_waiting_without_running_signal():
+    # No "esc to interrupt" → default waiting even with tool output
+    pane = "✻ Running bash...\n● Some response text\n"
+    assert _pane_lamp_state(pane) == "waiting"
+
+
+def test_pane_lamp_state_waiting_with_nbsp_draft_text():
+    # Real Claude Code pane: ❯\xa0draft text — NBSP not stripped by .strip()
+    pane = "Some content\n❯\xa0PR #122 マージして\n"
+    assert _pane_lamp_state(pane) == "waiting"
 
 
 def test_pane_lamp_state_error_when_api_error():
@@ -93,8 +125,8 @@ def test_pane_lamp_state_error_colon_pattern():
     assert _pane_lamp_state(pane) == "error"
 
 
-def test_pane_lamp_state_empty_returns_running():
-    assert _pane_lamp_state("") == "running"
+def test_pane_lamp_state_empty_returns_waiting():
+    assert _pane_lamp_state("") == "waiting"
 
 
 def test_pane_lamp_state_error_takes_priority_over_waiting():
@@ -104,6 +136,7 @@ def test_pane_lamp_state_error_takes_priority_over_waiting():
 
 
 # ── _sync_one tests ───────────────────────────────────────────────────────────
+
 
 async def test_sync_one_marks_dead_and_renames():
     repo = MagicMock()
@@ -121,7 +154,7 @@ async def test_sync_one_marks_dead_and_renames():
     repo.set_state.assert_awaited_once_with(111, "dead")
 
 
-async def test_sync_one_running_when_no_prompt_in_pane():
+async def test_sync_one_running_when_esc_to_interrupt_in_pane():
     repo = MagicMock()
     repo.set_state = AsyncMock()
     repo.set_tmux_window_id = AsyncMock()
@@ -137,11 +170,24 @@ async def test_sync_one_running_when_no_prompt_in_pane():
         bot.get_channel.return_value = fake_thread
         loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
         rec = _Rec(thread_id=222, state="dead", topic="やること", tmux_window_id=None)
-        by_tid = {222: {"window_id": "@9", "window_index": "4", "thread_id": "222",
-                        "session_name": "clord", "window_name": "work1"}}
+        by_tid = {
+            222: {
+                "window_id": "@9",
+                "window_index": "4",
+                "thread_id": "222",
+                "session_name": "clord",
+                "window_name": "work1",
+            }
+        }
 
-        with patch.object(thread_state_sync, "discord") as discord_mock, \
-             patch.object(thread_state_sync, "_capture_pane_text", return_value="● response text\n") as _cap:
+        with (
+            patch.object(thread_state_sync, "discord") as discord_mock,
+            patch.object(
+                thread_state_sync,
+                "_capture_pane_text",
+                return_value="● response text\nesc to interrupt\n",
+            ),
+        ):
             discord_mock.Thread = fake_thread.__class__
             discord_mock.HTTPException = Exception
             await loop._sync_one(rec, by_tid)
@@ -170,11 +216,20 @@ async def test_sync_one_waiting_when_prompt_visible():
         bot.get_channel.return_value = fake_thread
         loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
         rec = _Rec(thread_id=333, state="running", topic="入力待ち", tmux_window_id=None)
-        by_tid = {333: {"window_id": "@5", "window_index": "2", "thread_id": "333",
-                        "session_name": "clord", "window_name": "work2"}}
+        by_tid = {
+            333: {
+                "window_id": "@5",
+                "window_index": "2",
+                "thread_id": "333",
+                "session_name": "clord",
+                "window_name": "work2",
+            }
+        }
 
-        with patch.object(thread_state_sync, "discord") as discord_mock, \
-             patch.object(thread_state_sync, "_capture_pane_text", return_value="● done\n❯\n"):
+        with (
+            patch.object(thread_state_sync, "discord") as discord_mock,
+            patch.object(thread_state_sync, "_capture_pane_text", return_value="● done\n❯\n"),
+        ):
             discord_mock.Thread = fake_thread.__class__
             discord_mock.HTTPException = Exception
             await loop._sync_one(rec, by_tid)
@@ -198,11 +253,22 @@ async def test_sync_one_error_when_error_in_pane():
         bot.get_channel.return_value = fake_thread
         loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
         rec = _Rec(thread_id=444, state="running", topic="エラー発生", tmux_window_id=None)
-        by_tid = {444: {"window_id": "@6", "window_index": "3", "thread_id": "444",
-                        "session_name": "clord", "window_name": "work3"}}
+        by_tid = {
+            444: {
+                "window_id": "@6",
+                "window_index": "3",
+                "thread_id": "444",
+                "session_name": "clord",
+                "window_name": "work3",
+            }
+        }
 
-        with patch.object(thread_state_sync, "discord") as discord_mock, \
-             patch.object(thread_state_sync, "_capture_pane_text", return_value="APIError: rate limit\n"):
+        with (
+            patch.object(thread_state_sync, "discord") as discord_mock,
+            patch.object(
+                thread_state_sync, "_capture_pane_text", return_value="APIError: rate limit\n"
+            ),
+        ):
             discord_mock.Thread = fake_thread.__class__
             discord_mock.HTTPException = Exception
             await loop._sync_one(rec, by_tid)


### PR DESCRIPTION
## Summary

- `_pane_lamp_state` のデフォルト戻り値を `"running"` → `"waiting"` に変更
- `"running"` の検出を `"esc to interrupt"` 行の存在のみに限定 (Claude Code がツール実行中のみ表示)
- `_WAITING_PROMPTS` の完全一致チェックを廃止（`❯\xa0draft text` のNBSP誤判定問題を根本解決）
- 空ペイン → `"waiting"` に変更（以前は `"running"`）

## Root cause (from #130)

実機で確認した 2 つのバグ:

1. **デフォルトが逆** — アイドル状態がデフォルトなのに `"running"` を返していた
2. **NBSP による完全一致失敗** — `❯\xa0PR #122 マージして` の `\xa0`（ノーブレークスペース）は `.strip()` で除去されず、`frozenset({"❯", ">"})` に一致しなかった

## Test plan

- [ ] staging で 🟡（waiting）→ 🟢（running: "esc to interrupt" 時）の遷移を目視確認
- [ ] 本番 deploy 後に同確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)