### PR TITLE
fix: make tmux runner timeout inactivity-based so live sessions aren't killed (#94)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -533,7 +533,14 @@ class TmuxClaudeRunner:
         last_raw = ""
         raw_static_seconds = 0.0
 
-        while not self._stopped and elapsed < self.timeout_seconds:
+        # The hard ``timeout_seconds`` backstop is INACTIVITY-based, not total
+        # wall-clock (#94).  A heavy turn — Explore subagent + extended thinking
+        # — easily runs past 300s while the pane keeps changing every poll
+        # (spinner frame, elapsed-seconds tick).  Gating on ``raw_static_seconds``
+        # means an actively-working turn is never killed mid-flight; the timeout
+        # fires only once the pane has been frozen (Claude truly hung) for the
+        # whole window.  ``elapsed`` is kept for logging and the startup grace.
+        while not self._stopped and raw_static_seconds < self.timeout_seconds:
             await asyncio.sleep(_POLL_INTERVAL)
             elapsed += _POLL_INTERVAL
 
@@ -687,7 +694,7 @@ class TmuxClaudeRunner:
                 is_complete=True,
                 error=None if self._silent_stop else "Stopped by user",
             )
-        elif elapsed >= self.timeout_seconds:
+        elif raw_static_seconds >= self.timeout_seconds:
             yield StreamEvent(
                 raw={},
                 message_type=MessageType.RESULT,

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1063,6 +1063,78 @@ class TestTmuxClaudeRunnerRun:
         assert len(result_events) == 1
 
 
+class TestInactivityTimeout:
+    """#94: the hard ``timeout_seconds`` backstop must be inactivity-based.
+
+    The old loop killed any turn whose total wall-clock exceeded
+    ``timeout_seconds`` — even while Claude was actively thinking / running
+    tools (the pane spinner + elapsed counter ticking every poll).  That
+    posted a bogus "Session timed out" notice on live sessions.  The timeout
+    now fires only after the pane has been *frozen* for ``timeout_seconds``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_does_not_timeout_while_pane_active(self, runner, tmux_manager) -> None:
+        """A long but ACTIVE turn must complete, not emit a 'Timed out' RESULT."""
+        tmux_manager.is_claude_running.return_value = True
+        done_pane = _make_pane(["● All done!"], with_input_prompt=True)
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            # Pane changes every poll (elapsed-seconds tick) for far longer
+            # than timeout_seconds — Claude is alive — then finishes.
+            if call_idx <= 20:
+                return f"\n✻ Cogitating for {call_idx}s\n────────\n❯\n────────\n-- INSERT --"
+            return done_pane
+
+        tmux_manager.capture_pane.side_effect = capture_fn
+
+        runner.timeout_seconds = 0.2  # ~10 polls @ 0.02; the active phase outlasts it
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.02),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.0),
+        ):
+            async for event in runner.run("test"):
+                events.append(event)
+
+        result_events = [e for e in events if e.is_complete]
+        assert len(result_events) == 1
+        assert result_events[0].error is None, (
+            f"active turn was killed by the timeout: {result_events[0].error!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_timeout_fires_when_pane_frozen(self, runner, tmux_manager) -> None:
+        """A genuinely hung (frozen-pane) session is still killed by the backstop."""
+        tmux_manager.is_claude_running.return_value = True
+        # A response is on screen (so the empty-response idle break does not
+        # apply) but the pane never changes again — a real hang.
+        frozen = _make_pane(["● Partial answer, then hung"], user_prompt="q")
+        tmux_manager.capture_pane.return_value = frozen
+
+        runner.timeout_seconds = 0.2
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.02),
+            # Push the other exits out so only the inactivity backstop can fire.
+            patch("c_lord.claude.tmux_runner._IDLE_TIMEOUT", 100.0),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 100.0),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_FALLBACK", 100.0),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.0),
+        ):
+            async for event in runner.run("q"):
+                events.append(event)
+
+        result_events = [e for e in events if e.is_complete]
+        assert len(result_events) == 1
+        assert result_events[0].error is not None
+        assert "Timed out" in result_events[0].error
+
+
 class TestTmuxClaudeRunnerInterrupt:
     """Tests for interrupt() and kill()."""
 


### PR DESCRIPTION
## What does this PR do?

Makes the tmux runner's hard `timeout_seconds` (default 300s) backstop
**inactivity-based** instead of a total-wall-clock cap. The poll loop now
continues while the pane is changing (Claude is actively thinking / running
tools) and only times out once the pane has been **frozen** for the whole
window. `elapsed` is kept purely for logging and the startup grace.

One-line diff intent: `while ... elapsed < timeout_seconds` → `while ...
raw_static_seconds < timeout_seconds` (and the matching post-loop branch).

## Why?

The old loop killed any turn whose **total** wall-clock exceeded
`timeout_seconds` and posted a bogus "⏱️ Session timed out" notice — even
while Claude was alive. A heavy turn (Explore subagent + extended thinking, or
a long-running tool) routinely runs past 300s while the pane keeps changing
every poll (spinner frame + elapsed-seconds tick), so live sessions were being
declared dead. `raw_static_seconds` (tracked since #166) already measures true
inactivity — it resets whenever the raw pane changes — so it is exactly the
liveness signal the issue's preferred "essence" fix calls for.

Closes #94

## Acceptance Criteria (copied from the issue)

The issue lists solution options rather than checkbox ACs; binary criteria:

- [x] A long but **active** turn (pane changing each poll) is **not** killed by
      the hard timeout and completes normally (no "Session timed out" notice).
- [x] A genuinely **hung** turn (pane frozen for `timeout_seconds`) **is** still
      killed by the backstop (the safety net is preserved, not removed).
- [x] Implements option #2 ("筋論": liveness-based timeout) — uses pane activity
      as the liveness signal, equivalent to JSONL tool_use/thinking flow.

## Staging Evidence

Controlled repro on staging (`/home/yousan/c-lord-parallel-3`,
`CLORD_BRIDGE_MODE=jsonl`) with `SESSION_TIMEOUT_SECONDS=25` to make a >25s
active turn fast. Prompt (both runs): *"run `for i in $(seq 1 35); do echo tick
$i; sleep 1; done`, reply with the final line"* — 35s of active tool execution.

**RED — `main` (old elapsed-based code), timeout=25:**
```
10:39:56  prompt sent (35s bash loop)
Discord  01:40:25  ⏱️ Session timed out   ← false positive at ~25s, session still alive
Discord  01:40:41  "tick 35"              ← correct answer arrives anyway → it was alive
```

**GREEN — `fix/94-inactivity-timeout`, timeout=25 (identical prompt):**
```
10:43:43  run_claude: enter
10:44:28  run_claude: exit       ← ran 45s, NOT killed at 25s
Discord  (no "Session timed out" embed at all)
Discord  01:44:24  "tick 35"     ← completes normally with the correct answer
```
The hard-timeout false positive is gone; the active turn runs to completion. (A
benign soft "⚠️ No activity for 30s — could be extended thinking" notice appears
instead — informational, does not kill the session.)

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes (1157 passed, 8 e2e deselected)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright c_lord/` pass (0 errors)
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #94` used — this PR satisfies 100% of the issue's ACs

### TDD evidence (RED)

New test `tests/test_tmux_runner.py::TestInactivityTimeout::test_does_not_timeout_while_pane_active`
failed before the fix:
```
E  AssertionError: active turn was killed by the timeout: 'Timed out after 0.2 seconds'
E  assert 'Timed out after 0.2 seconds' is None
```
Passes after the fix; the companion `test_timeout_fires_when_pane_frozen`
guards that the backstop still kills a frozen session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
