### PR TITLE
fix: LLMタイムアウトを10s→30sに引き上げ (Closes #135)

### DIFF
--- a/c_lord/topic.py
+++ b/c_lord/topic.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # 20 characters is the upper bound for the topic body (Japanese full-width
 # count, which matches Python's len() for the BMP characters we care about).
 _TOPIC_MAX_LEN = 20
-_LLM_TIMEOUT_SECONDS = 10.0
+_LLM_TIMEOUT_SECONDS = 30.0
 _LLM_PROMPT_TEMPLATE = (
     "次の発言を20字以内の日本語トピックに要約してください。記号や絵文字は使わず簡潔に。: {msg}"
 )

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -89,6 +89,7 @@ async def test_generate_topic_never_raises_on_internal_exception():
 
 # ── _looks_like_instruction tests ─────────────────────────────────────────────
 
+
 def test_looks_like_instruction_short_returns_false():
     assert topic._looks_like_instruction("OK") is False
     assert topic._looks_like_instruction("ありがとう") is False
@@ -111,6 +112,7 @@ def test_looks_like_instruction_medium_length_instruction():
 
 # ── maybe_retitle tests ────────────────────────────────────────────────────────
 
+
 async def test_maybe_retitle_skips_short_message():
     result = await topic.maybe_retitle("OK", "認証リファクタ")
     assert result is None
@@ -127,7 +129,9 @@ async def test_maybe_retitle_verbatim_returns_none():
         return "認証リファクタ"
 
     with patch.object(topic, "_call_claude_p", fake_call):
-        result = await topic.maybe_retitle("認証のリファクタを続けて進めてください", "認証リファクタ")
+        result = await topic.maybe_retitle(
+            "認証のリファクタを続けて進めてください", "認証リファクタ"
+        )
     assert result is None  # verbatim → no change
 
 
@@ -174,6 +178,11 @@ async def test_maybe_retitle_passes_current_topic_in_prompt():
 
     assert captured, "LLM should have been called"
     assert "認証リファクタ" in captured[0], "current topic must appear in prompt"
+
+
+def test_llm_timeout_is_at_least_30_seconds():
+    # Measured haiku latency: 9.4s, 12.9s, 15.9s, 17.9s — 10s was too tight.
+    assert topic._LLM_TIMEOUT_SECONDS >= 30.0
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

- `_LLM_TIMEOUT_SECONDS` を `10.0` → `30.0` に変更 (`c_lord/topic.py`)
- `generate_topic()` と `maybe_retitle()` の両方がこの定数を使用

## Root cause (from #135)

実測した `claude -p --model haiku` のレイテンシ:

| run | 時間 | 結果 |
|-----|------|------|
| 1 | 15.9s | timeout → heuristic fallback |
| 2 | 17.9s | timeout → heuristic fallback |
| 3 | 9.4s | success |
| 4 | 12.9s | timeout → heuristic fallback |

10秒制限では約75%のケースでタイムアウト→heuristicフォールバック（生メッセージ先頭20字）が発生。

## Test plan

- [ ] staging でスレッドタイトルが要約される（heuristic fallback にならない）ことを確認
- [ ] 本番 deploy 後に同確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)