### PR TITLE
fix: ignore Discord system messages in on_message (#148)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -320,6 +320,10 @@ class ClaudeChatCog(commands.Cog):
         if message.channel.id == self.bot.channel_id:
             return
 
+        # System messages (thread rename, pin, etc.) must not reach Claude
+        if message.type not in (discord.MessageType.default, discord.MessageType.reply):
+            return
+
         # Text commands (e.g. !attach) are handled by process_commands — skip here
         ctx = await self.bot.get_context(message)
         if ctx.valid:

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1298,6 +1298,7 @@ class TestOnMessageSkipsTextCommands:
         msg.author.bot = False
         msg.author.id = 42
         msg.webhook_id = None
+        msg.type = discord.MessageType.default
 
         # DB session must exist for opt-in response
         record = MagicMock()
@@ -1309,6 +1310,94 @@ class TestOnMessageSkipsTextCommands:
         mock_ctx.valid = False
         cog.bot.get_context = AsyncMock(return_value=mock_ctx)
 
+        await cog.on_message(msg)
+
+        cog._handle_thread_reply.assert_called_once_with(msg)
+
+
+class TestOnMessageSkipsSystemMessages:
+    """on_message must not send Discord system messages to _handle_thread_reply."""
+
+    def _make_thread_msg(self, msg_type: discord.MessageType) -> MagicMock:
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 42
+        thread.parent_id = 999
+
+        msg = MagicMock(spec=discord.Message)
+        msg.channel = thread
+        msg.content = ""
+        msg.attachments = []
+        msg.author = MagicMock()
+        msg.author.bot = False
+        msg.author.id = 99
+        msg.webhook_id = None
+        msg.type = msg_type
+        return msg
+
+    @pytest.mark.asyncio
+    async def test_channel_name_change_not_forwarded(self) -> None:
+        """スレッド名変更通知は _handle_thread_reply に到達しない。"""
+        cog = _make_cog()
+        cog._handle_thread_reply = AsyncMock()
+        record = MagicMock()
+        cog.repo.get = AsyncMock(return_value=record)
+        mock_ctx = MagicMock()
+        mock_ctx.valid = False
+        cog.bot.get_context = AsyncMock(return_value=mock_ctx)
+
+        msg = self._make_thread_msg(discord.MessageType.channel_name_change)
+        await cog.on_message(msg)
+
+        cog._handle_thread_reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pins_add_not_forwarded(self) -> None:
+        """ピン留め通知は _handle_thread_reply に到達しない。"""
+        cog = _make_cog()
+        cog._handle_thread_reply = AsyncMock()
+        record = MagicMock()
+        cog.repo.get = AsyncMock(return_value=record)
+        mock_ctx = MagicMock()
+        mock_ctx.valid = False
+        cog.bot.get_context = AsyncMock(return_value=mock_ctx)
+
+        msg = self._make_thread_msg(discord.MessageType.pins_add)
+        await cog.on_message(msg)
+
+        cog._handle_thread_reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_default_message_forwarded(self) -> None:
+        """default タイプは従来どおり _handle_thread_reply に到達する。"""
+        cog = _make_cog()
+        cog._handle_thread_reply = AsyncMock()
+        record = MagicMock()
+        record.session_id = "sess-123"
+        cog.repo.get = AsyncMock(return_value=record)
+        mock_ctx = MagicMock()
+        mock_ctx.valid = False
+        cog.bot.get_context = AsyncMock(return_value=mock_ctx)
+
+        msg = self._make_thread_msg(discord.MessageType.default)
+        msg.content = "hello"
+        await cog.on_message(msg)
+
+        cog._handle_thread_reply.assert_called_once_with(msg)
+
+    @pytest.mark.asyncio
+    async def test_reply_message_forwarded(self) -> None:
+        """reply タイプは従来どおり _handle_thread_reply に到達する。"""
+        cog = _make_cog()
+        cog._handle_thread_reply = AsyncMock()
+        record = MagicMock()
+        record.session_id = "sess-456"
+        cog.repo.get = AsyncMock(return_value=record)
+        mock_ctx = MagicMock()
+        mock_ctx.valid = False
+        cog.bot.get_context = AsyncMock(return_value=mock_ctx)
+
+        msg = self._make_thread_msg(discord.MessageType.reply)
+        msg.content = "a reply"
         await cog.on_message(msg)
 
         cog._handle_thread_reply.assert_called_once_with(msg)
@@ -1329,6 +1418,7 @@ class TestMultiChannelOnMessage:
         msg.author = MagicMock()
         msg.author.bot = False
         msg.webhook_id = None
+        msg.type = discord.MessageType.default
         return msg
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

`on_message` に `message.type` ガードを追加し、`default` / `reply` 以外のシステムメッセージ（スレッド名変更、ピン留めなど）を即 return で弾くようにした。

## Why?

スレッドタイトルを変更すると Discord が `MessageType.channel_name_change`（type=4）のシステムメッセージを投下する。これが `_handle_thread_reply` に到達し、意図せず Claude Code セッションが起動していた。

Closes #148

## Acceptance Criteria (copied from the issue)

- [x] repo binding 済みスレッドのタイトルを変更しても、Claude Code セッションが起動しない（`_handle_thread_reply` が呼ばれない）
- [x] 通常のユーザー発言（`default`）と返信（`reply`）は従来どおり `_handle_thread_reply` に到達する

## Staging Evidence

**環境**: `/home/yousan/c-lord-parallel-3` (staging bot: C-lord-3#1206)

**RED** (修正前の挙動を unit test で確認):
```
FAILED tests/test_claude_chat.py::TestOnMessageSkipsSystemMessages::test_channel_name_change_not_forwarded
AssertionError: Expected 'mock' to not have been called. Called 1 times.
FAILED tests/test_claude_chat.py::TestOnMessageSkipsSystemMessages::test_pins_add_not_forwarded
AssertionError: Expected 'mock' to not have been called. Called 1 times.
```

**GREEN** (staging bot で thread 1508274772641972374 をリネーム):
```bash
# Discord API でスレッド名を変更 → type=4 (channel_name_change) システムメッセージを発生させる
PATCH /channels/1508274772641972374 {"name":"staging-qa-rename-test"} → 200 OK
```

staging log 抜粋 (`grep "run_claude\|_handle_thread_reply\|1508274772641972374" /tmp/clord-bot-staging.log`):
```
2026-05-26 13:34:37 [INFO] c_lord.bot: Manual rename detected for thread 1508274772641972374: topic='staging-qa-rename-test' (locked)
```

`run_claude: enter` は一切出ず。Discord 上には `type=4` メッセージが投下されたが Claude は起動しなかった。

```
# Discord messages in thread after rename:
type=4 author=C-lord-3 content='staging-qa-rename-test'   ← system message, Claude NOT triggered
```

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

> **Label exemptions** (`no-runtime-change` or `documentation` label): items 1–2 and 5 below are waived.
> `Closes` discipline (item 7) is **always enforced**, regardless of label.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #148` used only if 100% of the issue's ACs are met (else `Refs #N`)