### PR TITLE
fix: jsonl reply/file sink で trigger_message_id を DB フォールバック (#149)

### DIFF
--- a/c_lord/cogs/transcript_mirror.py
+++ b/c_lord/cogs/transcript_mirror.py
@@ -175,6 +175,11 @@ class TranscriptMirrorCog(commands.Cog):
             if table_files:
                 send_kwargs["files"] = table_files
             trigger_id = self._trigger_messages.get(thread_id)
+            if trigger_id is None:
+                with contextlib.suppress(Exception):
+                    record = await self._session_repo.get(thread_id)
+                    if record is not None:
+                        trigger_id = record.trigger_message_id
             if trigger_id is not None and reply_to_trigger_enabled():
                 send_kwargs["reference"] = discord.MessageReference(
                     message_id=trigger_id,
@@ -222,6 +227,11 @@ class TranscriptMirrorCog(commands.Cog):
             files = [discord.File(file_path, filename="progress.txt")] + table_files
             send_kwargs: dict = {"content": body, "files": files}
             trigger_id = self._trigger_messages.get(thread_id)
+            if trigger_id is None:
+                with contextlib.suppress(Exception):
+                    record = await self._session_repo.get(thread_id)
+                    if record is not None:
+                        trigger_id = record.trigger_message_id
             if trigger_id is not None and reply_to_trigger_enabled():
                 send_kwargs["reference"] = discord.MessageReference(
                     message_id=trigger_id,

--- a/tests/test_transcript_mirror_cog.py
+++ b/tests/test_transcript_mirror_cog.py
@@ -558,3 +558,155 @@ async def test_file_sink_uses_reference(monkeypatch: pytest.MonkeyPatch, tmp_pat
     ref = call_kwargs.get("reference")
     assert ref is not None
     assert ref.message_id == 8888
+
+
+# ---------------------------------------------------------------------------
+# Issue #149: DB fallback for trigger_message_id when in-memory is absent
+# ---------------------------------------------------------------------------
+
+
+def _make_repo_with_trigger(trigger_message_id: int | None) -> MagicMock:
+    repo = MagicMock()
+    repo.list_all = AsyncMock(return_value=[])
+    record = MagicMock()
+    record.trigger_message_id = trigger_message_id
+    repo.get = AsyncMock(return_value=record)
+    return repo
+
+
+async def test_reply_sink_falls_back_to_db_trigger_when_inmemory_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-memory absent + DB has trigger_message_id → reply_sink attaches reference."""
+    monkeypatch.delenv("CLORD_REPLY_TO_TRIGGER", raising=False)
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo_with_trigger(7777))
+    reply_sink = cog._make_reply_sink(42)
+    await reply_sink("final answer")
+
+    call_kwargs = channel.send.call_args.kwargs
+    assert call_kwargs.get("mention_author") is False
+    ref = call_kwargs.get("reference")
+    assert ref is not None
+    assert ref.message_id == 7777
+
+
+async def test_reply_sink_inmemory_takes_priority_over_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When in-memory is registered, it is used (DB is not consulted)."""
+    monkeypatch.delenv("CLORD_REPLY_TO_TRIGGER", raising=False)
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    repo = _make_repo_with_trigger(9999)
+    cog = TranscriptMirrorCog(bot, session_repo=repo)
+    cog.set_trigger_message(42, 1234)
+    reply_sink = cog._make_reply_sink(42)
+    await reply_sink("final answer")
+
+    ref = channel.send.call_args.kwargs.get("reference")
+    assert ref is not None
+    assert ref.message_id == 1234
+    repo.get.assert_not_called()
+
+
+async def test_reply_sink_no_reference_when_db_also_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When in-memory is absent and DB has no trigger_message_id, sends normally."""
+    monkeypatch.delenv("CLORD_REPLY_TO_TRIGGER", raising=False)
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo_with_trigger(None))
+    reply_sink = cog._make_reply_sink(42)
+    await reply_sink("final answer")
+
+    call_kwargs = channel.send.call_args.kwargs
+    assert "reference" not in call_kwargs
+
+
+async def test_reply_sink_no_reference_when_db_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB error in fallback does not crash reply_sink — sends normally."""
+    monkeypatch.delenv("CLORD_REPLY_TO_TRIGGER", raising=False)
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    repo = MagicMock()
+    repo.list_all = AsyncMock(return_value=[])
+    repo.get = AsyncMock(side_effect=Exception("DB exploded"))
+    cog = TranscriptMirrorCog(bot, session_repo=repo)
+    reply_sink = cog._make_reply_sink(42)
+    await reply_sink("final answer")
+
+    channel.send.assert_called_once()
+    call_kwargs = channel.send.call_args.kwargs
+    assert "reference" not in call_kwargs
+
+
+async def test_file_sink_falls_back_to_db_trigger_when_inmemory_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """In-memory absent + DB has trigger_message_id → file_sink attaches reference."""
+    monkeypatch.delenv("CLORD_REPLY_TO_TRIGGER", raising=False)
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    progress_file = tmp_path / "progress.txt"
+    progress_file.write_text("tool output")
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo_with_trigger(5555))
+    file_sink = cog._make_file_sink(55)
+    await file_sink("final answer", str(progress_file))
+
+    call_kwargs = channel.send.call_args.kwargs
+    assert call_kwargs.get("mention_author") is False
+    ref = call_kwargs.get("reference")
+    assert ref is not None
+    assert ref.message_id == 5555
+
+
+async def test_file_sink_no_reference_when_db_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """DB error in file_sink fallback does not crash — sends normally."""
+    monkeypatch.delenv("CLORD_REPLY_TO_TRIGGER", raising=False)
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    progress_file = tmp_path / "progress.txt"
+    progress_file.write_text("tool output")
+
+    repo = MagicMock()
+    repo.list_all = AsyncMock(return_value=[])
+    repo.get = AsyncMock(side_effect=Exception("DB exploded"))
+    cog = TranscriptMirrorCog(bot, session_repo=repo)
+    file_sink = cog._make_file_sink(55)
+    await file_sink("final answer", str(progress_file))
+
+    channel.send.assert_called_once()
+    call_kwargs = channel.send.call_args.kwargs
+    assert "reference" not in call_kwargs


### PR DESCRIPTION
## What does this PR do?

`CLORD_BRIDGE_MODE=jsonl` の `_make_reply_sink` / `_make_file_sink` が、in-memory の `self._trigger_messages` が `None` のとき `session_repo.get(thread_id).trigger_message_id` を DB フォールバック参照するようにした。skill モード (`api_server.reply`) と挙動を揃える。

## Why?

worker プロセスが bot 再起動を生き延びてターンを完了するケース（in-memory dict は空、DB には trigger あり、mirror は on_ready で再起動）では、完了報告が ↪返信にならず通常メッセージとして届いていた。in-memory dict だけを参照しており、再起動でメモリが空になるとフォールバック先が無かったのが原因。skill 側は既に DB から引いているので、jsonl 側だけ欠けていた DB フォールバックを補う。

Closes #149

## Acceptance Criteria (copied from the issue)

- [x] bot再起動後の自動継続/レジュームターンの完了報告が、DBに `trigger_message_id` があれば ↪返信になる
- [x] in-memory に登録がある場合は従来どおり（リグレッション無し）
- [x] in-memory にも DB にも無い場合は従来どおり通常送信（例外を出さない）
- [x] `mention_author=False` 維持
- [x] DB参照は非同期/例外安全（reply_sink内でのDBエラーが投稿自体を落とさない）

## Staging Evidence

staging (`/home/yousan/c-lord-parallel-3`, `CLORD_BRIDGE_MODE=jsonl`) の実スレッド `1508274772641972374` を使用。DB に `trigger_message_id=1508988243121537024` が存在し、bot 再起動直後で in-memory は空の状態を再現。同スレッドの jsonl に合成 `assistant`+`result` イベントを追記して reply_sink を発火させ、Discord REST API で投稿の `message_reference` を確認した。

**RED (修正前 / main HEAD — DB フォールバック無し):**
```
id=1509006197423079606 author=C-lord-3 ref=None :: '[RED-149-...] 修正前テスト: in-memory空 + DB trigger あり。reference が付かないはず。'
```
→ `message_reference` が付かず通常メッセージ（バグ再現）。

**GREEN (修正後 / 本 PR — DB フォールバック有り):**
```
id=1509006563585560740 author=C-lord-3 ref=1508988243121537024 :: '[GREEN-149-...] 修正後テスト: in-memory空 + DB trigger あり。DBフォールバックで reference が付くはず。'
```
→ DB の `trigger_message_id` を参照して `message_reference` が付き、↪返信になった。

同一スレッド・同一 DB 行で、コードのみ差し替えて RED→GREEN を確認。検証後は staging の作業ツリーを main に戻し、合成 jsonl 行を除去、clean main で再起動済み。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes (1120 passed, 5 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass (pyright: 0 errors)
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #149` used — 100% of the issue's ACs are met

### TDD RED (unit, before fix)
```
FAILED tests/test_transcript_mirror_cog.py::test_reply_sink_falls_back_to_db_trigger_when_inmemory_missing
FAILED tests/test_transcript_mirror_cog.py::test_file_sink_falls_back_to_db_trigger_when_inmemory_missing
>       assert call_kwargs.get("mention_author") is False
E       AssertionError: assert None is False
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)