### PR TITLE
feat: show AskUserQuestion option descriptions in Discord (button mode) (#169)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -196,18 +196,30 @@ def _parse_ask_from_pane(text: str) -> AskQuestion | None:
     # above the menu end) down to the menu end — never the whole buffer.
     scan_from = header_idx + 1 if header_idx >= 0 else max(0, end_idx - 20)
 
+    # Indices of every numbered line (including meta-options) within the menu —
+    # used to bound the region from which each real option's description is read.
+    all_opt_indices = [i for i in range(scan_from, end_idx + 1) if _ASK_OPTION_RE.match(lines[i])]
+
     options: list[AskOption] = []
     first_opt_idx: int | None = None
-    for i in range(scan_from, end_idx + 1):
-        m = _ASK_OPTION_RE.match(lines[i])
-        if not m:
-            continue
-        label = m.group(1).strip()
+    for pos, i in enumerate(all_opt_indices):
+        label = _ASK_OPTION_RE.match(lines[i]).group(1).strip()  # type: ignore[union-attr]
         if label in _ASK_META_LABELS:
             continue
         if first_opt_idx is None:
             first_opt_idx = i
-        options.append(AskOption(label=label))
+        # Description (#169): the first non-empty, non-separator line between this
+        # option and the next numbered line — Claude renders it indented below
+        # the option.  Empty when the option has no description.
+        next_i = all_opt_indices[pos + 1] if pos + 1 < len(all_opt_indices) else end_idx + 1
+        description = ""
+        for j in range(i + 1, next_i):
+            s = lines[j].strip()
+            if not s or _SEPARATOR_RE.match(lines[j]):
+                continue
+            description = s
+            break
+        options.append(AskOption(label=label, description=description))
 
     if not options:
         return None

--- a/c_lord/discord_ui/ask_handler.py
+++ b/c_lord/discord_ui/ask_handler.py
@@ -55,7 +55,12 @@ async def bridge_pane_ask(
     """
     answer_queue = _ask_bus.register(thread.id)
     view = AskView(question, thread_id=thread.id, q_idx=0, ask_repo=ask_repo)
-    msg = await thread.send(embed=ask_embed(question.question, question.header), view=view)
+    msg = await thread.send(
+        embed=ask_embed(
+            question.question, question.header, question.options, question.multi_select
+        ),
+        view=view,
+    )
 
     try:
         selected = await asyncio.wait_for(answer_queue.get(), timeout=ASK_ANSWER_TIMEOUT)
@@ -129,7 +134,9 @@ async def collect_ask_answers(
         answer_queue = _ask_bus.register(thread.id)
 
         view = AskView(q, thread_id=thread.id, q_idx=q_idx, ask_repo=ask_repo)
-        msg = await thread.send(embed=ask_embed(q.question, q.header), view=view)
+        msg = await thread.send(
+            embed=ask_embed(q.question, q.header, q.options, q.multi_select), view=view
+        )
 
         try:
             selected = await asyncio.wait_for(answer_queue.get(), timeout=ASK_ANSWER_TIMEOUT)

--- a/c_lord/discord_ui/embeds.py
+++ b/c_lord/discord_ui/embeds.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import discord
 
-from ..claude.types import TodoItem, ToolCategory, ToolUseEvent
+from ..claude.types import AskOption, TodoItem, ToolCategory, ToolUseEvent
 
 # Colors
 COLOR_INFO = 0x5865F2  # Discord blurple
@@ -233,12 +233,29 @@ def timeout_embed(seconds: int) -> discord.Embed:
     )
 
 
-def ask_embed(question: str, header: str = "") -> discord.Embed:
-    """Create an embed for an AskUserQuestion interactive prompt."""
+def ask_embed(
+    question: str,
+    header: str = "",
+    options: list[AskOption] | None = None,
+    multi_select: bool = False,
+) -> discord.Embed:
+    """Create an embed for an AskUserQuestion interactive prompt.
+
+    When *options* render as buttons (≤4 options, single-select), a legend of
+    ``**label** — description`` lines is appended to the body: Discord buttons
+    cannot show option descriptions, so without this a viewer sees only opaque
+    labels (#169).  The Select-menu case (≥5 options) shows descriptions in the
+    dropdown itself, so no legend is added there.
+    """
     title = f"❓ {header}" if header else "❓ Claude needs your input"
+    body = question
+    if options and not multi_select and len(options) <= 4:
+        legend = "\n".join(f"**{o.label}** — {o.description}" for o in options if o.description)
+        if legend:
+            body = f"{question}\n\n{legend}"
     return discord.Embed(
         title=title[:256],
-        description=question[:4096],
+        description=body[:4096],
         color=COLOR_ASK,
     )
 

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -2,14 +2,53 @@
 
 from __future__ import annotations
 
-from c_lord.claude.types import ToolCategory, ToolUseEvent
+from c_lord.claude.types import AskOption, ToolCategory, ToolUseEvent
 from c_lord.discord_ui.embeds import (
+    ask_embed,
     redacted_thinking_embed,
     session_complete_embed,
     thinking_embed,
     tool_result_embed,
     tool_use_embed,
 )
+
+
+class TestAskEmbedLegend:
+    """#169: option descriptions must reach Discord.  Buttons (≤4 options) can't
+    show descriptions, so ask_embed appends a `**label** — description` legend.
+    """
+
+    def _opts(self) -> list[AskOption]:
+        return [
+            AskOption(label="Production", description="本番"),
+            AskOption(label="Staging", description="検証"),
+        ]
+
+    def test_button_mode_appends_legend(self) -> None:
+        e = ask_embed("Which env?", "Deploy", self._opts(), multi_select=False)
+        assert "**Production** — 本番" in e.description
+        assert "**Staging** — 検証" in e.description
+        assert e.description.startswith("Which env?")
+
+    def test_select_mode_no_legend(self) -> None:
+        """≥5 options → Select menu shows descriptions itself; no embed legend."""
+        opts = [AskOption(label=f"O{i}", description=f"d{i}") for i in range(5)]
+        e = ask_embed("Pick", "H", opts, multi_select=False)
+        assert e.description == "Pick"
+
+    def test_multiselect_no_legend(self) -> None:
+        """multi_select renders a Select menu → no legend."""
+        e = ask_embed("Pick", "H", self._opts(), multi_select=True)
+        assert e.description == "Pick"
+
+    def test_options_without_descriptions_no_legend(self) -> None:
+        opts = [AskOption(label="Yes"), AskOption(label="No")]
+        e = ask_embed("OK?", "H", opts)
+        assert e.description == "OK?"
+
+    def test_no_options_unchanged(self) -> None:
+        e = ask_embed("Just a question", "H")
+        assert e.description == "Just a question"
 
 
 class TestThinkingEmbed:

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1766,6 +1766,16 @@ class TestParseAskFromPane:
         assert "Type something." not in labels
         assert "Chat about this" not in labels
 
+    def test_captures_option_descriptions(self) -> None:
+        """#169: each option's indented description line must be captured so it
+        can be shown in the embed (Discord buttons can't display descriptions).
+        """
+        pane = _load_fixture("ask_user_question_3options.txt")
+        q = _parse_ask_from_pane(pane)
+        assert q is not None
+        descriptions = [o.description for o in q.options]
+        assert descriptions == ["本番", "検証", "ローカル"]
+
     def test_plan_approval_is_not_ask(self) -> None:
         """A Plan-approval menu is NOT an AskUserQuestion → returns None."""
         pane = _load_fixture("plan_approval_menu.txt")


### PR DESCRIPTION
## What does this PR do?

When an AskUserQuestion renders as Discord **buttons** (≤4 options), the option descriptions are now shown as a legend in the embed body. Previously a viewer saw only opaque labels (OptionA/B/C) because Discord buttons have no description field.

## Why?

Closes #169 (follow-up to #166, spotted reviewing the production screenshot — labels alone weren't self-explanatory).

## Acceptance Criteria (copied from the issue)

- [x] `_parse_ask_from_pane` が各オプションの description（直後のインデント行）を `AskOption.description` に格納する
- [x] 説明文付きの実ペイン snapshot を fixture 化し、パーサが label と description の両方を返すことをユニットテストで担保 (`test_captures_option_descriptions`, fixture `ask_user_question_3options.txt`)
- [x] ボタン表示時（≤4）、embed 本文に各選択肢の `ラベル — 説明` が凡例として表示される (`TestAskEmbedLegend::test_button_mode_appends_legend`)
- [x] 説明が空の選択肢では凡例にその行を出さない／ボタン自体は不変 (`test_options_without_descriptions_no_legend`)
- [x] Select 表示時（≥5）の description 表示は従来どおり・凡例なし (`test_select_mode_no_legend`, `test_multiselect_no_legend`)
- [x] staging で説明文付き AskUserQuestion を踏ませ、Discord 本文に説明が出ることを確認（下記 Staging Evidence）

## Staging Evidence

Real webhook-triggered run on staging (`c-lord-parallel-3`, jsonl mode). Triggered an AskUserQuestion whose meaning lives in the descriptions (A案/B案/C案).

```
log: AskUserQuestion menu detected, bridging to Discord (thread=…)
```
Discord embed (fetched via REST API):
```
TITLE: ❓ Approach
BODY:
実装方針は?

**A案** — その場で書き換える
**B案** — 新規ファイルを作る
**C案** — いったん保留
BUTTONS: ['A案', 'B案', 'C案', '✏️ Other']
```
A Discord-only viewer can now distinguish the options (RED: pre-fix the body was just "実装方針は?" with no legend).

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: `test_captures_option_descriptions` failed before (RED) / passes after (GREEN)
- [x] `uv run pytest tests/ -v` passes — 1154 passed
- [x] `uv run ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #169`