### PR TITLE
fix: スレッド名の W<N> を安定した work{N} 名から導出 (#187)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -224,7 +224,7 @@ class ClaudeChatCog(commands.Cog):
           thread is ``auto_topic_locked`` from a previous manual rename).
         - Persists the tmux ``window_id`` (immutable) on the row.
         - Renames the Discord thread to
-          ``<status_emoji> <topic>[ #<window_index>]`` capped at 30 chars,
+          ``<status_emoji> W<work_number> │ <topic>`` capped at 30 chars,
           but only if the current name differs (minimises API calls).
 
         All errors are swallowed by the caller; this helper raises only
@@ -248,16 +248,16 @@ class ClaudeChatCog(commands.Cog):
             if pending_win and record.tmux_window_id != pending_win:
                 await self.repo.set_tmux_window_id(thread.id, pending_win)
 
-        # Resolve tmux window-id / window-index.
+        # Resolve tmux window-id / work-number (the stable work{N} number).
         info = await asyncio.to_thread(tmux_manager.get_window_info, thread.id)
         if info is not None:
-            window_id, window_index = info
+            window_id, window_number = info
             if record is not None and record.tmux_window_id != window_id:
                 await self.repo.set_tmux_window_id(thread.id, window_id)
             elif record is None:
                 self._pending_tmux_window_id[thread.id] = window_id
         else:
-            window_index = None
+            window_number = None
 
         # Re-summarize title on subsequent messages (#121).
         # Only runs when a topic already exists and the thread is not manually
@@ -293,7 +293,7 @@ class ClaudeChatCog(commands.Cog):
             # just deleted concurrently).
             topic = parse_topic_from_name(thread.name) or "新しいスレッド"
 
-        new_name = build_name(topic, state, window_index)
+        new_name = build_name(topic, state, window_number)
         if (thread.name or "") == new_name:
             return
         with contextlib.suppress(discord.HTTPException, TimeoutError, asyncio.TimeoutError):

--- a/c_lord/thread_name.py
+++ b/c_lord/thread_name.py
@@ -2,8 +2,8 @@
 
 Format::
 
-    <status_emoji> W<window_index> │ <topic>   (running/waiting/error, with window)
-    <status_emoji> <topic>                      (dead, or no window index)
+    <status_emoji> W<work_number> │ <topic>   (running/waiting/error, with window)
+    <status_emoji> <topic>                     (dead, or no window number)
 
 Examples::
 
@@ -61,19 +61,22 @@ _NO_PREFIX_STATES = frozenset({"dead"})
 def build_name(
     topic: str,
     state: str,
-    tmux_window_index: int | None,
+    window_number: int | None,
 ) -> str:
     """Build a thread name from its parts, capped at 30 characters.
 
-    Format: ``<emoji> W<N> │ <topic>`` when running/waiting/error with a window index.
-    Drops the work prefix for dead state or when window index is unknown.
+    ``window_number`` is the ``N`` from the tmux ``work{N}`` window name (a
+    stable identifier), not tmux's volatile ``#{window_index}``.
+
+    Format: ``<emoji> W<N> │ <topic>`` when running/waiting/error with a window number.
+    Drops the work prefix for dead state or when the window number is unknown.
     Unknown ``state`` falls back to the ``alive``/🟢 emoji.
     When the combination is too long, only the topic is truncated.
     """
     emoji = STATUS_EMOJI.get(state, STATUS_EMOJI["alive"])
 
-    if state not in _NO_PREFIX_STATES and tmux_window_index is not None:
-        fixed = f"{emoji} W{tmux_window_index} │ "
+    if state not in _NO_PREFIX_STATES and window_number is not None:
+        fixed = f"{emoji} W{window_number} │ "
     else:
         fixed = f"{emoji} "
 

--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -13,14 +13,14 @@ Every ``poll_interval`` seconds:
    * ``dead``     → no tmux window exists
    * ``pending`` is reserved for explicit external setters and is
      never produced by this loop.
-3. If the state changed (or the volatile window-index moved, or the
+3. If the state changed (or the work{N} window number changed, or the
    topic is set), build the new thread name with
    :func:`thread_name.build_name` and rename the Discord thread
    when it differs from the current name. Minimises API calls.
 
 The loop deliberately never touches the ``topic`` body — that is
 the user-visible stable identity. Only the leading status emoji and
-the trailing ``W<N> │`` window-index hint are kept fresh.
+the leading ``W<N> │`` work-number hint are kept fresh.
 """
 
 from __future__ import annotations
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 import discord
 
 from .thread_name import build_name
+from .tmux import parse_work_number
 
 if TYPE_CHECKING:
     from discord.ext.commands import Bot
@@ -247,18 +248,18 @@ class ThreadStateSyncLoop:
 
         if window_info is not None:
             window_id = window_info["window_id"] or None
-            idx_str = window_info.get("window_index") or ""
-            window_index: int | None = int(idx_str) if idx_str.isdigit() else None
 
             # Detect fine-grained lamp state from pane content (#120).
             session_name = window_info.get("session_name", "")
             window_name = window_info.get("window_name", "")
+            # W<N> follows the stable work{N} name, not the volatile window_index.
+            window_number: int | None = parse_work_number(window_name)
             pane_text = await asyncio.to_thread(_capture_pane_text, session_name, window_name)
             new_state = _pane_lamp_state(pane_text)
         else:
             new_state = "dead"
             window_id = record.tmux_window_id
-            window_index = None
+            window_number = None
 
         # Persist state and window-id changes.
         if record.state != new_state:
@@ -270,7 +271,7 @@ class ThreadStateSyncLoop:
         if not record.topic:
             return
 
-        new_name = build_name(record.topic, new_state, window_index)
+        new_name = build_name(record.topic, new_state, window_number)
 
         # Fetch the Discord thread and rename if different.
         try:

--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -44,6 +44,25 @@ _STATUS_BAR_ANCHORS = ("⏵⏵", "⏸⏸", "-- NORMAL")
 _INSERT_SETTLE = 0.15
 
 
+def parse_work_number(window_name: str) -> int | None:
+    """Extract the ``N`` from a ``work{N}`` window name.
+
+    Returns ``None`` for windows that don't follow the ``work{N}`` convention
+    (e.g. the session's initial shell window, or a window adopted by dir-match).
+
+    This number is the *stable* window identifier shown as the ``W<N>`` thread
+    name prefix. It deliberately is NOT tmux's ``#{window_index}``, which is
+    volatile — the index shifts when other windows are killed/renumbered and is
+    offset by ``base-index``, so using it would make the Discord ``W<N>`` label
+    disagree with the window's own ``work{N}`` name.
+    """
+    if window_name.startswith(WINDOW_PREFIX):
+        suffix = window_name[len(WINDOW_PREFIX) :]
+        if suffix.isdigit():
+            return int(suffix)
+    return None
+
+
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a subprocess and return the result (never raises on non-zero exit)."""
     return subprocess.run(
@@ -542,13 +561,16 @@ class TmuxSessionManager:
         logger.info("Remapped window %s → thread %d", window_name, thread_id)
         return True
 
-    def get_window_info(self, thread_id: int) -> tuple[str, int] | None:
-        """Return ``(window_id, window_index)`` for the thread, or None.
+    def get_window_info(self, thread_id: int) -> tuple[str, int | None] | None:
+        """Return ``(window_id, work_number)`` for the thread, or None.
 
         ``window_id`` is tmux's internal immutable id (e.g. ``@7``).
-        ``window_index`` is the volatile per-session integer index
-        shown in the tmux status line. Used by the thread-name builder
-        as the trailing ``#N`` hint.
+        ``work_number`` is the ``N`` in the window's ``work{N}`` name — the
+        stable identifier shown as the ``W<N>`` thread-name prefix. It is
+        ``None`` for windows that don't follow the ``work{N}`` convention.
+
+        Note: this is intentionally NOT tmux's volatile ``#{window_index}``.
+        See :func:`parse_work_number` for why the stable name is used instead.
 
         Returns None if tmux is unavailable or no window is mapped to
         the thread.
@@ -565,17 +587,15 @@ class TmuxSessionManager:
                 "-t",
                 self.session_name,
                 "-F",
-                "#{window_name}\t#{window_id}\t#{window_index}",
+                "#{window_name}\t#{window_id}",
             ]
         )
         if result.returncode != 0:
             return None
         for line in result.stdout.splitlines():
             parts = line.split("\t")
-            if len(parts) == 3 and parts[0] == window_name:
-                idx_str = parts[2]
-                if idx_str.isdigit():
-                    return parts[1], int(idx_str)
+            if len(parts) == 2 and parts[0] == window_name:
+                return parts[1], parse_work_number(window_name)
         return None
 
     def list_windows_full(self) -> list[dict[str, str]]:

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -181,6 +181,8 @@ async def test_sync_one_running_when_tool_executing_in_pane():
         bot.get_channel.return_value = fake_thread
         loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
         rec = _Rec(thread_id=222, state="dead", topic="やること", tmux_window_id=None)
+        # Divergence case: tmux window_index (4) != work-name number (1).
+        # The W<N> label must follow the stable work{N} name, not the volatile index.
         by_tid = {
             222: {
                 "window_id": "@9",
@@ -208,7 +210,9 @@ async def test_sync_one_running_when_tool_executing_in_pane():
     fake_thread.edit.assert_awaited_once()
     kwargs = fake_thread.edit.await_args.kwargs
     assert "やること" in kwargs["name"]
-    assert "W4" in kwargs["name"]
+    # W1 from window_name "work1", NOT W4 from the volatile window_index.
+    assert "W1" in kwargs["name"]
+    assert "W4" not in kwargs["name"]
 
 
 async def test_sync_one_waiting_when_prompt_visible():

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from c_lord.tmux import SESSION_NAME, TmuxSessionManager, _pane_in_insert_mode
+from c_lord.tmux import (
+    SESSION_NAME,
+    TmuxSessionManager,
+    _pane_in_insert_mode,
+    parse_work_number,
+)
 
 
 class TestTmuxSessionManager:
@@ -1282,3 +1287,55 @@ class TestPaneInsertModeDetection:
     def test_empty_or_unknown_returns_none(self) -> None:
         assert _pane_in_insert_mode("") is None
         assert _pane_in_insert_mode("just some\nresponse text\n") is None
+
+
+class TestParseWorkNumber:
+    """The W<N> thread-name label must track the stable work{N} window name."""
+
+    def test_parses_work_number(self) -> None:
+        assert parse_work_number("work1") == 1
+        assert parse_work_number("work5") == 5
+        assert parse_work_number("work42") == 42
+
+    def test_returns_none_for_non_work_names(self) -> None:
+        assert parse_work_number("zsh") is None
+        assert parse_work_number("bash") is None
+        assert parse_work_number("") is None
+
+    def test_returns_none_for_non_numeric_suffix(self) -> None:
+        assert parse_work_number("work") is None
+        assert parse_work_number("workbench") is None
+
+
+class TestGetWindowInfo:
+    """get_window_info returns the stable work{N} number, not the volatile index."""
+
+    def test_returns_work_number_not_window_index(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work3"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                # _find_window_for_thread cache hit → show-option verify
+                MagicMock(returncode=0, stdout="12345\n"),
+                # list-windows for window_id lookup — index 0 diverges from work3
+                MagicMock(returncode=0, stdout="work3\t@7\n"),
+            ]
+            info = mgr.get_window_info(12345)
+
+        assert info == ("@7", 3)
+
+    def test_returns_none_work_number_for_non_work_window(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "adopted-window"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),
+                MagicMock(returncode=0, stdout="adopted-window\t@2\n"),
+            ]
+            info = mgr.get_window_info(12345)
+
+        assert info == ("@2", None)


### PR DESCRIPTION
## What does this PR do?

スレッド名の `W<N>` を、tmux の volatile な `#{window_index}` ではなく安定した window 名 `work{N}` の N から導出するように変更する。`tmux.parse_work_number()` を追加し、`get_window_info` / `thread_state_sync` / `claude_chat` の番号源を統一。

## Why?

`base-index 1` / window kill / `renumber-windows on` で `W<N>` が `work{N}` 名とズレ、`tmux attach -t clord:work5` で目的の window に辿り着けなかった。`work{N}` 名は作成時固定で安定、`window_index` は volatile。

Closes #187

## 変更点

- `c_lord/tmux.py` — `parse_work_number("work5")→5`(`work{N}` 以外は `None`)を追加。`get_window_info` の戻り値2番目を `window_index` → `work{N}` 由来の安定番号に変更
- `c_lord/thread_state_sync.py` — `_sync_one` が `window_name` から番号を導出
- `c_lord/cogs/claude_chat.py` — `window_index` → `window_number`(同じ番号源)、docstring 修正
- `c_lord/thread_name.py` — `build_name` 引数を `window_number` に改名 + docstring 修正(関数の挙動は不変)

## Acceptance Criteria (copied from the issue)

- [x] `parse_work_number("work5") == 5` / `parse_work_number("zsh") is None`
- [x] `get_window_info()` が `work{N}` 由来の番号を返す(`work3` の window で `window_index=0` でも `3`)
- [x] `thread_state_sync._sync_one` が `window_name` から導出し、`window_index="4"` / `window_name="work1"` のとき `W1`(not `W4`)
- [x] `claude_chat._apply_thread_naming` も同じ番号源を使う
- [x] `pytest` + `ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/` 全 green
- [x] 実 tmux 上で `W<N>` が `work{N}` 名と一致(下記 Staging Evidence)

## Staging Evidence

staging clone (`c-lord-parallel-3`) は別 PR (`fix/wire-max-concurrent-sessions`) を checkout 中で bot も停止していたため、共有 bot を奪わず、**同一ホスト上の実 tmux セッション**で CI がモックしている tmux コードパスを直接検証した(Discord rename glue は本 PR で不変)。実ホストの tmux は `base-index 1` 設定で、まさに Issue #187 の恒久 +1 ズレ条件。

RED (before — 実 tmux の生 window_index = 旧コードが返していた値):

```
name=zsh    idx=1
name=work1  idx=2   ← 旧コードなら W2(work1 と不一致)
name=work2  idx=3   ← 旧コードなら W3
name=work3  idx=4   ← 旧コードなら W4
```

GREEN (after — 修正後の get_window_info を実 tmux に対して呼び出し):

```
get_window_info(1001) => ('@102', 1)  (W1)
get_window_info(1002) => ('@103', 2)  (W2)
get_window_info(1003) => ('@104', 3)  (W3)
PASS: W<N> follows stable work{N} name (W1/W2/W3), not the +1-offset window_index
```

ユニット側 RED(ソースを修正前に戻し、変更後テストを実行):

```
>       assert "W1" in kwargs["name"]
E       AssertionError: assert 'W1' in '🟢 W4 │ やること'
tests/test_thread_state_sync.py:214: AssertionError
```

GREEN: 全テスト `1178 passed, 5 skipped`、`ruff check`/`ruff format --check`/`pyright`(c_lord/)すべて 0 error。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
