### PR TITLE
fix: dedupe unknown_tui_prompt alerts so they don't re-fire every 5s (#165)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -38,6 +38,10 @@ _IDLE_TIMEOUT = 15.0
 # How long to wait for Claude to become ready (show input prompt).
 _STARTUP_TIMEOUT = 30.0
 
+# How long an unknown interactive menu must be continuously visible before we
+# alert Discord (seconds).  Guards against transient TUI redraws.
+_UNKNOWN_ALERT_DELAY = 5.0
+
 # Delay after startup before polling begins (seconds).
 _POST_STARTUP_DELAY = 1.0
 
@@ -101,6 +105,28 @@ def _permission_zone(text: str) -> str:
     """
     lines = text.splitlines()
     return "\n".join(lines[-_PERMISSION_SCAN_LINES:])
+
+
+# Matches a numbered menu item line, with or without the leading ❯ cursor:
+# "❯ 1. Production", "  2. Staging".  Used to build a stable signature of an
+# unknown menu so duplicate alerts can be suppressed (#165).
+_MENU_ITEM_RE = re.compile(r"^\s*❯?\s*(\d+\..*\S)\s*$", re.MULTILINE)
+
+
+def _unknown_prompt_signature(text: str) -> str:
+    """Stable identity of an unknown interactive prompt, ignoring volatile chrome.
+
+    The pane's spinner, elapsed-seconds and cost rows change on every poll, so
+    comparing raw captures would defeat dedup.  We key on the menu's option
+    lines (cursor stripped) plus any inline [y/N] line — the parts that stay
+    constant while the same menu lingers (#165).
+    """
+    zone = _permission_zone(text)
+    sig_lines = [m.strip() for m in _MENU_ITEM_RE.findall(zone)]
+    for line in zone.splitlines():
+        if _YN_PROMPT_RE.search(line):
+            sig_lines.append(line.strip())
+    return "\n".join(sig_lines)
 
 
 # Regex for separator lines (all box-drawing horizontal characters).
@@ -379,7 +405,10 @@ class TmuxClaudeRunner:
         # We require it to be stable for this long before alerting Discord,
         # to avoid false positives from transient TUI redraws.
         unknown_interactive_stable = 0.0
-        unknown_interactive_alert_delay = 5.0
+        # Signature of the last menu we already alerted on.  While the same menu
+        # lingers we must NOT re-alert every poll (#165); we re-alert only when
+        # the menu changes or after it clears (reset to None below).
+        last_alerted_unknown: str | None = None
 
         while not self._stopped and elapsed < self.timeout_seconds:
             await asyncio.sleep(_POLL_INTERVAL)
@@ -390,6 +419,7 @@ class TmuxClaudeRunner:
             # Auto-accept permission prompts so the bot doesn't stall.
             if self._has_permission_prompt(current):
                 unknown_interactive_stable = 0.0
+                last_alerted_unknown = None
                 await self._accept_permission_prompt(current)
                 continue
 
@@ -397,20 +427,26 @@ class TmuxClaudeRunner:
             # Alert Discord so the session doesn't stall silently.
             if self._has_unknown_interactive(current):
                 unknown_interactive_stable += _POLL_INTERVAL
-                if unknown_interactive_stable >= unknown_interactive_alert_delay:
-                    logger.warning(
-                        "Unknown TUI interactive prompt detected (thread=%d)",
-                        self._thread_id,
-                    )
-                    yield StreamEvent(
-                        raw={},
-                        message_type=MessageType.SYSTEM,
-                        unknown_tui_prompt=current[-800:],
-                    )
-                    unknown_interactive_stable = 0.0  # reset to avoid spam
+                if unknown_interactive_stable >= _UNKNOWN_ALERT_DELAY:
+                    signature = _unknown_prompt_signature(current)
+                    if signature != last_alerted_unknown:
+                        logger.warning(
+                            "Unknown TUI interactive prompt detected (thread=%d)",
+                            self._thread_id,
+                        )
+                        yield StreamEvent(
+                            raw={},
+                            message_type=MessageType.SYSTEM,
+                            unknown_tui_prompt=current[-800:],
+                        )
+                        last_alerted_unknown = signature
+                    # Reset the stability timer either way so we re-evaluate the
+                    # signature on the next dwell window rather than every poll.
+                    unknown_interactive_stable = 0.0
                 continue
             else:
                 unknown_interactive_stable = 0.0
+                last_alerted_unknown = None
 
             # Extract the clean response from the TUI pane.
             response = self._extract_response(current)

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1731,3 +1731,100 @@ class TestGhostTextInputNotFlagged:
         """Ghost text in input area MUST NOT trigger _has_unknown_interactive."""
         pane = _load_fixture("bug_62_ghost_text_input.txt")
         assert TmuxClaudeRunner._has_unknown_interactive(pane) is False
+
+
+# -- Regression tests for #165 (unknown_tui_prompt re-fire spam) ---------------
+
+_UNKNOWN_MENU_A = (
+    "● Bash(python3 menu.py)\n"
+    "  ⎿  Select deployment target:\n"
+    "     ❯ 1. Production\n"
+    "       2. Staging\n"
+    "       3. Cancel\n"
+    "✻ Cogitated for {n}s\n"
+    "────────\n❯\n────────\n-- INSERT --"
+)
+
+_UNKNOWN_MENU_B = (
+    "● Bash(python3 other.py)\n"
+    "  ⎿  Choose a branch:\n"
+    "     ❯ 1. main\n"
+    "       2. develop\n"
+    "✻ Cogitated for {n}s\n"
+    "────────\n❯\n────────\n-- INSERT --"
+)
+
+_DONE_PANE = "● All done!\n\n────────\n❯\n────────\n-- INSERT --"
+
+
+class TestUnknownPromptDedup:
+    """Regression for #165: an unknown menu that lingers in the pane must
+    trigger the unknown_tui_prompt embed only ONCE, not every ~5s.  The
+    volatile chrome (spinner / elapsed seconds) must not defeat the dedup.
+    A *different* menu, or the same menu reappearing after it cleared, must
+    alert again.
+    """
+
+    @pytest.mark.asyncio
+    async def test_same_menu_fires_once(self, runner, tmux_manager) -> None:
+        """A lingering unknown menu yields exactly one unknown_tui_prompt event."""
+        tmux_manager.is_claude_running.return_value = True
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            # Same menu for many polls (volatile spinner seconds change each poll),
+            # then a completed pane so the run loop can finish.
+            if call_idx <= 12:
+                return _UNKNOWN_MENU_A.format(n=call_idx)
+            return _DONE_PANE
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.02),
+            patch("c_lord.claude.tmux_runner._UNKNOWN_ALERT_DELAY", 0.04),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.0),
+        ):
+            async for event in runner.run("test"):
+                events.append(event)
+
+        unknown_events = [e for e in events if e.unknown_tui_prompt is not None]
+        assert len(unknown_events) == 1, (
+            f"expected exactly 1 unknown_tui_prompt event, got {len(unknown_events)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_different_menu_fires_again(self, runner, tmux_manager) -> None:
+        """A second, distinct unknown menu must alert again (not be suppressed)."""
+        tmux_manager.is_claude_running.return_value = True
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            if call_idx <= 6:
+                return _UNKNOWN_MENU_A.format(n=call_idx)
+            if call_idx <= 12:
+                return _UNKNOWN_MENU_B.format(n=call_idx)
+            return _DONE_PANE
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.02),
+            patch("c_lord.claude.tmux_runner._UNKNOWN_ALERT_DELAY", 0.04),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.0),
+        ):
+            async for event in runner.run("test"):
+                events.append(event)
+
+        unknown_events = [e for e in events if e.unknown_tui_prompt is not None]
+        assert len(unknown_events) == 2, (
+            f"expected 2 unknown_tui_prompt events (menu A then B), got {len(unknown_events)}"
+        )


### PR DESCRIPTION
## What does this PR do?

Suppress duplicate `unknown_tui_prompt` warning embeds while the same unknown interactive menu lingers in the pane. Alert only when the menu's content changes or after it clears.

## Why?

Closes #165

Discovered during #154 staging verification: while an unknown `❯ N.` menu stayed visible, the warning embed re-fired every ~5s — **43 embeds for a single menu**. The old `unknown_interactive_stable = 0.0  # reset to avoid spam` only reset the 5s dwell timer; it never deduped by content.

## Approach

- New `_unknown_prompt_signature(text)` builds a stable identity from the menu's option lines (leading `❯` cursor stripped) + any inline `[y/N]` line — ignoring volatile chrome (spinner, elapsed-seconds, cost rows) that changes every poll.
- The run loop tracks `last_alerted_unknown`; it yields the event only when the signature differs from the last alert, and resets to `None` when the menu clears (or a permission prompt appears) so a later/different menu alerts again.
- Extracted the hardcoded `5.0` dwell into module-level `_UNKNOWN_ALERT_DELAY` so tests can patch it.

## Acceptance Criteria (copied from the issue)

- [x] 同一内容の `unknown_tui_prompt` が連続するポーリングで検出された場合、2回目以降は embed を投稿しない（テキスト変化 or クリアまで抑制）
- [x] 上記を検証する回帰テストを追加（同一ペインで複数回ポーリング → イベントは1回だけ yield）— `TestUnknownPromptDedup::test_same_menu_fires_once`
- [x] 別の未知メニューに変わったら再度1回発火することをテストで担保 — `TestUnknownPromptDedup::test_different_menu_fires_again`

## Staging Evidence

Re-ran the **exact** scenario from #154 (a `❯ N.` menu held stable via `sleep`) on the staging bot (`c-lord-parallel-3`).

**RED (before, from #154):** same scenario fired **43×** in the log and posted multiple warning embeds to Discord.

**GREEN (after, this branch deployed to staging):**
```
baseline fires=0
2026-05-26 20:37:26 [WARNING] tmux_runner: Unknown TUI interactive prompt detected (thread=1508274772641972374)
=== fires after fix: 1 ===
```
Discord: exactly **1** `⚠️ Unknown TUI prompt detected` embed (11:37:26 UTC) for the post-fix run (verified via REST API). Waited 25s+ after first detection — no re-fire.

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED: `AttributeError: ... does not have the attribute '_UNKNOWN_ALERT_DELAY'`) and passes after (GREEN)
- [x] `uv run pytest tests/ -v` passes — 1132 passed
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (RED 43× → GREEN 1×)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #165` — satisfies 100% of the issue's ACs