### PR TITLE
fix: ランプが running 中も🟡固着する不具合を修正 (#190)

### DIFF
--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 import subprocess
 from typing import TYPE_CHECKING
 
@@ -56,14 +57,29 @@ _RENAME_TIMEOUT_SECONDS = 30.0
 # ~10-minute rename window per channel.
 _DEFAULT_RENAME_BACKOFF_SECONDS = 600.0
 
-# How many bottom lines of the pane to check for prompt/error indicators.
+# How many bottom lines of the pane to check for error indicators.
 _PANE_PROBE_LINES = 6
 
-# Characters that signal active Claude Code execution in the pane content area.
-# ✢ (U+2722) appears during response generation (Actualizing/Synthesizing/…).
-# ✻ (U+273B) appears during tool execution (Running bash / Reading file / …).
-# Both are specific to the Claude Code TUI and absent from idle panes.
-_RUNNING_CHARS = frozenset({"✢", "✻"})
+# How many bottom lines to scan for the live working spinner. The spinner
+# renders just above the input box, but the box + status footer (~8 lines) and
+# any in-progress tool-result preview push it 10–20 lines off the bottom — so a
+# narrow window misses it. Verified against live captures (#190).
+_RUNNING_PROBE_LINES = 30
+
+# The live working spinner shows a "(<elapsed> · …)" timer that only exists
+# while Claude is actively generating/executing, e.g.
+#   ✢ Swirling… (2m 29s · ↓ 9.3k tokens)
+#   ✶ Creating PR… (11m 57s · ↑ 36.5k tokens)
+#   ✻ Running… (12s · esc to interrupt)
+# A completed turn collapses to "<char> <Word> for <N>s" (no parenthetical), so
+# matching the timer — not the spinner glyph — avoids false-positives on stale
+# completed spinners left in scrollback (#190). It is also independent of which
+# glyph the spinner is cycling through (✢ ✻ ✶ · …), which the old glyph set missed.
+_RUNNING_SPINNER_RE = re.compile(r"\((?:\d+h\s*)?(?:\d+m\s*)?\d+s\s*·")
+
+# Spinner glyphs that, at the very bottom of the pane, still signal active work.
+# Kept as a narrow fallback for panes where the spinner has no timer line yet.
+_RUNNING_CHARS = frozenset({"✢", "✻", "✶"})
 
 # Substrings that indicate an error state (checked in the bottom pane lines).
 _ERROR_INDICATORS = (
@@ -88,9 +104,10 @@ def _pane_lamp_state(pane_text: str) -> str:
     draft text in input, ``-- INSERT --`` etc.) is far more common than
     active execution.
 
-    Running is detected by the Claude Code TUI characters that appear only
-    during active work: ``✢`` (response generation) and ``✻`` (tool execution).
-    These are absent from idle panes — verified against live pane captures.
+    Running is detected by the live working spinner's ``(<elapsed> · …)`` timer
+    (see :data:`_RUNNING_SPINNER_RE`), scanned across a wide bottom window since
+    the input box + footer + tool-result preview push it well off the bottom
+    (#190). A narrow bottom-glyph check remains as a fallback.
     """
     if not pane_text:
         return "waiting"
@@ -101,6 +118,10 @@ def _pane_lamp_state(pane_text: str) -> str:
         for indicator in _ERROR_INDICATORS:
             if indicator in line:
                 return "error"
+
+    for line in lines[-_RUNNING_PROBE_LINES:]:
+        if _RUNNING_SPINNER_RE.search(line):
+            return "running"
 
     for line in tail:
         if any(ch in line for ch in _RUNNING_CHARS):

--- a/tests/fixtures/panes/running_spinner_above_footer.txt
+++ b/tests/fixtures/panes/running_spinner_above_footer.txt
@@ -1,0 +1,80 @@
+                                                                                                                                        
+  修正に着手してよいですか？方針は「probe 窓拡大」と「入力ボックス基準で spinner を探す」のどちらが良いか、希望があれば合わせて教えてください。              
+
+✻ Baked for 3m 9s                                                                                                                                            
+
+❯ ありがとう！　では実機の確認などをスクショなどを織り交ぜながら起票して。そこから修正に、フローに沿ってどんどん進めていって。                               
+
+● 実機確認 → 起票 → TDD修正 → staging検証 → PR のフローで進めます。まずタスク化して、起票用のクリーンな証拠とテスト fixture を実機から採取します。           
+
+● Bash(cd /home/yousan/c-lord-sessions/1505747831447883806/1509026341448843314                                                                           
+      echo "=== git remote/branch here ==="; git remote -v 2>&1 | head -2; git branch --show-c…)                                                             
+  ⎿  === git remote/branch here ===       
+     origin     git@github.com:yousan/c-lord.git (fetch)
+     origin     git@github.com:yousan/c-lord.git (push)
+     … +7 lines (ctrl+o to expand)                  
+                                          
+● Bash(cd /tmp                       
+      # Save raw running-pane capture as fixture source…)                                                                                                    
+  ⎿  saved. line counts:                                                                                                                                     
+        83 /tmp/running_pane_work22.txt                                                                                                                      
+        83 /tmp/running_pane_work21.txt                                                                                                                  
+     … +2 lines (ctrl+o to expand)                                                                                                                           
+  ⎿  Shell cwd was reset to /home/yousan/c-lord-sessions/1505747831447883806/1509026341448843314                                                
+                                     
+● 本セッションの作業ディレクトリは main の clean clone。開発は staging 用の parallel-3 で行えば検証まで一箇所で済むので、parallel-3 の git                   
+  状態を確認します。あわせて採取した running ペインを確認します。                                                                                        
+                                                                                                                                                             
+● Bash(cd /home/yousan/c-lord-parallel-3                                                                                                 
+      echo "=== parallel-3 git ==="; git branch --show-current; git status --short | head; echo "remote:"; git remote get-url origin…)                       
+  ⎿  === parallel-3 git ===                                                                                                                     
+     fix/wire-max-concurrent-sessions                                                                                                                        
+     remote:                                                                                                                             
+     … +5 lines (ctrl+o to expand)                                                                                                                           
+  ⎿  Shell cwd was reset to /home/yousan/c-lord-sessions/1505747831447883806/1509026341448843314                                                
+                                     
+● Bash(echo "=== running_pane_work22.txt (tail 14) ==="; tail -14 /tmp/running_pane_work22.txt | cat -A | sed 's/\xc2\xa0/_/g' | cut -c1-80)                 
+  ⎿  === running_pane_work22.txt (tail 14) ===                                                                                                           
+     $                                                                                                                                                       
+     M-bM-^]M-/ 1. branch + PR M-dM-=M-^\M-fM-^HM-^PM-cM-^AM->M-cM-^AM-'                                                                 
+     … +12 lines (ctrl+o to expand)                                                                                                                          
+                                                                                                                                                
+● parallel-3 は別 PR のブランチ作業中＋staging bot 稼働中なので触りません。開発は本セッションの clean main で新ブランチを切ります。まず今まさに running      
+  状態のペインを採取し直します（パネルは生きていて状態が変わるため）。                                                                   
+                                                                                                                                                             
+● Bash(cd /tmp                                                                                                                                  
+      for w in $(tmux list-windows -t c-lord -F "#{window_name}"); do…)
+  ⎿  Shell cwd was reset to /home/yousan/c-lord-sessions/1505747831447883806/1509026341448843314                                                             
+                                                                                                                                                         
+● 今は全 window が待機中（spinner は生成中のみ表示）。自分自身(work24)は今まさにツール実行中=running なので、自分のペインをキャプチャすれば本物の running
+  fixture が採れます。                                                                                                                                       
+                                                                                                                                                         
+● Bash(tmux capture-pane -p -J -t "c-lord:work24" -S -22 > /tmp/running_self.txt 2>&1; echo "captured $(wc -l < /tmp/running_self.txt) lines"; echo "--- tail
+       14 ---";…)                                                                                                                                            
+  ⎿  captured 80 lines                                                                                                                                   
+     --- tail 14 ---                                                                                                                                         
+          ◻ File GitHub issue with reproduction                                                                                          
+     … +18 lines (ctrl+o to expand)                                                                                                                          
+                                                                                                                                                
+● spinner はツール開始直後に描画されるので、少し待ってから自分のペインを撮ります。
+
+  Bash(sleep 4; tmux capture-pane -p -J -t "c-lord:work24" -S -22 > /tmp/running_self.txt 2>&1; echo "--- tail 16 ---"; tail -16 /tmp/running_self.txt)  
+  ⎿  Running… (3s)                                                                                                                                           
+     (ctrl+b ctrl+b (twice) to run in background)                                                                                        
+
+✢ Swirling… (2m 29s · ↓ 9.3k tokens)                                                                                                            
+  ⎿  ◻ Capture real-machine evidence + pane fixtures
+     ◻ File GitHub issue with reproduction                                                                                                                   
+     ◻ TDD fix: RED test from fixture    
+     ◻ Implement fix in thread_state_sync                                                                                                                    
+     ◻ Staging verification (RED→GREEN)                                                                                                  
+      … +1 pending
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯                                                                                                                                                            
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.7  v2.1.152  Style: default  Ctx: 86.3k  Context: [█░░░░░░░░░░░░░░░] 86k/1000k (9%)  Ctx Used: 9.0%  Ctx(u) Used: 10.8%                 
+   Cost: $1.89  Session: 60.0%  Weekly: 48.0%  Session: 12m  Reset: 1hr 54m  Weekly Reset: 2d 4hr 54m  Block: 3hr 5m  In: 86.3k  Out: 405  Cached: 3.7...
+   ⎇ main  (+0,-0)  +0  -0  1509026341448843314  𖠰 main  cwd: /home/yousan/c-lord-sessions/1505747831447883806/1509026341448843314  Skill: none 
+  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle)
+

--- a/tests/fixtures/panes/waiting_completed_spinner_no_timer.txt
+++ b/tests/fixtures/panes/waiting_completed_spinner_no_timer.txt
@@ -1,0 +1,74 @@
+
+● Full suite still running; I'll commit once it completes and reports green.                                                     
+                                                                                                                                 
+✻ Churned for 3m 52s · 1 shell still running                                                                                         
+
+● Background command "Run full test suite before commit" completed (exit code 0)                                                     
+
+  Read 1 file (ctrl+o to expand)                                                                                                     
+
+● All 1167 tests pass (exit 0). Committing the fix on the feature branch.                                                            
+
+● Bash(cd /home/yousan/c-lord && git add c_lord/session_dir.py c_lord/skills/__init__.py c_lord/skills/injector.py                   
+      tests/test_session_dir.py tests/test_skills.py && gi…)
+  ⎿  pre-commit: ruff format...                                                                                                      
+     5 files left unchanged
+     pre-commit: ruff check --fix...                                                                                                 
+     … +9 lines (ctrl+o to expand)                                                                                               
+  ⎿  Shell cwd was reset to /home/yousan/c-lord-sessions/1475756095887773877/1499664870948339834                                     
+
+● The commit landed on main, not my feature branch — the branch checkout was reset (likely by the bot's git handling between         
+  operations). CLAUDE.md requires no direct commits to main. Let me check state and move the commit onto a feature branch, restoring
+  main.                                                                                                                              
+
+● Bash(cd /home/yousan/c-lord                                                                                                        
+      echo "=== current branch ==="; git branch --show-current…)                                                                 
+  ⎿  === current branch ===                                                                                                          
+     main
+     === all branches ===                                                                                                            
+     … +18 lines (ctrl+o to expand)                                                                                              
+  ⎿  Shell cwd was reset to /home/yousan/c-lord-sessions/1475756095887773877/1499664870948339834                                     
+
+● I can see what happened: the bot restart pulled main forward (new commit 9d96941 #175) and switched HEAD back to main, so my commit
+   47dad73 landed on main on top of the latest. The good news: it's a clean commit on current main, and my fix/... branch still  
+  points at the old base. I'll move the commit onto the feature branch and reset main's pointer back to origin/main —                
+  non-destructively (no reset --hard, just repoint while checked out elsewhere).                                                 
+
+● Bash(cd /home/yousan/c-lord                                                                                                    
+      git branch -f fix/scrub-stale-skills-in-jsonl-mode main && echo "feature branch repointed to my commit"…)                  
+  ⎿  feature branch repointed to my commit                                                                                           
+     Switched to branch 'fix/scrub-stale-skills-in-jsonl-mode'
+     switched to feature branch                                                                                                      
+     … +14 lines (ctrl+o to expand)                                                                                              
+  ⎿  Shell cwd was reset to /home/yousan/c-lord-sessions/1475756095887773877/1499664870948339834                                     
+
+● 状態がクリーンになりました:                                                                                                        
+  - fix/scrub-stale-skills-in-jsonl-mode = 47dad73(私の修正、最新main 9d96941 の上)                                              
+  - main = origin/main と完全一致(ズレ 0/0)                                                                                          
+  - 作業ツリーは feature ブランチで修正を含む
+
+  完了した残作業                                                                                                                     
+
+  再起動でワークツリーがリセットされ消えていた修正を再適用・検証・コミットしました。                                                 
+
+  - 原因: jsonlブリッジモードでは REST API も discord-reply スキルも使われない設計だが、旧 skill モード時代に注入された discord-reply
+   SKILL.md が残り、死んだAPIへ誘導していた。                                                                                    
+  - 修正: remove_injected_skills() を追加し、skills_enabled() が偽のとき create_session_dir()
+  が毎回これを呼んで残骸を掃除(c-lord管理スキルのみ削除、ユーザースキルは温存)。                                                     
+  - 検証: ruff check/ruff format --check(CI対象の c_lord/)パス、全 1167 テスト pass。
+  - コミット 47dad73 を feature ブランチに退避し、ローカル main は origin/main に戻しました(誤って main に乗っていたため)。
+
+  確認(リモート操作なので指示待ち)                                                                                                   
+
+  コミットはローカルのみです。再起動で再び失われないよう、git push して PR を作成してよいですか? よければ                            
+  fix/scrub-stale-skills-in-jsonl-mode を push して PR を立てます。                                                              
+
+✻ Brewed for 1m 20s                                                                                                              
+                                                                                                                                 
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ push it and open the PR                                   
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.7  v2.1.150  Style: default  Ctx: 141.6k  Context: [██░░░░░░░░░░░░░░] 142k/1000k (14%)  Ctx Used: 14.0%  Ctx(...
+   Cost: $7.12  Session: 36.0%  Weekly: 45.0%  Session: 3hr 1m  Reset: 3hr 1m  Weekly Reset: 2d 6hr 1m  Block: 1hr 58m  In: 14...
+   ⎇ main  (+0,-0)  +0  -0  1499664870948339834  𖠰 main  cwd: /home/yousan/c-lord-sessions/1475756095887773877/149966487094833...
+  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -144,6 +145,40 @@ def test_pane_lamp_state_error_takes_priority_over_waiting():
     # Error has higher priority than waiting prompt
     pane = "APIError: something\n❯\n"
     assert _pane_lamp_state(pane) == "error"
+
+
+# ── #190: lamp stuck yellow — real-capture regression fixtures ─────────────────
+
+_PANES_DIR = Path(__file__).parent / "fixtures" / "panes"
+
+
+def _load_pane(name: str) -> str:
+    return (_PANES_DIR / name).read_text()
+
+
+def test_pane_lamp_state_running_when_spinner_above_footer():
+    """#190: live spinner sits ~15 lines above the bottom (input box + status
+    footer + a tool-result preview push it up). Real captured pane where the
+    old bottom-6 probe returned ``waiting`` despite ``✢ Swirling… (2m 29s · …)``
+    being live. Must be ``running``."""
+    pane = _load_pane("running_spinner_above_footer.txt")
+    assert _pane_lamp_state(pane) == "running"
+
+
+def test_pane_lamp_state_waiting_with_completed_spinner_no_timer():
+    """#190 inverse: an idle pane whose last turn collapsed to
+    ``✻ Brewed for 1m 20s`` (a spinner char, but no live ``(Ns · …)`` timer).
+    A char-only detector widened to clear the footer would false-positive here
+    and get stuck green — must stay ``waiting``."""
+    pane = _load_pane("waiting_completed_spinner_no_timer.txt")
+    assert _pane_lamp_state(pane) == "waiting"
+
+
+def test_pane_lamp_state_running_with_alternate_spinner_chars():
+    """#190: real spinners also use ✶ and · (not just ✢/✻). Detection must be
+    spinner-charset-independent via the live ``(Ns · …)`` timer."""
+    assert _pane_lamp_state("✶ Creating PR… (11m 57s · ↑ 36.5k tokens)\n\n❯\n") == "running"
+    assert _pane_lamp_state("· Precipitating… (3m 4s · ↑ 10.6k tokens)\n\n❯\n") == "running"
 
 
 # ── _sync_one tests ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

state-sync ループがスレッド名のランプを「実行中=🟢 / 待機=🟡」で更新する際、**実行中スレッドを🟡と誤判定し🟢に戻らない**不具合 (#190) を修正する。検出を spinner glyph ベースから、ライブ spinner 特有のタイマー `(<elapsed>s · …)` ベース（30行窓）に変更する。

## Why?

Closes #190

原因は2つ:
1. **probe 窓が狭い** — ライブ spinner 行は入力ボックス＋ステータスフッター（約8行）＋実行中ツールの結果プレビューで**下端から 10–20 行上**に出るが、検出は下6行 (`_PANE_PROBE_LINES=6`) しか見ない。
2. **glyph セットが不完全** — `{✢,✻}` のみで、実機の `✶`（`✶ Creating PR…`）や `·`（`· Precipitating…`）spinner を取りこぼす。

結果 running は二度と検出されず、初回 `alive`(🟢) → sync loop が必ず🟡に書き換えて固着。
完了形 `… for <N>s`（括弧なし）はタイマーを持たないので、スクロールバックの完了済み spinner で**緑誤固着する逆バグも回避**できる。

## Acceptance Criteria (copied from the issue)

- [x] `tests/fixtures/panes/` に実機キャプチャの running ペイン（フッター下＋ツール結果で spinner が下端から離れ、スクロールバックに完了形 spinner を含む実例）を追加 → `running_spinner_above_footer.txt`
- [x] 修正前の `_pane_lamp_state()` が当該 fixture で `waiting` を返す（RED 再現）ことをテストで示す
- [x] 修正後、同 fixture で `_pane_lamp_state()` が `running` を返す（GREEN）
- [x] 完了形 spinner（`✻ Brewed for …`）を含むがライブタイマーの無い idle ペイン fixture で `waiting` を返す（緑誤固着の回帰防止）→ `waiting_completed_spinner_no_timer.txt`
- [x] 既存の `_pane_lamp_state` テストが全て green のまま（`14 passed`）
- [x] staging（実機ライブペイン）で「実行中スレッドのランプが🟢になる」ことを確認（下記 Staging Evidence）

## Staging Evidence

専用 staging clone (parallel-3) は別 PR (#183) の検証で占有中のため、変更対象の純粋関数 `_pane_lamp_state` を**本番の稼働中ライブペイン**に対して実行し、旧版 (probe=6, glyph={✢,✻}) と新版を比較した。

RED (before / 旧コード) と GREEN (after / 新コード) を同一ライブペインで対比:
```
window   thread_id            OLD      NEW      spinner
work21   1508751041854836799  waiting  running  · Contemplating… (11m 24s · ↓ 25.8  <== FIXED
work24   1509026341448843314  waiting  running  ✢ Verifying on staging… (14m 5s ·   <== FIXED
work14   1499664870948339834  waiting  waiting  (idle — 誤検知なし)
（他の真に idle なペインは全て OLD=NEW=waiting）
```
- RED: 旧コードは稼働中ペイン (work21=`·`spinner / work24=`✢`spinner) を `waiting` と誤判定
- GREEN: 新コードは `running` を返し、真に idle なペインは `waiting` のまま（誤検知ゼロ）
- `·` spinner は旧 glyph セットでは原理的に拾えなかったケースを含む

ユニット側の RED→GREEN（修正前ソース＋新テスト）:
```
E  AssertionError: assert 'waiting' == 'running'  # running_when_spinner_above_footer
E  AssertionError: assert 'waiting' == 'running'  # running_with_alternate_spinner_chars
2 failed, 1 passed  →（修正後）3 passed
```

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（`1179 passed, 5 skipped`）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)