### PR TITLE
fix: トピックLLM出力バリデーション + 1回リトライ (Closes #138)

### DIFF
--- a/c_lord/topic.py
+++ b/c_lord/topic.py
@@ -64,6 +64,10 @@ _FALLBACK_TOPIC = "新しいスレッド"
 # Minimum length for a message to be considered instruction-like.
 _INSTRUCTION_MIN_LEN = 15
 
+# Substrings that indicate an invalid LLM response (refusal, safety notice, etc.).
+# Outputs containing these are rejected and trigger a retry.
+_INVALID_TOPIC_MARKERS = ("許可", "Permission", "権限", "申し訳", "---")
+
 
 def heuristic_topic(first_message: str) -> str:
     """Derive a topic from ``first_message`` without invoking any LLM.
@@ -97,6 +101,20 @@ def _looks_like_instruction(message: str) -> bool:
     return not (msg.endswith("?") or msg.endswith("？"))
 
 
+def _is_valid_topic(result: str | None, original_msg: str) -> bool:
+    """Return True when *result* looks like a genuine ≤20-char summary.
+
+    Rejects None, empty strings, outputs containing refusal/safety markers,
+    and exact verbatim copies of the beginning of the original message.
+    """
+    if not result:
+        return False
+    if any(m in result for m in _INVALID_TOPIC_MARKERS):
+        return False
+    # Exact first-20-chars copy = haiku echoed the input instead of summarising.
+    return result != original_msg[:_TOPIC_MAX_LEN]
+
+
 async def _call_claude_p(prompt: str) -> str | None:
     """Call ``claude -p --model haiku`` with the given raw prompt string.
 
@@ -111,6 +129,7 @@ async def _call_claude_p(prompt: str) -> str | None:
             "haiku",
             "--",
             prompt,
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -159,17 +178,25 @@ async def generate_topic(first_message: str) -> tuple[str, str]:
     Claude CLI succeeded, or ``"heuristic"`` otherwise. The returned
     topic is always a non-empty string ≤20 chars; this function never
     raises.
-    """
-    llm = None
-    try:
-        llm = await _invoke_claude_haiku(first_message)
-    except Exception:  # pragma: no cover — defensive
-        logger.warning("topic LLM: unexpected error", exc_info=True)
-        llm = None
 
-    if llm:
-        return llm, "llm"
-    return heuristic_topic(first_message), "heuristic"
+    Retries once on invalid/None output before falling back to heuristic.
+    """
+    for attempt in range(2):
+        llm = None
+        try:
+            llm = await _invoke_claude_haiku(first_message)
+        except Exception:  # pragma: no cover — defensive
+            logger.warning("topic LLM: unexpected error (attempt=%d)", attempt + 1, exc_info=True)
+
+        if _is_valid_topic(llm, first_message):
+            return llm, "llm"  # type: ignore[return-value]
+
+        if attempt == 0:
+            logger.debug("topic LLM: attempt 1 invalid (%r), retrying", llm)
+
+    fallback = heuristic_topic(first_message)
+    logger.info("topic LLM: both attempts failed — heuristic fallback %r", fallback)
+    return fallback, "heuristic"
 
 
 async def maybe_retitle(message: str, current_topic: str) -> str | None:
@@ -181,18 +208,28 @@ async def maybe_retitle(message: str, current_topic: str) -> str | None:
     Comparison: returns None when LLM output equals ``current_topic``
     byte-for-byte (no Discord rename needed).
 
-    On any LLM failure, returns None (no retitle — safe default).
+    Retries once when the output is invalid. On any exception or after two
+    invalid outputs, returns None (safe default — no retitle).
     """
     if not _looks_like_instruction(message):
         return None
 
     prompt = _RETITLE_PROMPT_TEMPLATE.format(current_topic=current_topic, msg=message)
-    try:
-        new_topic = await _call_claude_p(prompt)
-    except Exception:
-        logger.debug("maybe_retitle: LLM call failed", exc_info=True)
-        return None
 
-    if not new_topic or new_topic == current_topic:
-        return None
-    return new_topic
+    for attempt in range(2):
+        try:
+            new_topic = await _call_claude_p(prompt)
+        except Exception:
+            logger.debug("maybe_retitle: LLM call failed (attempt=%d)", attempt + 1, exc_info=True)
+            return None
+
+        if not new_topic or new_topic == current_topic:
+            return None  # "no change" signal — valid, stop here
+
+        if _is_valid_topic(new_topic, message):
+            return new_topic
+
+        if attempt == 0:
+            logger.debug("maybe_retitle: invalid output %r, retrying", new_topic)
+
+    return None

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -186,6 +186,146 @@ def test_llm_timeout_is_at_least_30_seconds():
     assert topic._LLM_TIMEOUT_SECONDS >= 30.0
 
 
+# ── Output validation tests ────────────────────────────────────────────────────
+
+
+def test_is_valid_topic_rejects_none() -> None:
+    assert topic._is_valid_topic(None, "何かメッセージ") is False
+
+
+def test_is_valid_topic_rejects_empty() -> None:
+    assert topic._is_valid_topic("", "何かメッセージ") is False
+
+
+def test_is_valid_topic_rejects_forbidden_markers() -> None:
+    assert topic._is_valid_topic("許可が必要です", "ファイルを削除して") is False
+    assert topic._is_valid_topic("Permission denied", "ファイルを削除して") is False
+    assert topic._is_valid_topic("権限がありません", "ファイルを削除して") is False
+    assert topic._is_valid_topic("申し訳ありません", "ファイルを削除して") is False
+    assert topic._is_valid_topic("--- ただし注意", "ファイルを削除して") is False
+
+
+def test_is_valid_topic_rejects_verbatim_copy() -> None:
+    msg = "ランプの状態検出がおかしいので直して"
+    # Exact first 20 chars of the input = verbatim copy
+    assert topic._is_valid_topic(msg[:20], msg) is False
+
+
+def test_is_valid_topic_accepts_good_summary() -> None:
+    assert (
+        topic._is_valid_topic("ランプ状態検出の修正", "ランプの状態検出がおかしいので直して")
+        is True
+    )
+    assert topic._is_valid_topic("認証リファクタ", "認証まわりのリファクタをしてください") is True
+
+
+# ── Retry logic tests ──────────────────────────────────────────────────────────
+
+
+async def test_generate_topic_retries_once_on_none() -> None:
+    """LLM fails first, succeeds on retry → source is 'llm'."""
+    calls: list[int] = []
+
+    async def fake_invoke(_msg: str) -> str | None:
+        calls.append(1)
+        if len(calls) == 1:
+            return None  # first attempt: failure
+        return "認証リファクタ"  # retry: success
+
+    with patch.object(topic, "_invoke_claude_haiku", fake_invoke):
+        body, source = await topic.generate_topic("認証まわりのリファクタをしてください")
+
+    assert source == "llm"
+    assert body == "認証リファクタ"
+    assert len(calls) == 2, "must have called LLM exactly twice"
+
+
+async def test_generate_topic_retries_once_on_invalid_output() -> None:
+    """LLM returns verbatim input first, valid summary on retry."""
+    msg = "ランプの状態検出がおかしいので直して"
+    calls: list[str] = []
+
+    async def fake_invoke(_m: str) -> str | None:
+        calls.append(_m)
+        if len(calls) == 1:
+            return msg[:20]  # verbatim copy — invalid
+        return "ランプ状態検出の修正"  # retry: valid
+
+    with patch.object(topic, "_invoke_claude_haiku", fake_invoke):
+        body, source = await topic.generate_topic(msg)
+
+    assert source == "llm"
+    assert body == "ランプ状態検出の修正"
+    assert len(calls) == 2
+
+
+async def test_generate_topic_falls_back_after_two_invalid() -> None:
+    """Both attempts return invalid → heuristic fallback."""
+    msg = "ランプの状態検出がおかしいので直して"
+    calls: list[int] = []
+
+    async def fake_invoke(_m: str) -> str | None:
+        calls.append(1)
+        return None  # always fails
+
+    with patch.object(topic, "_invoke_claude_haiku", fake_invoke):
+        body, source = await topic.generate_topic(msg)
+
+    assert source == "heuristic"
+    assert body  # must be non-empty (heuristic_topic result)
+    assert len(calls) == 2, "must try exactly twice"
+
+
+async def test_generate_topic_does_not_retry_more_than_once() -> None:
+    """Only one retry allowed — LLM called at most twice."""
+    calls: list[int] = []
+
+    async def fake_invoke(_m: str) -> str | None:
+        calls.append(1)
+        return None
+
+    with patch.object(topic, "_invoke_claude_haiku", fake_invoke):
+        await topic.generate_topic("テスト")
+
+    assert len(calls) == 2
+
+
+async def test_maybe_retitle_retries_once_on_invalid_output() -> None:
+    """maybe_retitle retries once when LLM returns invalid output."""
+    calls: list[str] = []
+
+    async def fake_call(prompt: str) -> str | None:
+        calls.append(prompt)
+        if len(calls) == 1:
+            return "許可が必要です"  # forbidden — invalid
+        return "Dockerfile最適化"  # retry: valid
+
+    with patch.object(topic, "_call_claude_p", fake_call):
+        result = await topic.maybe_retitle(
+            "次はDockerfileを最適化してCI/CDを改善してください", "認証リファクタ"
+        )
+
+    assert result == "Dockerfile最適化"
+    assert len(calls) == 2
+
+
+async def test_maybe_retitle_returns_none_after_two_invalid() -> None:
+    """Both retitle attempts invalid → None (safe: no rename)."""
+    calls: list[int] = []
+
+    async def fake_call(_prompt: str) -> str | None:
+        calls.append(1)
+        return "許可が必要です"  # always invalid
+
+    with patch.object(topic, "_call_claude_p", fake_call):
+        result = await topic.maybe_retitle(
+            "次はDockerfileを最適化してCI/CDを改善してください", "認証リファクタ"
+        )
+
+    assert result is None
+    assert len(calls) == 2
+
+
 # ── Prompt structure tests (#138) ─────────────────────────────────────────────
 # The prompts must clearly separate the instruction from user content so haiku
 # cannot misinterpret action-like messages as commands to execute.
@@ -320,6 +460,7 @@ _LIVE_CORPUS = [
 ]
 
 _LIVE_MIN_PASS_RATE = 0.90  # 90% of runs must be clean
+_LIVE_MIN_LLM_RATE = 0.80  # ≥80% must use LLM source (not heuristic fallback)
 
 
 @pytest.mark.live_llm
@@ -337,6 +478,22 @@ async def test_generate_topic_live_llm_corpus() -> None:
     report = "\n".join(f"  {m!r} → {b!r}" for m, b in failures)
     assert pass_rate >= _LIVE_MIN_PASS_RATE, (
         f"pass rate {pass_rate:.0%} < {_LIVE_MIN_PASS_RATE:.0%}\nfailures:\n{report}"
+    )
+
+
+@pytest.mark.live_llm
+@pytestmark_live
+async def test_generate_topic_live_llm_fallback_rate() -> None:
+    """Concurrent calls; LLM success rate must be ≥80% (not heuristic fallback)."""
+    import asyncio as _asyncio
+
+    results = await _asyncio.gather(*[topic.generate_topic(m) for m in _LIVE_CORPUS])
+    llm_count = sum(1 for _, src in results if src == "llm")
+    llm_rate = llm_count / len(results)
+    heuristic_msgs = [_LIVE_CORPUS[i] for i, (_, src) in enumerate(results) if src != "llm"]
+    assert llm_rate >= _LIVE_MIN_LLM_RATE, (
+        f"LLM success rate {llm_rate:.0%} < {_LIVE_MIN_LLM_RATE:.0%}\n"
+        f"heuristic fallbacks: {heuristic_msgs}"
     )
 
 


### PR DESCRIPTION
## Summary

- **`_is_valid_topic()`** を新設: None・空文字・拒否マーカー (`許可`, `Permission`, `権限`, `申し訳`, `---`) を含む出力・verbatim copy を排除
- **`generate_topic` / `maybe_retitle`** を `range(2)` ループに変更し、無効出力時に1回リトライしてからheuristicフォールバック
- **`stdin=asyncio.subprocess.DEVNULL`** を追加: "no stdin data received in 3s" 警告が VERBATIM 出力を引き起こしていた問題を修正
- 実LLM統合テスト (`CLORD_TEST_LIVE_LLM=1`) で ≥80% LLM成功率を回帰検証

## Acceptance Criteria (Issue #138)

- [x] 原因特定: TIMEOUT (#137 で30sに修正済み) + stdin未設定による VERBATIM 出力
- [x] 出力バリデーション: `_is_valid_topic()` が空/verbatim/拒否マーカーを排除
- [x] 1回リトライ: 無効出力時に2回目を試みてからheuristicに落ちる
- [x] 実測フォールバック率をPR本文に記載

## TDD Evidence

**RED** (追加前、新テストは失敗):
```
FAILED tests/test_topic.py::test_is_valid_topic_rejects_none - AssertionError
FAILED tests/test_topic.py::test_generate_topic_retries_once_on_none - AssertionError
```

**GREEN** (追加後):
```
1094 passed, 8 deselected, 9 warnings in 92.25s
```

## Fallback Rate (実測)

| 条件 | LLM成功率 | heuristic率 |
|------|----------|------------|
| 修正前 (本番観察) | ~67% (6件中4件) | ~33% (6件中2件) |
| 修正後 (live test, 10件並列) | **100%** (10/10) | 0% |

```
CLORD_TEST_LIVE_LLM=1 uv run pytest tests/test_topic.py -m live_llm -v
3 passed in 130.46s ✓ (≥80% LLM rate threshold confirmed)
```

## Staging Evidence

staging (`c-lord-parallel-3`, fix/topic-retry-validation) で `generate_topic()` を直接実行:

```
source='llm'  topic='ランプの状態検出を修正'       msg='ランプの状態検出がおかしいので直してください'
source='llm'  topic='Dockerfile最適化とCI/CD改'  msg='Dockerfileを最適化してCI/CDを改善してください'
source='llm'  topic='PR #138 マージ'            msg='PR #138 をマージして'
```

**3/3 = 100% LLM成功** (修正前は本番で2/6 = 33%がheuristicに落ちていた)

## Test plan

- [x] `uv run pytest tests/ -q` → 1094 passed
- [x] `CLORD_TEST_LIVE_LLM=1 uv run pytest tests/test_topic.py -m live_llm -v` → 3 passed
- [ ] 本番デプロイ後、Discordで新スレッド作成してタイトルが要約されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)