### PR TITLE
fix: silence intermediate assistant_text; only last reply gets ↪ (#143)

### DIFF
--- a/c_lord/transcript/mirror.py
+++ b/c_lord/transcript/mirror.py
@@ -144,42 +144,79 @@ class TranscriptMirror:
         )
         # Buffer for tool_use / tool_result lines in minimal mode.
         progress_buf: list[str] = []
+        # Pending assistant_text held until we know if it's intermediate or final.
+        # When a subsequent event arrives we can decide: another assistant_text or
+        # tool event → flush silently; result/user_input/stop → flush as reply.
+        _pending_text: str | None = None
+        _pending_progress: list[str] = []  # snapshot of progress_buf at capture time
+
+        async def _flush_pending_silently() -> None:
+            nonlocal _pending_text, _pending_progress
+            if _pending_text is None:
+                return
+            await self._try_sink(_pending_text)
+            # Merge the snapshot back so subsequent tool output accumulates.
+            progress_buf[:0] = _pending_progress
+            _pending_text = None
+            _pending_progress = []
+
+        async def _flush_pending_as_reply() -> None:
+            nonlocal _pending_text, _pending_progress
+            if _pending_text is None:
+                return
+            await self._flush_as_reply(_pending_text, _pending_progress)
+            _pending_text = None
+            _pending_progress = []
 
         try:
             async for event in tail_events(self.project_dir, poll_interval=self._poll_interval):
+                if self._verbosity == "minimal" and event.get("type") == "result":
+                    # Turn boundary: flush pending as the final reply.
+                    await _flush_pending_as_reply()
+                    continue
+
                 rendered = render_event(event)
                 if rendered is None:
                     continue
 
                 if self._verbosity == "minimal":
-                    await self._handle_minimal(rendered, progress_buf)
+                    if rendered.kind in _BUFFERED_KINDS:
+                        # Tool event: if there's pending text, it was intermediate.
+                        await _flush_pending_silently()
+                        progress_buf.append(_format_body(rendered))
+                    elif rendered.kind == "assistant_text":
+                        # Another text while one is pending → previous was intermediate.
+                        if _pending_text is not None:
+                            await _flush_pending_silently()
+                        _pending_text = _format_body(rendered)
+                        _pending_progress = list(progress_buf)
+                        progress_buf.clear()
+                    elif rendered.kind == "user_input":
+                        # Human turn: previous assistant turn is over → flush as reply.
+                        await _flush_pending_as_reply()
+                        await self._post(rendered)
+                    else:
+                        await _flush_pending_silently()
+                        await self._post(rendered)
                 else:
                     await self._post(rendered)
 
         except asyncio.CancelledError:
             pass
         finally:
+            if self._verbosity == "minimal":
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await _flush_pending_as_reply()
             logger.info("TranscriptMirror stopped: thread=%d", self.thread_id)
 
-    async def _handle_minimal(self, rendered: RenderedEvent, progress_buf: list[str]) -> None:
-        """Route one event in minimal mode."""
-        if rendered.kind in _BUFFERED_KINDS:
-            progress_buf.append(_format_body(rendered))
-            return
-
-        if rendered.kind == "assistant_text":
-            body = _format_body(rendered)
-            if progress_buf and self._file_sink is not None:
-                await self._flush_with_progress(body, progress_buf)
-            elif self._reply_sink is not None:
-                await self._try_reply_sink(body)
-            else:
-                await self._try_sink(body)
-            progress_buf.clear()
-            return
-
-        # user_input and any future kinds: post directly.
-        await self._post(rendered)
+    async def _flush_as_reply(self, text: str, progress: list[str]) -> None:
+        """Flush pending text as the final reply for the current turn."""
+        if progress and self._file_sink is not None:
+            await self._flush_with_progress(text, progress)
+        elif self._reply_sink is not None:
+            await self._try_reply_sink(text)
+        else:
+            await self._try_sink(text)
 
     async def _flush_with_progress(self, body: str, progress_buf: list[str]) -> None:
         """Write buffered tool lines to a tempfile and call file_sink."""

--- a/c_lord/transcript/mirror.py
+++ b/c_lord/transcript/mirror.py
@@ -83,6 +83,16 @@ def reply_to_trigger_enabled() -> bool:
     return os.getenv("CLORD_REPLY_TO_TRIGGER", "1").strip().lower() not in ("0", "false", "no")
 
 
+def _is_turn_end(event: dict) -> bool:
+    """Return True for JSONL events that signal the end of a Claude turn.
+
+    Handles both ``{"type": "result"}`` (older Claude Code builds) and
+    ``{"type": "system", "subtype": "turn_duration"}`` (current production).
+    """
+    t = event.get("type")
+    return t == "result" or (t == "system" and event.get("subtype") == "turn_duration")
+
+
 _KIND_PREFIX = {
     "assistant_text": "",
     "tool_use": "",  # tool_use bodies already start with the 🔧 emoji
@@ -170,7 +180,7 @@ class TranscriptMirror:
 
         try:
             async for event in tail_events(self.project_dir, poll_interval=self._poll_interval):
-                if self._verbosity == "minimal" and event.get("type") == "result":
+                if self._verbosity == "minimal" and _is_turn_end(event):
                     # Turn boundary: flush pending as the final reply.
                     await _flush_pending_as_reply()
                     continue

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -426,7 +426,7 @@ async def test_mirror_minimal_clears_buffer_after_assistant_text(tmp_path: Path)
         # Turn 1: tool + final text → result event triggers reply flush via file_sink
         _write_event(jsonl, _assistant_tool_use("Bash", "ls"))
         _write_event(jsonl, _assistant_text("turn1 done"))
-        _write_event(jsonl, {"type": "result", "subtype": "success"})
+        _write_event(jsonl, {"type": "system", "subtype": "turn_duration"})
         await asyncio.sleep(0.3)
         # Turn 2: no tools, just final text → reply_sink (no file_sink, buffer was cleared)
         _write_event(jsonl, _assistant_text("turn2 done"))
@@ -522,7 +522,7 @@ async def test_mirror_result_event_flushes_pending_as_reply(tmp_path: Path) -> N
     try:
         await asyncio.sleep(0.1)
         _write_event(jsonl, _assistant_text("turn answer"))
-        _write_event(jsonl, {"type": "result", "subtype": "success"})
+        _write_event(jsonl, {"type": "system", "subtype": "turn_duration"})
         # Give time for events to be processed; don't stop yet.
         await asyncio.sleep(0.3)
         # reply_sink must have been called before stop().
@@ -566,11 +566,11 @@ async def test_mirror_multiple_turns_each_final_text_as_reply(tmp_path: Path) ->
         await asyncio.sleep(0.1)
         # Turn 1
         _write_event(jsonl, _assistant_text("answer1"))
-        _write_event(jsonl, {"type": "result", "subtype": "success"})
+        _write_event(jsonl, {"type": "system", "subtype": "turn_duration"})
         await asyncio.sleep(0.2)
         # Turn 2
         _write_event(jsonl, _assistant_text("answer2"))
-        _write_event(jsonl, {"type": "result", "subtype": "success"})
+        _write_event(jsonl, {"type": "system", "subtype": "turn_duration"})
         await asyncio.sleep(0.3)
     finally:
         await mirror.stop()

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -386,7 +386,11 @@ async def test_mirror_full_mode_posts_tool_events_directly(tmp_path: Path) -> No
 
 
 async def test_mirror_minimal_clears_buffer_after_assistant_text(tmp_path: Path) -> None:
-    """Buffer is reset after each assistant_text so second turn starts fresh."""
+    """Buffer is reset after each assistant_text so second turn starts fresh.
+
+    A ``result`` event between turns signals the turn boundary; each turn's
+    final text is flushed as a reply on that event.
+    """
     project = tmp_path / "proj"
     project.mkdir()
     jsonl = project / "s.jsonl"
@@ -396,9 +400,13 @@ async def test_mirror_minimal_clears_buffer_after_assistant_text(tmp_path: Path)
     os.utime(jsonl, (1, 1))
 
     file_sink_calls: list[tuple[str, str]] = []
+    reply_sink_calls: list[str] = []
 
     async def sink(text: str) -> None:
         pass
+
+    async def reply_sink(text: str) -> None:
+        reply_sink_calls.append(text)
 
     async def file_sink(text: str, file_path: str) -> None:
         file_sink_calls.append((text, file_path))
@@ -407,6 +415,7 @@ async def test_mirror_minimal_clears_buffer_after_assistant_text(tmp_path: Path)
         thread_id=1,
         project_dir=project,
         sink=sink,
+        reply_sink=reply_sink,
         file_sink=file_sink,
         verbosity="minimal",
         poll_interval=0.05,
@@ -414,19 +423,162 @@ async def test_mirror_minimal_clears_buffer_after_assistant_text(tmp_path: Path)
     mirror.start()
     try:
         await asyncio.sleep(0.1)
-        # Turn 1: tool + final text → file_sink called
+        # Turn 1: tool + final text → result event triggers reply flush via file_sink
         _write_event(jsonl, _assistant_tool_use("Bash", "ls"))
         _write_event(jsonl, _assistant_text("turn1 done"))
+        _write_event(jsonl, {"type": "result", "subtype": "success"})
         await asyncio.sleep(0.3)
-        # Turn 2: no tools, just final text → plain sink, NOT file_sink
+        # Turn 2: no tools, just final text → reply_sink (no file_sink, buffer was cleared)
         _write_event(jsonl, _assistant_text("turn2 done"))
         await asyncio.sleep(0.3)
     finally:
         await mirror.stop()
 
-    # file_sink only called once (turn 1), not for turn 2 (no buffered tools)
+    # Turn 1: file_sink called (tools were buffered)
     assert len(file_sink_calls) == 1
     assert file_sink_calls[0][0] == "turn1 done"
+    # Turn 2: reply_sink called (no tools buffered)
+    assert any("turn2 done" in s for s in reply_sink_calls)
+
+
+# ---------------------------------------------------------------------------
+# Issue #143: intermediate assistant_text must be silent; only last gets reply
+# ---------------------------------------------------------------------------
+
+
+async def test_mirror_multiple_assistant_texts_intermediate_silent(tmp_path: Path) -> None:
+    """Issue #143: when multiple assistant_text events arrive in one turn,
+    intermediate ones must go to sink (no reference), only the last to reply_sink."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    sink_calls: list[str] = []
+    reply_sink_calls: list[str] = []
+
+    async def sink(text: str) -> None:
+        sink_calls.append(text)
+
+    async def reply_sink(text: str) -> None:
+        reply_sink_calls.append(text)
+
+    mirror = TranscriptMirror(
+        thread_id=1,
+        project_dir=project,
+        sink=sink,
+        reply_sink=reply_sink,
+        verbosity="minimal",
+        poll_interval=0.05,
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl, _assistant_text("intermediate text"))
+        _write_event(jsonl, _assistant_text("final text"))
+        await asyncio.sleep(0.3)
+    finally:
+        await mirror.stop()
+
+    # intermediate → silent sink
+    assert any("intermediate text" in s for s in sink_calls), f"sink={sink_calls}"
+    # final → reply_sink (not silent)
+    assert any("final text" in s for s in reply_sink_calls), f"reply={reply_sink_calls}"
+    # final must NOT appear in the silent sink
+    assert not any("final text" in s for s in sink_calls), f"final leaked to sink={sink_calls}"
+
+
+async def test_mirror_result_event_flushes_pending_as_reply(tmp_path: Path) -> None:
+    """Issue #143: a ``result`` JSONL event signals turn end and flushes
+    the pending assistant_text as a reply (not waiting for mirror stop)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    reply_sink_calls: list[str] = []
+
+    async def sink(text: str) -> None:
+        pass
+
+    async def reply_sink(text: str) -> None:
+        reply_sink_calls.append(text)
+
+    mirror = TranscriptMirror(
+        thread_id=1,
+        project_dir=project,
+        sink=sink,
+        reply_sink=reply_sink,
+        verbosity="minimal",
+        poll_interval=0.05,
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl, _assistant_text("turn answer"))
+        _write_event(jsonl, {"type": "result", "subtype": "success"})
+        # Give time for events to be processed; don't stop yet.
+        await asyncio.sleep(0.3)
+        # reply_sink must have been called before stop().
+        assert any("turn answer" in s for s in reply_sink_calls), (
+            f"reply_sink not called before stop: {reply_sink_calls}"
+        )
+    finally:
+        await mirror.stop()
+
+
+async def test_mirror_multiple_turns_each_final_text_as_reply(tmp_path: Path) -> None:
+    """Issue #143: with explicit result events between turns, each turn's
+    final assistant_text is posted as reply (not silenced)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    reply_sink_calls: list[str] = []
+    sink_calls: list[str] = []
+
+    async def sink(text: str) -> None:
+        sink_calls.append(text)
+
+    async def reply_sink(text: str) -> None:
+        reply_sink_calls.append(text)
+
+    mirror = TranscriptMirror(
+        thread_id=1,
+        project_dir=project,
+        sink=sink,
+        reply_sink=reply_sink,
+        verbosity="minimal",
+        poll_interval=0.05,
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.1)
+        # Turn 1
+        _write_event(jsonl, _assistant_text("answer1"))
+        _write_event(jsonl, {"type": "result", "subtype": "success"})
+        await asyncio.sleep(0.2)
+        # Turn 2
+        _write_event(jsonl, _assistant_text("answer2"))
+        _write_event(jsonl, {"type": "result", "subtype": "success"})
+        await asyncio.sleep(0.3)
+    finally:
+        await mirror.stop()
+
+    assert any("answer1" in s for s in reply_sink_calls), f"turn1 not in reply={reply_sink_calls}"
+    assert any("answer2" in s for s in reply_sink_calls), f"turn2 not in reply={reply_sink_calls}"
+    assert not any("answer1" in s for s in sink_calls), f"turn1 leaked to sink={sink_calls}"
+    assert not any("answer2" in s for s in sink_calls), f"turn2 leaked to sink={sink_calls}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`CLORD_BRIDGE_MODE=jsonl` 運用時に、1ターン内で Claude が複数回テキストを出すと全部 ↪（Discord 返信）になっていたバグを修正します。途中のテキストはサイレント投稿、最後の1つだけが ↪ 付き返信になります。

Closes #143

## Why?

`_handle_minimal()` が `assistant_text` イベントを受け取るたびに即座に `reply_sink`（↪付き）へ流していた。ターン内に複数の `assistant_text` があっても「最後だけが final reply」という区別がなかった。

## Acceptance Criteria (copied from the issue)

- [x] 1ターンで `assistant_text` が複数出ても、Discord に **返信（↪付き）として出るのは最後の1つだけ**。
- [x] 途中の `assistant_text` は **サイレント投稿**（push通知なし・↪なし）。投稿自体は残ってよい。
- [x] ツールログ（tool_use/tool_result）の既存のバッファ／サイレント挙動・progress.txt 添付は維持。
- [x] 完了の返信は従来どおり `mention_author=False`（メンション通知は出さない）。
- [x] `CLORD_REPLY_TO_TRIGGER=0` 時は従来どおり一切 reference を付けない。

## 実装概要

`_run()` にローカル状態 `_pending_text` / `_pending_progress` を持たせ、イベント駆動でターン終端を判定：

| イベント | 動作 |
|---|---|
| `assistant_text` 到着 | `_pending_text` にバッファ。既存 pending があればサイレント flush |
| `tool_use` / `tool_result` 到着 | pending があればサイレント flush → `progress_buf` に追加 |
| `system.turn_duration`（ターン終端） | pending を `reply_sink` / `file_sink` に flush（↪付き） |
| `user_input` 到着 | pending を reply flush |
| `stop()` 呼び出し | `finally` で残った pending を reply flush |

`_is_turn_end()` ヘルパーが `{"type":"system","subtype":"turn_duration"}`（現行 Claude Code）と `{"type":"result"}`（旧ビルド）の両方を認識。

## Staging Evidence

**RED（修正前 / result-only 判定の初期コード）:**

1+1 テストの `assistant_text` がターン終端を検出できずに保留され、次の 2+2 `assistant_text` 到来時に `_flush_pending_silently()` されたことで **[silent]・↪なし** で投稿された:
```
1508653544759234570 C-lord-3 [silent]: **思考の過程:**↵1+1 は…
```

**GREEN（修正後 / system.turn_duration 判定）:**

3+3 テストで `system turn_duration` イベントを検出し、final text が **↪付き・非 silent** で正しく投稿された:
```
1508654647768907966 C-lord-3 [↪1508654615074308159]: 6
```

`↪1508654615074308159` はトリガーメッセージ（Spidey Bot の「GREEN確認: 3+3は？」）への参照。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line: `AssertionError: sink=[] assert False` (`test_mirror_multiple_assistant_texts_intermediate_silent`)
- [x] `uv run pytest tests/ -v` passes (1081 passed)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #143` — 100% of ACs met