### PR TITLE
ci: main にブランチ保護を設定し dod-gate を required にする (#155)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,7 @@ PR. When you (or Opus) author an Issue:
 - **No direct push to main**: Always create a PR
 - **Squash merge preferred**: Keeps main history clean
 - **Commit style**: `<type>: <description>` — types: feat, fix, refactor, docs, test, chore, security
+- **Required checks**: `dod-gate` and `test (3.10/3.11/3.12)` are required status checks on `main`. **A PR with a red `dod-gate` cannot be merged — not by humans, not by sub-Claude.** If `dod-gate` is red, fix the PR body or the issue before merging. `enforce_admins=true` means the admin account is also blocked.
 
 ### Standard Development Flow (Mandatory)
 


### PR DESCRIPTION
## 概要

- `main` ブランチに保護ルールを設定（GitHub API で適用）
- CLAUDE.md に「required check が赤の PR はマージ不可（sub-Claude 含む）」を明記

## Acceptance Criteria

- [x] `dod-gate` が required status checks に入っている
- [x] `test (3.10)` / `test (3.11)` / `test (3.12)` が required status checks に入っている
- [x] `enforce_admins=true` — admin アカウントも赤を越えられない
- [x] CLAUDE.md に制約が明記されている

## Staging Evidence

ブランチ保護は GitHub API で直接適用（コード変更なし）。適用後の設定確認：

```bash
gh api repos/yousan/c-lord/branches/main/protection \
  | python3 -c "import sys,json; p=json.load(sys.stdin); \
    print('enforce_admins:', p['enforce_admins']['enabled']); \
    print('required_checks:', [c['context'] for c in p['required_status_checks']['checks']])"
```

期待出力:
```
enforce_admins: True
required_checks: ['dod-gate', 'test (3.10)', 'test (3.11)', 'test (3.12)']
```

このPR自体が `dod-gate` + tests を通過してからマージする。

## Definition of Done checklist

- [x] TDD evidence: N/A（Python コード変更なし）
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` all green（CI確認）
- [x] Staging behavior verified: ブランチ保護API適用確認（下記）
- [x] No unrelated changes in diff
- [x] Closes discipline: `Closes #155` — 全AC達成

Closes #155