### PR TITLE
feat: detect unknown TUI interactive prompts and alert Discord (#110)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -54,10 +54,23 @@ _TRUST_PROMPT_MARKERS = (
 )
 
 # Patterns that indicate a permission/approval prompt that needs "Yes".
+# Sources: existing c-lord markers + Claude Code v2.1+ npm package strings.
 _PERMISSION_PROMPT_MARKERS = (
     "Do you want to proceed?",
     "This command requires approval",
+    "Do you want to continue?",
+    "Do you want to allow Claude to fetch this content?",
+    "Do you want to allow this connection?",
+    "Continue anyway?",
 )
+
+# Regex matching [y/N] or [Y/n] inline yes/no prompts (Claude Code v2.1+).
+# These need "y" + Enter instead of just Enter (Enter selects the default, N).
+_YN_PROMPT_RE = re.compile(r"\[y/N\]|\[Y/n\]", re.IGNORECASE)
+
+# Regex matching a numbered-menu cursor line: "❯ 1. ..." or y/N inline prompt.
+# Used to detect interactive menus regardless of whether the question text is known.
+_INTERACTIVE_MENU_RE = re.compile(r"^\s*❯\s+\d+\.", re.MULTILINE)
 
 # Regex for separator lines (all box-drawing horizontal characters).
 _SEPARATOR_RE = re.compile(r"^[─━═─\s]{10,}$")
@@ -331,6 +344,11 @@ class TmuxClaudeRunner:
         # changes so that transient TUI redraw artifacts (e.g. mid-frame cursor
         # rewrites that produce text like "claude_chat.pypy") are not yielded.
         prev_capture_response = ""
+        # Seconds the unknown-interactive pattern has been continuously visible.
+        # We require it to be stable for this long before alerting Discord,
+        # to avoid false positives from transient TUI redraws.
+        unknown_interactive_stable = 0.0
+        unknown_interactive_alert_delay = 5.0
 
         while not self._stopped and elapsed < self.timeout_seconds:
             await asyncio.sleep(_POLL_INTERVAL)
@@ -340,8 +358,28 @@ class TmuxClaudeRunner:
 
             # Auto-accept permission prompts so the bot doesn't stall.
             if self._has_permission_prompt(current):
+                unknown_interactive_stable = 0.0
                 await self._accept_permission_prompt()
                 continue
+
+            # Detect unknown TUI interactive menus (not covered by known markers).
+            # Alert Discord so the session doesn't stall silently.
+            if self._has_unknown_interactive(current):
+                unknown_interactive_stable += _POLL_INTERVAL
+                if unknown_interactive_stable >= unknown_interactive_alert_delay:
+                    logger.warning(
+                        "Unknown TUI interactive prompt detected (thread=%d)",
+                        self._thread_id,
+                    )
+                    yield StreamEvent(
+                        raw={},
+                        message_type=MessageType.SYSTEM,
+                        unknown_tui_prompt=current[-800:],
+                    )
+                    unknown_interactive_stable = 0.0  # reset to avoid spam
+                continue
+            else:
+                unknown_interactive_stable = 0.0
 
             # Extract the clean response from the TUI pane.
             response = self._extract_response(current)
@@ -493,6 +531,29 @@ class TmuxClaudeRunner:
     def _has_permission_prompt(text: str) -> bool:
         """Check if the pane shows a permission/approval prompt."""
         return any(marker in text for marker in _PERMISSION_PROMPT_MARKERS)
+
+    @staticmethod
+    def _is_yn_prompt(text: str) -> bool:
+        """Return True if the pane contains a [y/N] or [Y/n] inline prompt."""
+        return bool(_YN_PROMPT_RE.search(text))
+
+    @staticmethod
+    def _has_unknown_interactive(text: str) -> bool:
+        """Return True if the pane shows an interactive menu not covered by known markers.
+
+        Detects numbered-menu cursors (❯ 1. ...) and [y/N] prompts that do NOT
+        match any known trust or permission marker. Used to surface unknown prompts
+        to Discord rather than letting the session stall silently.
+        """
+        if not text:
+            return False
+        has_menu = bool(_INTERACTIVE_MENU_RE.search(text)) or bool(_YN_PROMPT_RE.search(text))
+        if not has_menu:
+            return False
+        # Exclude already-handled prompts so they don't double-fire.
+        if any(marker in text for marker in _TRUST_PROMPT_MARKERS):
+            return False
+        return not any(marker in text for marker in _PERMISSION_PROMPT_MARKERS)
 
     async def _accept_permission_prompt(self) -> None:
         """Auto-accept a permission prompt by pressing Enter."""

--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -359,7 +359,7 @@ class TmuxClaudeRunner:
             # Auto-accept permission prompts so the bot doesn't stall.
             if self._has_permission_prompt(current):
                 unknown_interactive_stable = 0.0
-                await self._accept_permission_prompt()
+                await self._accept_permission_prompt(current)
                 continue
 
             # Detect unknown TUI interactive menus (not covered by known markers).
@@ -555,8 +555,12 @@ class TmuxClaudeRunner:
             return False
         return not any(marker in text for marker in _PERMISSION_PROMPT_MARKERS)
 
-    async def _accept_permission_prompt(self) -> None:
-        """Auto-accept a permission prompt by pressing Enter."""
+    async def _accept_permission_prompt(self, pane_text: str = "") -> None:
+        """Auto-accept a permission prompt.
+
+        Numbered-menu prompts (❯ 1. Yes / 2. No) accept with Enter (selects highlighted).
+        Inline [y/N] prompts send "y" explicitly, because Enter selects the default N.
+        """
         logger.info(
             "Permission prompt detected, auto-accepting (thread=%d)",
             self._thread_id,
@@ -566,7 +570,8 @@ class TmuxClaudeRunner:
         window = self._tmux._find_window_for_thread(self._thread_id)
         if window:
             target = f"{self._tmux.session_name}:{window}"
-            _run(["tmux", "send-keys", "-t", target, "Enter"])
+            key = "y" if self._is_yn_prompt(pane_text) else "Enter"
+            _run(["tmux", "send-keys", "-t", target, key])
 
     @staticmethod
     def _extract_response(pane_text: str) -> str:

--- a/c_lord/claude/types.py
+++ b/c_lord/claude/types.py
@@ -168,6 +168,7 @@ class StreamEvent:
     is_plan_approval: bool = False
     permission_request: PermissionRequest | None = None
     elicitation: ElicitationRequest | None = None
+    unknown_tui_prompt: str | None = None
     is_compact: bool = False
     compact_trigger: str | None = None
     compact_pre_tokens: int | None = None

--- a/c_lord/cogs/event_processor.py
+++ b/c_lord/cogs/event_processor.py
@@ -25,6 +25,7 @@ from ..discord_ui.embeds import (
     todo_embed,
     tool_result_embed,
     tool_use_embed,
+    unknown_tui_prompt_embed,
 )
 from ..discord_ui.permission_view import PermissionView
 from ..discord_ui.plan_view import PlanApprovalView
@@ -172,6 +173,14 @@ class EventProcessor:
         # MCP elicitation — show form or URL button
         if event.elicitation is not None:
             await self._handle_elicitation(event)
+            return
+
+        # Unknown TUI interactive prompt — warn Discord so the session doesn't stall silently
+        if event.unknown_tui_prompt is not None:
+            with contextlib.suppress(Exception):
+                await self._config.thread.send(
+                    embed=unknown_tui_prompt_embed(event.unknown_tui_prompt)
+                )
             return
 
         if not event.session_id:

--- a/c_lord/discord_ui/embeds.py
+++ b/c_lord/discord_ui/embeds.py
@@ -189,6 +189,27 @@ def redacted_thinking_embed() -> discord.Embed:
     )
 
 
+def unknown_tui_prompt_embed(pane_snapshot: str) -> discord.Embed:
+    """Create a warning embed for an unknown TUI interactive prompt.
+
+    Posted when the TUI shows a selection menu that c-lord doesn't recognise,
+    so the session would otherwise stall silently. Includes the raw pane
+    snapshot to help identify the new prompt type for cataloging.
+    """
+    truncated = pane_snapshot[-800:] if len(pane_snapshot) > 800 else pane_snapshot
+    return discord.Embed(
+        title="⚠️ Unknown TUI prompt detected — session may be waiting for input",
+        description=(
+            "Claude Code is showing an interactive menu that c-lord doesn't handle yet.\n\n"
+            "**What to do:**\n"
+            "• Use `/attach` (or tmux) to respond manually\n"
+            "• Consider filing a GitHub issue to add support for this prompt\n\n"
+            f"**Pane snapshot:**\n```\n{truncated}\n```"
+        ),
+        color=0xF1C40F,  # Yellow-warning
+    )
+
+
 def error_embed(error: str) -> discord.Embed:
     """Create an embed for errors."""
     return discord.Embed(

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1603,3 +1603,33 @@ class TestUnknownTuiInteractive:
         # A y/N prompt that doesn't match any known marker
         text = "Would you like to enable auto-connect to IDE? [y/N]"
         assert TmuxClaudeRunner._has_unknown_interactive(text) is True
+
+
+# -- Tests for y/N auto-accept ------------------------------------------------
+
+
+class TestAcceptPermissionPromptYN:
+    """_accept_permission_prompt sends 'y' for [y/N] prompts, Enter for numbered menus."""
+
+    @pytest.mark.asyncio
+    async def test_yn_prompt_sends_y(self, runner, tmux_manager) -> None:
+        tmux_manager._find_window_for_thread.return_value = "work1"
+        pane_with_yn = "Continue anyway? [y/N]"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            await runner._accept_permission_prompt(pane_with_yn)
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            # Should send "y" not bare Enter
+            assert "y" in args
+
+    @pytest.mark.asyncio
+    async def test_numbered_menu_sends_enter(self, runner, tmux_manager) -> None:
+        tmux_manager._find_window_for_thread.return_value = "work1"
+        pane_numbered = "Do you want to proceed?\n❯ 1. Yes\n  2. No"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            await runner._accept_permission_prompt(pane_numbered)
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert "Enter" in args

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1507,3 +1507,99 @@ class TestContinueFallback:
         # Only one is_claude_running call (no post-continue check)
         assert tmux_manager.is_claude_running.call_count == 1
         assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)
+
+
+
+# -- Tests for new permission markers (v2.1+) ---------------------------------
+
+
+class TestPermissionPromptNewMarkers:
+    """_has_permission_prompt must detect all known Claude Code v2.1+ variants."""
+
+    def test_do_you_want_to_continue(self) -> None:
+        text = "Some context\nDo you want to continue?\n❯ 1. Yes\n  2. No"
+        assert TmuxClaudeRunner._has_permission_prompt(text) is True
+
+    def test_allow_fetch_content(self) -> None:
+        text = "Do you want to allow Claude to fetch this content?\n❯ 1. Yes\n  2. No"
+        assert TmuxClaudeRunner._has_permission_prompt(text) is True
+
+    def test_allow_connection(self) -> None:
+        text = "Do you want to allow this connection?\n❯ 1. Yes\n  2. No"
+        assert TmuxClaudeRunner._has_permission_prompt(text) is True
+
+    def test_continue_anyway_yn(self) -> None:
+        text = "Security warnings found.\nContinue anyway? [y/N]"
+        assert TmuxClaudeRunner._has_permission_prompt(text) is True
+
+    def test_existing_proceed_still_detected(self) -> None:
+        text = "Do you want to proceed?\n❯ 1. Yes"
+        assert TmuxClaudeRunner._has_permission_prompt(text) is True
+
+
+# -- Tests for y/N prompt detection -------------------------------------------
+
+
+class TestYesNoPromptDetection:
+    """_is_yn_prompt distinguishes [y/N] style from numbered-menu style."""
+
+    def test_detects_yn_format(self) -> None:
+        text = "Continue anyway? [y/N]"
+        assert TmuxClaudeRunner._is_yn_prompt(text) is True
+
+    def test_detects_yn_uppercase_Y(self) -> None:
+        text = "Security warning. Continue anyway? [Y/n]"
+        assert TmuxClaudeRunner._is_yn_prompt(text) is True
+
+    def test_numbered_menu_is_not_yn(self) -> None:
+        text = "Do you want to proceed?\n❯ 1. Yes\n  2. No"
+        assert TmuxClaudeRunner._is_yn_prompt(text) is False
+
+
+# -- Tests for unknown TUI interactive detection ------------------------------
+
+
+class TestUnknownTuiInteractive:
+    """_has_unknown_interactive detects menu cursors not matching known prompts."""
+
+    def test_detects_unknown_numbered_menu(self) -> None:
+        # A numbered menu that does NOT match any known marker
+        text = (
+            "Would you like to stash these changes and continue with teleport?\n"
+            "❯ 1. Yes, stash and continue\n"
+            "  2. No, abort"
+        )
+        assert TmuxClaudeRunner._has_unknown_interactive(text) is True
+
+    def test_known_permission_prompt_is_not_unknown(self) -> None:
+        # Known prompt — should NOT trigger unknown detection
+        text = "Do you want to proceed?\n❯ 1. Yes\n  2. No"
+        assert TmuxClaudeRunner._has_unknown_interactive(text) is False
+
+    def test_known_trust_prompt_is_not_unknown(self) -> None:
+        text = "Yes, I trust this folder\nEnter to confirm"
+        assert TmuxClaudeRunner._has_unknown_interactive(text) is False
+
+    def test_normal_idle_prompt_is_not_unknown(self) -> None:
+        # The bare ❯ input prompt (idle state) — NOT an interactive menu
+        text = "● Some response\n\n────────\n❯\n────────\n-- INSERT --"
+        assert TmuxClaudeRunner._has_unknown_interactive(text) is False
+
+    def test_empty_text_is_not_unknown(self) -> None:
+        assert TmuxClaudeRunner._has_unknown_interactive("") is False
+
+    def test_install_prompt_detected(self) -> None:
+        text = "Would you like to install this LSP plugin?\n❯ 1. Yes\n  2. No"
+        assert TmuxClaudeRunner._has_unknown_interactive(text) is True
+
+    def test_update_prompt_detected(self) -> None:
+        text = (
+            "A new version of Claude Code is available.\n"
+            "Update now? [y/N]"
+        )
+        assert TmuxClaudeRunner._has_unknown_interactive(text) is True
+
+    def test_yn_unknown_prompt_detected(self) -> None:
+        # A y/N prompt that doesn't match any known marker
+        text = "Would you like to enable auto-connect to IDE? [y/N]"
+        assert TmuxClaudeRunner._has_unknown_interactive(text) is True


### PR DESCRIPTION
## Summary

- Claude Code v2.1+ で新たに確認されたパーミッション確認文字列を `_PERMISSION_PROMPT_MARKERS` に追加
- `[y/N]` 形式のインラインプロンプト検出 (`_YN_PROMPT_RE`)
- 未知のインタラクティブメニュー検出 (`_has_unknown_interactive`) — 既知マーカーに一致しない `❯ 1.` 形式や `[y/N]` を検出
- 5 秒安定したら Discord に ⚠️ 警告 embed を投稿（pane スナップショット + 手動対応ガイド付き）

## Changes

- `c_lord/claude/tmux_runner.py`: 新マーカー追加、`_is_yn_prompt`・`_has_unknown_interactive` メソッド追加、未知プロンプト検出ループ
- `c_lord/claude/types.py`: `StreamEvent.unknown_tui_prompt` フィールド追加
- `c_lord/discord_ui/embeds.py`: `unknown_tui_prompt_embed()` 追加
- `c_lord/cogs/event_processor.py`: `unknown_tui_prompt` イベントハンドラ追加
- `tests/test_tmux_runner.py`: 16 テスト追加

## Test plan

- [x] 942 テスト全 PASS
- [x] `ruff check` + `ruff format --check` OK
- [ ] staging で既知パーミッションプロンプトが引き続き自動 Enter されること
- [ ] staging で未知プロンプト相当のシナリオで Discord 警告 embed が表示されること

Closes #110 Phase 3 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)