### PR TITLE
fix: 実行中ランプ検出を ✢/✻ TUI文字で正確に判定 (esc to interrupt は出ない)

### DIFF
--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -50,9 +50,11 @@ _DEFAULT_INTERVAL_SECONDS = 60.0
 # How many bottom lines of the pane to check for prompt/error indicators.
 _PANE_PROBE_LINES = 6
 
-# Substring that signals Claude Code is actively executing a tool/task.
-# Visible in the pane only while Claude is running (not at the input prompt).
-_RUNNING_SIGNAL = "esc to interrupt"
+# Characters that signal active Claude Code execution in the pane content area.
+# ✢ (U+2722) appears during response generation (Actualizing/Synthesizing/…).
+# ✻ (U+273B) appears during tool execution (Running bash / Reading file / …).
+# Both are specific to the Claude Code TUI and absent from idle panes.
+_RUNNING_CHARS = frozenset({"✢", "✻"})
 
 # Substrings that indicate an error state (checked in the bottom pane lines).
 _ERROR_INDICATORS = (
@@ -75,8 +77,11 @@ def _pane_lamp_state(pane_text: str) -> str:
 
     Default is ``'waiting'`` because the idle state (user prompt visible,
     draft text in input, ``-- INSERT --`` etc.) is far more common than
-    active execution.  Only the ``'esc to interrupt'`` line — shown by
-    Claude Code while a tool/task is executing — signals ``'running'``.
+    active execution.
+
+    Running is detected by the Claude Code TUI characters that appear only
+    during active work: ``✢`` (response generation) and ``✻`` (tool execution).
+    These are absent from idle panes — verified against live pane captures.
     """
     if not pane_text:
         return "waiting"
@@ -89,7 +94,7 @@ def _pane_lamp_state(pane_text: str) -> str:
                 return "error"
 
     for line in tail:
-        if _RUNNING_SIGNAL in line.lower():
+        if any(ch in line for ch in _RUNNING_CHARS):
             return "running"
 
     return "waiting"

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -97,15 +97,26 @@ def test_pane_lamp_state_waiting_gt_prompt():
     assert _pane_lamp_state(pane) == "waiting"
 
 
-def test_pane_lamp_state_running_when_esc_to_interrupt():
-    # Positive signal: "esc to interrupt" line present → running
-    pane = "✻ Running bash...\nesc to interrupt\n"
+def test_pane_lamp_state_running_when_tool_executing():
+    # ✻ in the pane means a tool (Bash/Read/etc.) is actively running
+    pane = "✻ Running bash...\n"
     assert _pane_lamp_state(pane) == "running"
 
 
-def test_pane_lamp_state_waiting_without_running_signal():
-    # No "esc to interrupt" → default waiting even with tool output
-    pane = "✻ Running bash...\n● Some response text\n"
+def test_pane_lamp_state_running_when_actualizing():
+    # ✢ appears during Claude response generation (Actualizing/Synthesizing)
+    pane = "✢ Actualizing… (1m 13s · ↓ 3.6k tokens)\n\n❯\n"
+    assert _pane_lamp_state(pane) == "running"
+
+
+def test_pane_lamp_state_running_when_synthesizing():
+    pane = "✢ Synthesizing… (1m 43s · ↓ 5.5k tokens)\n\n❯\n"
+    assert _pane_lamp_state(pane) == "running"
+
+
+def test_pane_lamp_state_waiting_without_running_chars():
+    # No ✢ or ✻ → default waiting
+    pane = "● Some completed tool output\n❯\n"
     assert _pane_lamp_state(pane) == "waiting"
 
 
@@ -154,7 +165,7 @@ async def test_sync_one_marks_dead_and_renames():
     repo.set_state.assert_awaited_once_with(111, "dead")
 
 
-async def test_sync_one_running_when_esc_to_interrupt_in_pane():
+async def test_sync_one_running_when_tool_executing_in_pane():
     repo = MagicMock()
     repo.set_state = AsyncMock()
     repo.set_tmux_window_id = AsyncMock()
@@ -185,7 +196,7 @@ async def test_sync_one_running_when_esc_to_interrupt_in_pane():
             patch.object(
                 thread_state_sync,
                 "_capture_pane_text",
-                return_value="● response text\nesc to interrupt\n",
+                return_value="✻ Running bash...\n● response text\n",
             ),
         ):
             discord_mock.Thread = fake_thread.__class__


### PR DESCRIPTION
## 問題

実行中スレッドが🟡（waiting）のまま🟢（running）にならない。

## 根本原因

`_RUNNING_SIGNAL = "esc to interrupt"` と実装したが、実機ペインキャプチャで確認した結果、
Claude Code v2.1.150 はステータスバーに **`esc to interrupt` を出さない**。

実際の実行中ペイン末尾（実機キャプチャ）:
```
✢ Actualizing… (1m 13s · ↓ 3.6k tokens)

────────────────────────────────────────────────
❯
────────────────────────────────────────────────
   Model: Sonnet 4.6  v2.1.150  ...
  -- INSERT -- ⏵⏵ bypass permissions on · 1 shell
```

実行中でも `-- INSERT -- ⏵⏵` はそのままで、`esc to interrupt` は現れない。

## 修正

実際の実行シグナル（TUI固有のUnicode文字）を検出するよう変更:

| 文字 | Unicode | 意味 |
|---|---|---|
| `✢` | U+2722 | 応答生成中 (Actualizing / Synthesizing / …) |
| `✻` | U+273B | ツール実行中 (Running bash / Reading file / …) |

```python
# 修正前
_RUNNING_SIGNAL = "esc to interrupt"  # 実機で一度も出ない

# 修正後
_RUNNING_CHARS = frozenset({"✢", "✻"})  # 実ペインから確認
```

## テスト

- `✻ Running bash...` → running ✅
- `✢ Actualizing… (1m 13s · ↓ 3.6k tokens)` → running ✅
- `✢ Synthesizing… (1m 43s · ↓ 5.5k tokens)` → running ✅
- `● completed tool output` (✢/✻ なし) → waiting ✅

## Staging Evidence

このPR自体がwork7ウィンドウで作業中に上記のペインキャプチャを取得、
`✢ Synthesizing…` が実行中の正確なシグナルであることを実機確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)