### PR TITLE
fix: send menu-nav keystrokes one at a time so the right option is selected (#171)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -52,6 +52,12 @@ _UNKNOWN_ALERT_DELAY = 5.0
 # expected prompt — but still guards against a half-drawn menu frame (#166).
 _ASK_ALERT_DELAY = 1.5
 
+# Delay between individual menu-navigation keystrokes (seconds).  Keys must be
+# sent one at a time with a gap — batching `Down Down Enter` into one send-keys
+# call is too fast and the TUI drops the navigations, selecting the wrong
+# option (#171).
+_MENU_NAV_DELAY = 0.25
+
 # Delay after startup before polling begins (seconds).
 _POST_STARTUP_DELAY = 1.0
 
@@ -832,6 +838,19 @@ class TmuxClaudeRunner:
             key = "y" if self._is_yn_prompt(pane_text) else "Enter"
             _run(["tmux", "send-keys", "-t", target, key])
 
+    async def _navigate_menu(self, index: int) -> None:
+        """Move the menu cursor down *index* times then confirm with Enter.
+
+        Each key is sent as a SEPARATE ``send-keys`` call with a delay between
+        them (#171): batching them into one ``send-keys Down Down Enter`` is too
+        fast — the TUI drops the Down navigations and Enter selects the wrong
+        (first) option.
+        """
+        for _ in range(max(0, index)):
+            await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Down")
+            await asyncio.sleep(_MENU_NAV_DELAY)
+        await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Enter")
+
     async def answer_menu(self, index: int) -> None:
         """Select option *index* (0-based) of an open AskUserQuestion menu (#166).
 
@@ -845,8 +864,7 @@ class TmuxClaudeRunner:
             index,
             self._thread_id,
         )
-        keys: list[str] = ["Down"] * max(0, index) + ["Enter"]
-        await asyncio.to_thread(self._tmux.send_keys, self._thread_id, *keys)
+        await self._navigate_menu(index)
 
     async def answer_menu_text(self, text_option_index: int, text: str) -> None:
         """Answer via the free-text ("Type something.") affordance (#166).
@@ -859,9 +877,8 @@ class TmuxClaudeRunner:
             "Answering AskUserQuestion with free text (thread=%d)",
             self._thread_id,
         )
-        keys: list[str] = ["Down"] * max(0, text_option_index) + ["Enter"]
-        await asyncio.to_thread(self._tmux.send_keys, self._thread_id, *keys)
-        await asyncio.sleep(0.3)
+        await self._navigate_menu(text_option_index)
+        await asyncio.sleep(_MENU_NAV_DELAY)
         await asyncio.to_thread(self._tmux.send_input, self._thread_id, text)
 
     async def cancel_menu(self) -> None:

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1943,16 +1943,43 @@ class TestRunYieldsPaneAsk:
         assert [o.label for o in ask_events[0].pane_ask.options] == ["Coffee", "Tea", "Water"]
 
     @pytest.mark.asyncio
-    async def test_answer_menu_sends_down_then_enter(self, runner, tmux_manager) -> None:
-        """answer_menu(2) navigates Down twice and confirms with Enter."""
-        await runner.answer_menu(2)
-        tmux_manager.send_keys.assert_called_once_with(12345, "Down", "Down", "Enter")
+    async def test_answer_menu_sends_each_key_separately(self, runner, tmux_manager) -> None:
+        """#171: keys must be sent ONE PER send_keys call (with delays between),
+        not batched — a single `send-keys Down Down Enter` is too fast and the
+        TUI drops the Down navigations, selecting the wrong (first) option.
+        """
+        from unittest.mock import call
+
+        with patch("c_lord.claude.tmux_runner._MENU_NAV_DELAY", 0.0):
+            await runner.answer_menu(2)
+        assert tmux_manager.send_keys.call_args_list == [
+            call(12345, "Down"),
+            call(12345, "Down"),
+            call(12345, "Enter"),
+        ]
 
     @pytest.mark.asyncio
     async def test_answer_menu_zero_just_enter(self, runner, tmux_manager) -> None:
         """answer_menu(0) selects the first (already-highlighted) option."""
-        await runner.answer_menu(0)
+        with patch("c_lord.claude.tmux_runner._MENU_NAV_DELAY", 0.0):
+            await runner.answer_menu(0)
         tmux_manager.send_keys.assert_called_once_with(12345, "Enter")
+
+    @pytest.mark.asyncio
+    async def test_answer_menu_text_navigates_then_types(self, runner, tmux_manager) -> None:
+        """#171: free-text path navigates to 'Type something.' one key at a time,
+        then sends the literal text via send_input.
+        """
+        from unittest.mock import call
+
+        with patch("c_lord.claude.tmux_runner._MENU_NAV_DELAY", 0.0):
+            await runner.answer_menu_text(2, "melon")
+        assert tmux_manager.send_keys.call_args_list == [
+            call(12345, "Down"),
+            call(12345, "Down"),
+            call(12345, "Enter"),
+        ]
+        tmux_manager.send_input.assert_called_once_with(12345, "melon")
 
 
 # -- Regression tests for #165 (unknown_tui_prompt re-fire spam) ---------------


### PR DESCRIPTION
## What does this PR do?

Fixes a **critical regression in #166** (already in production): clicking any non-first AskUserQuestion button selected the **first** option. `answer_menu` batched all keys into one `send-keys Down Down Enter`, which the TUI processes too fast — the `Down` navigations were dropped. Now each key is a separate `send-keys` call with `_MENU_NAV_DELAY` (0.25s) between them, via a shared `_navigate_menu` helper.

## Why?

Closes #171. Refs #172 (free-text ✏️ Other is a separate, deeper issue — see below).

## How the regression slipped through #166

The #166 staging/prod "selection" checks sent keys **manually with sleeps** (`Down` → wait → `Enter`), not via the bot's own batched `answer_menu`. So the real answer path was never exercised. This PR's staging evidence runs the **actual `answer_menu` method**.

## Acceptance Criteria

- [x] `answer_menu` sends each key individually with a delay (`Down`×index one at a time → `Enter`)
- [x] `answer_menu_text` keystroke sending likewise individual + delayed
- [x] Unit test asserts `answer_menu(2)` calls `send_keys` **3 times separately** (`Down`/`Down`/`Enter`), not batched
- [x] Staging: the **real `answer_menu`** correctly selects the 2nd/3rd option

## Staging Evidence

Ran the **actual bot code** (`TmuxClaudeRunner.answer_menu`) against a live staging menu — no manual key spacing:

```python
runner = TmuxClaudeRunner(tmux_manager=TmuxSessionManager(session_name='c-lord-parallel-3'),
                          thread_id=1508274772641972374, model='sonnet')
asyncio.run(runner.answer_menu(2))   # select 3rd option
```
RED (pre-fix, batched send): `「3択ナビ → First」` (wrong — selected 1st).
GREEN (this branch, real `answer_menu(2)`): `「実コードで3番目選択 → Tres」` (correct — selected 3rd) ✅

## Out of scope → #172

Free-text (✏️ Other / "Type something.") does **not** work: navigating to "Type something." + Enter registers as *"User declined to answer questions"* and the typed text becomes a separate message. This is a different root cause (the TUI's free-text interaction model, not keystroke timing) and is tracked in #172.

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: per-key test failed before (RED, batched single call) / passes after (GREEN)
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/` pass
- [x] Staging Evidence above (real answer_menu, RED→GREEN)
- [x] No unrelated changes; self-review done
- [x] `Closes #171` (option-selection); `Refs #172` for the deferred free-text work