### PR TITLE
fix: trust ダイアログ検知をメニュー行に厳格化し誤承認を防ぐ (#184)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -73,6 +73,13 @@ _TRUST_PROMPT_MARKERS = (
     "Enter to confirm",
 )
 
+# The trust dialog's distinctive *menu option line*: "❯ 1. Yes, I trust this
+# folder".  Detection keys on this anchored line rather than a loose substring
+# of the marker phrases anywhere in the pane: the runner captures ~500 lines of
+# scrollback, so a session that merely *mentions* the dialog's wording (e.g. a
+# chat about this very feature) must not trip a spurious Enter into the input.
+_TRUST_PROMPT_RE = re.compile(r"^\s*❯?\s*1\.\s+Yes, I trust this folder\s*$", re.MULTILINE)
+
 # Patterns from Plan approval (ExitPlanMode) and AskUserQuestion TUI menus.
 # These are KNOWN prompt types handled via Discord buttons; they must NOT be
 # flagged as "unknown" interactive prompts (#153).
@@ -787,13 +794,14 @@ class TmuxClaudeRunner:
     def _has_trust_prompt(text: str) -> bool:
         """Check if the pane shows the folder-trust dialog.
 
-        The dialog is top-anchored (its markers are near the top of the pane,
+        The dialog is top-anchored (its content is near the top of the pane,
         bottom rows blank), so this scans the WHOLE pane rather than the bottom
-        permission zone.  It requires *all* markers — the actionable menu option
-        AND the confirm line — so prose that merely mentions one phrase (e.g. a
-        chat about this very feature) does not trip a spurious Enter.
+        permission zone.  To stay robust against the ~500 lines of scrollback the
+        runner captures, it keys on the *menu option line* "❯ 1. Yes, I trust
+        this folder" — a structure prose does not reproduce — instead of a loose
+        substring of the marker phrases.
         """
-        return all(marker in text for marker in _TRUST_PROMPT_MARKERS)
+        return bool(_TRUST_PROMPT_RE.search(text))
 
     @staticmethod
     def _has_permission_prompt(text: str) -> bool:

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -924,7 +924,7 @@ class TestTmuxClaudeRunnerHandleStartupPrompts:
     async def test_handles_trust_prompt(self, runner, tmux_manager) -> None:
         capture_sequence = [
             "Loading...",
-            "Yes, I trust this folder\nEnter to confirm",
+            "❯ 1. Yes, I trust this folder\n  2. No, exit\nEnter to confirm",
             "Processing...",
             "Processing...",
             "Processing...",
@@ -2205,13 +2205,25 @@ class TestTrustPromptTopAnchored:
         assert TmuxClaudeRunner._is_yn_prompt(pane) is False
         assert TmuxClaudeRunner._has_unknown_interactive(pane) is False
 
-    def test_single_marker_in_prose_does_not_trigger(self) -> None:
-        # The dialog needs BOTH markers; a response that merely mentions one
-        # phrase (e.g. a chat about this very feature) must NOT trip an Enter.
-        only_confirm = "I'll select option 1 and press Enter to confirm the choice."
-        only_trust = 'The dialog reads "Yes, I trust this folder" when you open a new repo.'
-        assert TmuxClaudeRunner._has_trust_prompt(only_confirm) is False
-        assert TmuxClaudeRunner._has_trust_prompt(only_trust) is False
+    def test_prose_mentioning_the_dialog_does_not_trigger(self) -> None:
+        # Detection keys on the menu OPTION LINE, not a loose substring.  The
+        # runner captures ~500 lines of scrollback, so a session that merely
+        # discusses the dialog — even quoting BOTH marker phrases — must NOT
+        # trip a spurious Enter into the input (regression for the #180 fix).
+        prose = (
+            '● The trust dialog shows "Yes, I trust this folder" as option 1;\n'
+            "  the user presses Enter to confirm to accept it.\n"
+            "────────\n❯\n────────\n-- INSERT -- bypass permissions on"
+        )
+        assert "Yes, I trust this folder" in prose  # both phrases present...
+        assert "Enter to confirm" in prose
+        assert TmuxClaudeRunner._has_trust_prompt(prose) is False  # ...yet not a dialog
+
+    def test_menu_line_without_cursor_still_detected(self) -> None:
+        # The cursor (❯) may render on a different option; the "1." menu line
+        # itself is the stable signature.
+        text = "Quick safety check\n  1. Yes, I trust this folder\n  2. No, exit"
+        assert TmuxClaudeRunner._has_trust_prompt(text) is True
 
 
 class TestRunAutoAcceptsTrustPrompt:


### PR DESCRIPTION
## What does this PR do?

#180/#181 で入れた trust ダイアログ検知を、緩い substring 一致から**メニュー行構造**（`❯ 1. Yes, I trust this folder`、カーソル有無不問）の一致に厳格化する。

## Why?

Closes #184

メインループは `capture_pane`（history_lines=500 のスクロールバック込み）をフルスキャンするため、両マーカー文字列を**本文に含むだけ**のペイン（この機能自体を会話で言及している等）でも誤検知し、稼働中セッションの入力欄に余計な Enter を送り得た（#156 と同クラスの問題の再導入）。メニュー行はプロンプト本文が再現しない構造なので、これに限定すれば誤検知しない。

## Acceptance Criteria (copied from the issue)

- [x] trust 検知をメニュー行構造（`❯ 1. Yes, I trust this folder`、カーソル有無は問わない）に限定し、本文に両マーカーが現れても誤検知しない
- [x] 「両マーカーを本文に含むが実際のダイアログではない」ペインで `_has_trust_prompt() is False` を検証する回帰テストを追加
- [x] 実ダイアログ（カーソル無しのメニュー行含む）は引き続き `True`
- [x] `pytest` / `ruff check c_lord/` / `ruff format --check c_lord/` / `pyright c_lord/` グリーン

## Staging Evidence

検知ロジックの誤検知修正。実機 bot で「ダイアログ文言を会話に含むセッション」を再現するのは手間なので、`_has_trust_prompt` を直接叩いて RED/GREEN を観測した（実ダイアログ fixture と、両マーカーを本文に含む擬似ペインで比較）。

RED（修正前 #181 のコード）:
```
real dialog -> True
prose both  -> True    # 両マーカーを本文に含むだけ → 誤検知（Enter を送ってしまう）
```

GREEN（本 PR）:
```
real dialog -> True
prose both  -> False   # 本文言及では発火しない
```
ユニットテスト: `tests/test_tmux_runner.py` の trust 系含む 149 passed。`test_prose_mentioning_the_dialog_does_not_trigger`（両マーカー本文→False）/ `test_menu_line_without_cursor_still_detected`（カーソル無し→True）を追加。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: 誤検知を実測で再現(RED)→修正後 False(GREEN)。回帰テスト追加
- [x] `uv run pytest tests/` passes（tmux_runner 149 passed、影響範囲確認済み）
- [x] `ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/`（0 errors）pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes（pre-existing な #178 由来の tests 整形には触れていない）; self-review done
- [x] `Closes #184` used — 100% の AC を満たす
