### PR TITLE
fix: type free text onto 'Type something.' row, not navigate+Enter (#172)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -867,19 +867,35 @@ class TmuxClaudeRunner:
         await self._navigate_menu(index)
 
     async def answer_menu_text(self, text_option_index: int, text: str) -> None:
-        """Answer via the free-text ("Type something.") affordance (#166).
+        """Answer via the free-text ("Type something.") affordance (#172).
 
-        Navigates to the text option at ``text_option_index`` (the meta-option
-        that follows the real options), confirms with Enter to open the input,
-        then types *text* literally and submits.
+        Verified on a live Claude Code v2.1.150 TUI, the correct interaction is:
+
+        1. Navigate to the "Type something." row with ``Down`` × *text_option_index*
+           — **without** pressing Enter.  (Pressing Enter on that row registers a
+           *decline* and closes the menu; no input field opens — this was the #172
+           bug.)
+        2. Type *text* **literally onto the highlighted row**, which replaces the
+           "Type something." label with the typed text.  This must NOT go through
+           :meth:`send_input`, which would append Enter and post the text as a
+           separate message instead of the answer.
+        3. Press ``Enter`` once to record the typed text as the menu answer.
+
+        Keystrokes are spaced by ``_MENU_NAV_DELAY`` for the same reason as
+        :meth:`answer_menu` (#171): the TUI drops keys sent too fast.
         """
         logger.info(
             "Answering AskUserQuestion with free text (thread=%d)",
             self._thread_id,
         )
-        await self._navigate_menu(text_option_index)
+        for _ in range(max(0, text_option_index)):
+            await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Down")
+            await asyncio.sleep(_MENU_NAV_DELAY)
+        # Type the free text directly onto the highlighted "Type something." row.
+        await asyncio.to_thread(self._tmux.send_literal, self._thread_id, text)
         await asyncio.sleep(_MENU_NAV_DELAY)
-        await asyncio.to_thread(self._tmux.send_input, self._thread_id, text)
+        # Confirm — records the typed text as the AskUserQuestion answer.
+        await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Enter")
 
     async def cancel_menu(self) -> None:
         """Dismiss an open AskUserQuestion menu with Esc (e.g. on timeout) (#166)."""

--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -759,6 +759,37 @@ class TmuxSessionManager:
         result = _run(["tmux", "send-keys", "-t", target, "Enter"])
         return result.returncode == 0
 
+    def send_literal(self, thread_id: int, text: str) -> bool:
+        """Send literal text to the pane WITHOUT submitting (no Enter) (#172).
+
+        Unlike :meth:`send_input`, this does **not** append Enter, and does
+        **not** prepend the jsonl bridge ZWSP marker.  It is used to type free
+        text onto an open TUI menu's "Type something." row, where:
+
+        - typing the literal text directly replaces the highlighted row's label
+          with the text, and
+        - the text must NOT be submitted as a separate message — the caller
+          presses Enter afterwards to record it as the menu answer, and
+        - the answer is not a c-lord-originated *user* turn, so the dedup ZWSP
+          would only corrupt the recorded answer.
+
+        Returns True on success.
+        """
+        if not self._check_available():
+            return False
+
+        window = self._find_window_for_thread(thread_id)
+        if window is None:
+            logger.warning("send_literal: no window for thread %d", thread_id)
+            return False
+
+        target = f"{self.session_name}:{window}"
+        result = _run(["tmux", "send-keys", "-l", "-t", target, text])
+        if result.returncode != 0:
+            logger.warning("send_literal: send-keys -l failed: %s", result.stderr.strip())
+            return False
+        return True
+
     def send_keys(self, thread_id: int, *keys: str) -> bool:
         """Send raw tmux key names to the window (e.g. ``"Down"``, ``"Enter"``).
 

--- a/docs/askuserquestion-bridge.md
+++ b/docs/askuserquestion-bridge.md
@@ -66,7 +66,7 @@ C案 — いったん保留
 | `☐ <header>` | embed title `❓ <header>` | header extracted |
 | question line | embed body (first line) | question extracted |
 | `❯ N. <label>` + indented description | **button `<label>`** + body legend `<label> — <description>` | label → button; description → legend (#169) |
-| `Type something.` (meta) | **`✏️ Other` button** (free-text modal) | mapped to free text — **broken, see Limitations (#172)** |
+| `Type something.` (meta) | **`✏️ Other` button** (free-text modal) | mapped to free text — typed onto the row, then confirmed (#172) |
 | `Chat about this` (meta) | *(dropped)* | TUI-only affordance |
 | `Enter to select · ↑/↓ · Esc` footer | *(dropped)* | replaced by clicking |
 | ANSI colour codes | *(stripped)* | `_normalize_capture` before detection (#166) |
@@ -98,14 +98,29 @@ verified with the bot's actual `answer_menu` selecting the intended option.
 While the bridge waits for the click, the runner is suspended at its `yield`,
 so the pane is not re-polled and the menu is not re-detected (natural dedup).
 
+## How free text (`✏️ Other`) is answered (#172)
+
+The `Type something.` row is **not** confirmed with Enter. Verified on a live
+Claude Code v2.1.150 TUI, pressing Enter on that row registers a *decline* and
+no input field opens; and typing through `send_input` would post the text as a
+*separate message* rather than the answer. The working sequence is to **type
+onto the highlighted row**, which replaces its label, then confirm:
+
+```
+Down  (×index)            # navigate to "Type something." — NO Enter here
+send_literal(text)        # type the text directly onto the row (no Enter)
+Enter                     # records the typed text as the answer
+```
+
+`index` is the number of real options (the meta-row sits immediately after
+them). `TmuxClaudeRunner.answer_menu_text` implements this; `send_literal`
+(in `tmux.py`) sends raw `send-keys -l` with no Enter and no jsonl ZWSP marker.
+Keystrokes are spaced by `_MENU_NAV_DELAY` for the same timing reason as
+`answer_menu` (#171). Verified end-to-end: the typed text is recorded as
+`<question> → <text>` (not "User declined to answer questions").
+
 ## Limitations
 
-- **Free text (`✏️ Other`) does not work yet (#172).** Selecting
-  `Type something.` via navigate-then-Enter registers as *"User declined to
-  answer questions"* and the typed text arrives as a separate follow-up
-  message rather than the AskUserQuestion answer. The correct TUI interaction
-  for free-text input is still being determined; until then, prefer providing
-  explicit options.
 - **Single question at a time.** A multi-question AskUserQuestion is handled one
   menu at a time as each renders in the pane.
 

--- a/docs/tui-prompts.md
+++ b/docs/tui-prompts.md
@@ -99,7 +99,7 @@ JSONL transcript が始まる前に出るため、JSONL 経路では検出でき
 | **画面シグネチャ** | TUI に選択メニュー（`☐ header` / `❯ N. label` / `Type something.` / `Chat about this`） |
 | **操作** | ↑/↓ + Enter（TUI）/ Discord ボタン・セレクト（Discord） |
 | **JSONL** | ⚠️ `StreamEvent.ask_questions` は **SDK ストリーミング経路でのみ** 埋まる。jsonl/tmux モードの tmux runner は埋めない |
-| **現在の c-lord 対応** | ✅ jsonl/tmux モードは **ペイン解析** (`_parse_ask_from_pane`) で `AskView` 表示＋クリック→キーストロークで回答（#166）。説明文も併記（#169）、キー送信は1つずつ間隔送出（#171）。**自由記入 ✏️Other は未対応（#172）** |
+| **現在の c-lord 対応** | ✅ jsonl/tmux モードは **ペイン解析** (`_parse_ask_from_pane`) で `AskView` 表示＋クリック→キーストロークで回答（#166）。説明文も併記（#169）、キー送信は1つずつ間隔送出（#171）。自由記入 ✏️Other は「Type something. 行に直接タイプ→Enter」で回答（#172） |
 | **詳細** | [`askuserquestion-bridge.md`](./askuserquestion-bridge.md)（変換表・画像・制限） |
 
 ### 2-4. Elicitation（MCP サーバーからの入力要求）

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -588,6 +588,74 @@ class TestTmuxSessionManager:
             if prev is not None:
                 os.environ["CLORD_BRIDGE_MODE"] = prev
 
+    # -- #172: send_literal (type onto a TUI menu's free-text row) ----------
+    #
+    # The AskUserQuestion "Type something." row is NOT submitted as a message:
+    # typing the literal text replaces the highlighted row's label, then a
+    # separate Enter records it as the answer. send_literal sends raw
+    # ``send-keys -l`` only — no Enter and no jsonl ZWSP marker.
+
+    def test_send_literal_sends_text_without_enter(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0),  # send-keys -l (text)
+            ]
+            assert mgr.send_literal(12345, "メロン") is True
+
+        calls = mock_run.call_args_list
+        # Exactly one send-keys after the window verify: the literal text.
+        assert len(calls) == 2
+        text_call = calls[1][0][0]
+        assert text_call[:3] == ["tmux", "send-keys", "-l"]
+        assert "メロン" in text_call
+        # No Enter is sent (the caller confirms separately).
+        for c in calls:
+            assert "Enter" not in c[0][0]
+
+    def test_send_literal_no_zwsp_under_jsonl_mode(self) -> None:
+        """send_literal must NOT prepend the jsonl ZWSP marker (#172).
+
+        The ZWSP exists to dedup c-lord-originated *user* turns; a menu free-text
+        answer is not a user turn, so a stray ZWSP would only corrupt the answer.
+        """
+        import os
+
+        prev = os.environ.get("CLORD_BRIDGE_MODE")
+        os.environ["CLORD_BRIDGE_MODE"] = "jsonl"
+        try:
+            mgr = TmuxSessionManager(mapping_path="")
+            mgr._available = True
+            mgr._thread_to_window[12345] = "work1"
+
+            with patch("c_lord.tmux._run") as mock_run:
+                mock_run.side_effect = [
+                    MagicMock(returncode=0, stdout="12345\n"),
+                    MagicMock(returncode=0),
+                ]
+                assert mgr.send_literal(12345, "hi") is True
+
+            text_call = mock_run.call_args_list[1][0][0]
+            assert "hi" in text_call
+            assert "​hi" not in text_call  # no ZWSP (U+200B) prefix
+        finally:
+            if prev is None:
+                os.environ.pop("CLORD_BRIDGE_MODE", None)
+            else:
+                os.environ["CLORD_BRIDGE_MODE"] = prev
+
+    def test_send_literal_no_window(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert mgr.send_literal(99999, "hello") is False
+
     def test_send_input_no_window(self) -> None:
         mgr = TmuxSessionManager(mapping_path="")
         mgr._available = True

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1966,20 +1966,50 @@ class TestRunYieldsPaneAsk:
         tmux_manager.send_keys.assert_called_once_with(12345, "Enter")
 
     @pytest.mark.asyncio
-    async def test_answer_menu_text_navigates_then_types(self, runner, tmux_manager) -> None:
-        """#171: free-text path navigates to 'Type something.' one key at a time,
-        then sends the literal text via send_input.
+    async def test_answer_menu_text_types_onto_row_then_confirms(self, runner, tmux_manager) -> None:
+        """#172: free text is typed ONTO the highlighted 'Type something.' row,
+        then confirmed with Enter.
+
+        Verified on a live Claude Code v2.1.150 TUI:
+        - Navigating to 'Type something.' and pressing Enter registers a
+          *decline* (no input field opens).
+        - Submitting the text via send_input would post it as a SEPARATE
+          message, not the AskUserQuestion answer.
+        - Typing literal text while the row is highlighted replaces its label
+          with the text; a final Enter records it as the answer.
+
+        So the order must be: Down×N (NO Enter) → send_literal(text) → Enter.
         """
         from unittest.mock import call
 
         with patch("c_lord.claude.tmux_runner._MENU_NAV_DELAY", 0.0):
             await runner.answer_menu_text(2, "melon")
-        assert tmux_manager.send_keys.call_args_list == [
-            call(12345, "Down"),
-            call(12345, "Down"),
-            call(12345, "Enter"),
+
+        # Ordered across send_keys + send_literal.
+        relevant = [c for c in tmux_manager.mock_calls if c[0] in ("send_keys", "send_literal")]
+        assert relevant == [
+            call.send_keys(12345, "Down"),
+            call.send_keys(12345, "Down"),
+            call.send_literal(12345, "melon"),
+            call.send_keys(12345, "Enter"),
         ]
-        tmux_manager.send_input.assert_called_once_with(12345, "melon")
+        # Must NOT submit via send_input (that adds Enter + posts a separate msg).
+        tmux_manager.send_input.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_answer_menu_text_index_zero_no_navigation(self, runner, tmux_manager) -> None:
+        """When the text row is already highlighted (index 0): type then Enter."""
+        from unittest.mock import call
+
+        with patch("c_lord.claude.tmux_runner._MENU_NAV_DELAY", 0.0):
+            await runner.answer_menu_text(0, "kiwi")
+
+        relevant = [c for c in tmux_manager.mock_calls if c[0] in ("send_keys", "send_literal")]
+        assert relevant == [
+            call.send_literal(12345, "kiwi"),
+            call.send_keys(12345, "Enter"),
+        ]
+        tmux_manager.send_input.assert_not_called()
 
 
 # -- Regression tests for #165 (unknown_tui_prompt re-fire spam) ---------------


### PR DESCRIPTION
## What does this PR do?

Fixes the AskUserQuestion free-text affordance (`✏️ Other` → "Type something.") in jsonl/tmux mode. `answer_menu_text` now **types the text onto the highlighted "Type something." row and then confirms with Enter**, instead of navigating + Enter + `send_input`.

## Why?

Closes #172.

On a live Claude Code v2.1.150 TUI the old sequence (navigate → Enter → `send_input`) failed two ways:
- Pressing **Enter on the "Type something." row registers a *decline*** ("User declined to answer questions") — no input field opens.
- The text sent via `send_input` arrives as a **separate follow-up message**, not the AskUserQuestion answer.

The correct interaction, discovered on the live TUI, is to **type directly onto the highlighted row** (which replaces its "Type something." label with the typed text) and then press Enter once.

## Acceptance Criteria (copied from the issue)

- [x] Claude Code TUI で "Type something." に正しくテキストを入れる操作列を実機で特定し記録する → **`Down`×N（Enter なし）→ literal タイプ → `Enter`**。docs/askuserquestion-bridge.md に記録。
- [x] `answer_menu_text` をその操作列に修正
- [x] staging で ✏️Other → 自由入力テキストが **AskUserQuestion の回答として** 記録される（decline や別メッセージにならない）ことを bot の実コードで確認（下記 Staging Evidence）
- [x] ユニットテストで操作列を担保（`test_answer_menu_text_types_onto_row_then_confirms` ほか、send_keys+send_literal の順序を assert）

### 暫定対応の検討
修正したので ✏️Other を隠す必要はなし（実機で回答として記録されることを確認済み）。

## Staging Evidence

実機の Claude Code TUI (v2.1.150) を tmux で起動し AskUserQuestion メニューを描画させ、**本番と同一の `TmuxClaudeRunner.answer_menu_text` コード**で回答。

**RED (修正前の操作列 = navigate+Enter):** "Type something." 行で Enter を押すと:
```
● User declined to answer questions
  ⎿  · 好きな果物は？ (Apple / Banana)
```
→ decline 扱い。入力欄は開かず、テキストは別メッセージ化。

**GREEN (修正後 = 実 answer_menu_text コード):** 2 real options のメニューで `answer_menu_text(2, "ドリアンジュース")` を実行:
```
# 操作列: Down → Down → send_literal("ドリアンジュース") → Enter
# "Type something." 行のラベルがタイプテキストに置換 → ❯ 3. ドリアンジュース
[結果]
  ⎿  · 好きな飲み物は？ → ドリアンジュース       ← AskUserQuestion の回答として記録
● You chose ドリアンジュース (durian juice).      ← Claude が回答として受領
```
decline でも別メッセージでもなく、`<質問> → <自由入力>` として記録された。

中間状態（タイプ直後、Enter 前）も実機確認:
```
  1. Apple
  2. Banana
❯ 3. メロン                                       ← literal がそのまま行に入る
Enter to select · ↑/↓ to navigate · ctrl+g to edit in Vim · Esc to cancel
```

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: tests failed before (RED: `AttributeError`/順序不一致 — old test encoded navigate+Enter+send_input) and pass after (GREEN)
- [x] `uv run pytest tests/` passes — 1154 passed, 5 skipped
- [x] `uv run ruff check c_lord/` + `ruff format --check c_lord/` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #172` used — 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)