### PR TITLE
fix: enter vim INSERT before literal send_input in NORMAL mode (#147)

### DIFF
--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import subprocess
+import time
 
 # Discord snowflake IDs are 17–19 digits. Require ≥10 to avoid matching
 # unrelated trailing-numeric path components (PIDs, ports, etc.).
@@ -25,6 +26,23 @@ logger = logging.getLogger(__name__)
 SESSION_NAME = "clord"
 WINDOW_PREFIX = "work"
 
+# #147: Claude Code runs with ``editorMode: vim``.  Its input box therefore has
+# a vim NORMAL mode in which literal characters (``send-keys -l``) are
+# interpreted as editor commands, corrupting the message.  The TUI status bar
+# shows ``-- INSERT`` only while in INSERT mode; NORMAL mode simply omits the
+# prefix (current Claude Code, v2.1.150, renders NO ``-- NORMAL`` marker).  So
+# we detect mode by the presence of ``-- INSERT`` and anchor the NORMAL case on
+# the always-present permission/plan status indicators.
+_INSERT_MARKER = "-- INSERT"
+# Status-bar anchors that prove the pane is sitting at the input prompt (and so
+# its vim mode is meaningful).  ``⏵⏵``/``⏸⏸`` are the bypass/plan indicators;
+# ``-- NORMAL`` is included for forward-compat in case a future build restores
+# the explicit NORMAL marker.
+_STATUS_BAR_ANCHORS = ("⏵⏵", "⏸⏸", "-- NORMAL")
+# Pause after pressing ``i`` so the TUI commits the INSERT-mode switch before the
+# literal text arrives (verified on staging: the switch is near-instant).
+_INSERT_SETTLE = 0.15
+
 
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a subprocess and return the result (never raises on non-zero exit)."""
@@ -33,6 +51,28 @@ def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+def _pane_in_insert_mode(pane_text: str) -> bool | None:
+    """Return True if the input box is in vim INSERT mode, False for NORMAL.
+
+    Returns ``None`` when the mode cannot be determined (no status bar in the
+    captured frame — e.g. mid-redraw or while Claude is generating).  Callers
+    should treat ``None`` as "leave input untouched" to avoid the double-``i``
+    regression (#147 AC2).
+
+    Only the bottom status zone is inspected, so a stale ``-- INSERT`` lingering
+    in scrollback above a current NORMAL status bar does not win.
+    """
+    lines = [ln for ln in pane_text.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    zone = "\n".join(lines[-8:])
+    if _INSERT_MARKER in zone:
+        return True
+    if any(anchor in zone for anchor in _STATUS_BAR_ANCHORS):
+        return False
+    return None
 
 
 def _tmux_available() -> bool:
@@ -748,6 +788,20 @@ class TmuxSessionManager:
         # the same thread.
         from .transcript.formatter import ZWSP_MARKER
         from .transcript.mirror import bridge_mode_jsonl
+
+        # #147: Claude's vim-mode input box drops to NORMAL after some
+        # operations (e.g. an Escape sent by cancel_menu()).  Sending literal
+        # text in NORMAL makes each character a vim command, corrupting the
+        # message.  Capture the current frame and, if not positively in INSERT,
+        # press ``i`` first.  We only correct when the pane is positively NOT in
+        # INSERT (a recognised status bar without ``-- INSERT``); an
+        # indeterminate frame is left untouched so we never inject a stray ``i``
+        # into an already-INSERT box (AC2).
+        visible = _run(["tmux", "capture-pane", "-p", "-t", target])
+        if visible.returncode == 0 and _pane_in_insert_mode(visible.stdout) is False:
+            logger.debug("send_input: pane in NORMAL mode, entering INSERT (thread=%d)", thread_id)
+            _run(["tmux", "send-keys", "-t", target, "i"])
+            time.sleep(_INSERT_SETTLE)
 
         payload = f"{ZWSP_MARKER}{text}" if bridge_mode_jsonl() else text
         result = _run(["tmux", "send-keys", "-l", "-t", target, payload])

--- a/docs/tui-prompts.md
+++ b/docs/tui-prompts.md
@@ -197,11 +197,19 @@ JSONL に出ない。`tmux capture-pane` でしか検出できない。誤検知
 
 | シグネチャ | 意味 |
 |-----------|------|
-| `-- INSERT ⏵⏵ bypass permissions on` | dangerously-skip-permissions 有効、入力モード |
-| `-- NORMAL` | ノーマルモード |
+| `-- INSERT ⏵⏵ bypass permissions on` | vim INSERT モード（入力可） |
+| ステータスバーに `-- INSERT` が**無い** | vim NORMAL モード。**現行 Claude Code (v2.1.150) は `-- NORMAL` を表示せず、`-- INSERT` プレフィックスが消えるだけ**（`⏵⏵ bypass permissions on …` だけが残る） |
 | `Model: Sonnet 4.6 Style: default` | ccstatusline 行 1 |
 | `Cost: $0.05 Session: 7.0%` | ccstatusline 行 2（コンテキスト使用量） |
 | `⎇ main (+0,-0) cwd: /path` | ccstatusline 行 3（ブランチ） |
+
+> **vim NORMAL モードと `send_input`（#147）**: `editorMode: vim` のため入力欄に NORMAL
+> モードがあり、NORMAL のまま `send-keys -l`（literal）を送ると各文字が vim コマンドとして
+> 解釈されメッセージが壊れる（例: "melon" → `m`/`e`/`l` がカーソル移動、`o` が改行+INSERT 化で
+> `n` だけ入力）。`TmuxSessionManager.send_input` は送信前に `capture-pane` でモードを判定し、
+> INSERT でない（`-- INSERT` 不在）ときだけ `i` を送って INSERT に遷移してから literal を流す。
+> 判定不能なフレーム（生成中・再描画中で status bar 不在）は誤って `i` を混入させないよう無補正。
+> トリガ例: `cancel_menu()` 等が送る `Escape` 後の follow-up 送信。
 
 ### 4-2. 生成中インジケーター
 

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from c_lord.tmux import SESSION_NAME, TmuxSessionManager
+from c_lord.tmux import SESSION_NAME, TmuxSessionManager, _pane_in_insert_mode
 
 
 class TestTmuxSessionManager:
@@ -509,6 +509,7 @@ class TestTmuxSessionManager:
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.side_effect = [
                 MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0, stdout=self._INSERT_PANE),  # capture-pane (mode)
                 MagicMock(returncode=0),  # send-keys -l (text)
                 MagicMock(returncode=0),  # send-keys Enter
             ]
@@ -517,14 +518,14 @@ class TestTmuxSessionManager:
         assert result is True
 
         # Verify send-keys -l was called with the text
-        text_call = mock_run.call_args_list[1]
+        text_call = mock_run.call_args_list[2]
         args = text_call[0][0]
         assert "send-keys" in args
         assert "-l" in args
         assert "my prompt" in args
 
         # Verify Enter was sent
-        enter_call = mock_run.call_args_list[2]
+        enter_call = mock_run.call_args_list[3]
         args = enter_call[0][0]
         assert "Enter" in args
 
@@ -546,12 +547,13 @@ class TestTmuxSessionManager:
             with patch("c_lord.tmux._run") as mock_run:
                 mock_run.side_effect = [
                     MagicMock(returncode=0, stdout="12345\n"),
+                    MagicMock(returncode=0, stdout=self._INSERT_PANE),  # capture-pane (mode)
                     MagicMock(returncode=0),
                     MagicMock(returncode=0),
                 ]
                 assert mgr.send_input(12345, "hi") is True
 
-            text_call = mock_run.call_args_list[1]
+            text_call = mock_run.call_args_list[2]
             args = text_call[0][0]
             # ZWSP (U+200B) is prepended to the literal text.
             assert "​hi" in args
@@ -574,12 +576,13 @@ class TestTmuxSessionManager:
             with patch("c_lord.tmux._run") as mock_run:
                 mock_run.side_effect = [
                     MagicMock(returncode=0, stdout="12345\n"),
+                    MagicMock(returncode=0, stdout=self._INSERT_PANE),  # capture-pane (mode)
                     MagicMock(returncode=0),
                     MagicMock(returncode=0),
                 ]
                 assert mgr.send_input(12345, "hi") is True
 
-            text_call = mock_run.call_args_list[1]
+            text_call = mock_run.call_args_list[2]
             args = text_call[0][0]
             assert "hi" in args
             # No ZWSP under default mode (backward compat with skill path).
@@ -587,6 +590,84 @@ class TestTmuxSessionManager:
         finally:
             if prev is not None:
                 os.environ["CLORD_BRIDGE_MODE"] = prev
+
+    # -- #147: vim NORMAL-mode correction before literal input --------------
+    #
+    # Claude Code runs with ``editorMode: vim``. When the input box is in
+    # NORMAL mode, ``send-keys -l`` characters are interpreted as vim commands
+    # and the message is corrupted. This Claude version (v2.1.150) shows
+    # ``-- INSERT`` in the status bar only in INSERT mode; NORMAL omits it
+    # entirely (no ``-- NORMAL`` marker). So send_input must capture the pane,
+    # and if not in INSERT, press ``i`` to enter INSERT before the literal text.
+
+    _INSERT_PANE = (
+        "❯ \n"
+        "─────────────────────────────\n"
+        "   Model: Opus 4.7  v2.1.150  Style: default\n"
+        "   ⎇ no git  cwd: /tmp  Skill: none\n"
+        "  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+    )
+    _NORMAL_PANE = (
+        "❯ \n"
+        "─────────────────────────────\n"
+        "   Model: Opus 4.7  v2.1.150  Style: default\n"
+        "   ⎇ no git  cwd: /tmp  Skill: none\n"
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+    )
+
+    def test_send_input_enters_insert_when_normal_mode(self) -> None:
+        """NORMAL mode → press ``i`` (key) before sending the literal text (#147)."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0, stdout=self._NORMAL_PANE),  # capture-pane (mode)
+                MagicMock(returncode=0),  # send-keys i
+                MagicMock(returncode=0),  # send-keys -l (text)
+                MagicMock(returncode=0),  # send-keys Enter
+            ]
+            assert mgr.send_input(12345, "melon") is True
+
+        calls = mock_run.call_args_list
+        # The bare ``i`` keypress (NON-literal) must precede the literal text.
+        i_call = calls[2][0][0]
+        assert i_call[:2] == ["tmux", "send-keys"]
+        assert "-l" not in i_call  # ``i`` is a key, not literal
+        assert i_call[-1] == "i"
+        # Then the literal text.
+        text_call = calls[3][0][0]
+        assert "-l" in text_call and "melon" in text_call
+        # Then Enter.
+        assert "Enter" in calls[4][0][0]
+
+    def test_send_input_no_extra_i_when_insert_mode(self) -> None:
+        """INSERT mode → no extra ``i`` injected (AC2: no regression / double-i) (#147)."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0, stdout=self._INSERT_PANE),  # capture-pane (mode)
+                MagicMock(returncode=0),  # send-keys -l (text)
+                MagicMock(returncode=0),  # send-keys Enter
+            ]
+            assert mgr.send_input(12345, "melon") is True
+
+        calls = mock_run.call_args_list
+        # No bare ``i`` keypress anywhere — the text goes out literally first.
+        for c in calls:
+            args = c[0][0]
+            if args[:2] == ["tmux", "send-keys"] and "-l" not in args and args[-1] == "i":
+                raise AssertionError("unexpected bare 'i' sent while already in INSERT mode")
+        # send-keys -l with the text comes right after the capture.
+        text_call = calls[2][0][0]
+        assert "-l" in text_call and "melon" in text_call
+        assert "Enter" in calls[3][0][0]
 
     def test_send_input_no_window(self) -> None:
         mgr = TmuxSessionManager(mapping_path="")
@@ -1091,3 +1172,45 @@ class TestTmuxSessionManager:
         assert any(str(THREAD_ID) in c for c in set_option_calls), (
             "@thread_id was not set on the adopted window"
         )
+
+
+class TestPaneInsertModeDetection:
+    """#147: detect vim INSERT vs NORMAL from the pane status bar.
+
+    Claude Code (v2.1.150) shows ``-- INSERT`` in the status bar only in
+    INSERT mode. NORMAL mode omits it — there is NO ``-- NORMAL`` marker —
+    so detection keys on the presence of ``-- INSERT`` plus a recognisable
+    status-bar anchor for the NORMAL case.
+    """
+
+    _INSERT = (
+        "❯ some text\n"
+        "──────────\n"
+        "   Model: Opus 4.7  v2.1.150  Style: default\n"
+        "  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+    )
+    _NORMAL = (
+        "❯ some text\n"
+        "──────────\n"
+        "   Model: Opus 4.7  v2.1.150  Style: default\n"
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+    )
+
+    def test_insert_marker_present(self) -> None:
+        assert _pane_in_insert_mode(self._INSERT) is True
+
+    def test_normal_no_insert_marker(self) -> None:
+        assert _pane_in_insert_mode(self._NORMAL) is False
+
+    def test_old_insert_in_scrollback_ignored(self) -> None:
+        """A stale ``-- INSERT`` far above the current status bar must not win.
+
+        Only the bottom status zone decides the mode; an old INSERT frame in
+        scrollback above a current NORMAL status bar should read as NORMAL.
+        """
+        stale = "  -- INSERT -- ⏵⏵ old frame\n" + ("filler\n" * 30) + self._NORMAL
+        assert _pane_in_insert_mode(stale) is False
+
+    def test_empty_or_unknown_returns_none(self) -> None:
+        assert _pane_in_insert_mode("") is None
+        assert _pane_in_insert_mode("just some\nresponse text\n") is None


### PR DESCRIPTION
## What does this PR do?

`TmuxSessionManager.send_input` now ensures the Claude TUI input box is in vim **INSERT** mode before sending the message literally. If the pane is in NORMAL mode it presses `i` first; otherwise it behaves exactly as before.

## Why?

Closes #147.

Claude Code runs with `editorMode: vim`. After some operations (e.g. an `Escape` sent by `cancel_menu()`) the input box drops to vim **NORMAL** mode. `send_input` always sent the message via `tmux send-keys -l` (literal) assuming INSERT, so in NORMAL each character was interpreted as a vim command and the message was corrupted — the body never reached Claude.

Key finding (verified on a live Claude Code v2.1.150 TUI): **NORMAL mode renders NO `-- NORMAL` marker** — the `-- INSERT` prefix simply disappears. So detection keys on the presence of `-- INSERT`, and the NORMAL case is anchored on the always-present `⏵⏵`/`⏸⏸` permission/plan status indicator. An indeterminate frame (no status bar — mid-redraw / generating) is left untouched, so we never inject a stray `i` into an already-INSERT box.

## Acceptance Criteria (copied from the issue)

- [x] TUI が NORMAL モードの状態で Discord メッセージを送ったとき、本文が欠落・コマンド誤解釈なく入力欄に全文入力され、submit される
- [x] TUI が INSERT モードのときの既存挙動が退行しない（二重 `i` 混入等が起きない）

### 要確認（調査タスク／AC とは別）
- 「INSERT が外れる」トリガを実機で特定: **`Escape`** が確定トリガ（`cancel_menu()` 等が送る）。`C-c` 単体は INSERT 維持、通常のターン完了後も INSERT に復帰、と実機で確認。

## Staging Evidence

実機の Claude Code TUI (v2.1.150, `editorMode: vim`) を tmux で起動し、**本番と同一の `TmuxSessionManager.send_input` コード**を NORMAL モードのペインに対して走らせて検証。

**RED (修正前の挙動 = 補正なしで NORMAL に literal を送る):**
```
[BEFORE] status bar: ⏵⏵ bypass permissions on (shift+tab to cycle)   ← -- INSERT 不在 = NORMAL
$ tmux send-keys -l "melon banana cherry"   # 旧 send_input 相当
[AFTER ] ❯ 入力欄:  n banana cherry          ← "melo" が vim コマンド消費、本文崩壊
```

**GREEN (修正後 = 実 send_input コード):**
```
$ python -c "... mgr.send_input(999, 'melon banana cherry - reply with only the word ok')"
detected mode (pre-send): False     # NORMAL を正しく検出
send_input returned: True
[AFTER] submitted user turn:
  ❯ melon banana cherry - reply with only the word ok   ← 全文が欠落なく入力・submit
  ❯
  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle)
```

**INSERT 退行なし (AC2):** ターン完了後/通常時はペインが `-- INSERT` を表示 → `_pane_in_insert_mode` が `True` を返し `i` を送らない（unit test `test_send_input_no_extra_i_when_insert_mode` でも担保）。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED: `ImportError: cannot import name '_pane_in_insert_mode'` / send_input 未補正) and passes after (GREEN)
- [x] `uv run pytest tests/` passes — 1156 passed, 5 skipped
- [x] `uv run ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/tmux.py` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #147` used — 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)