### PR TITLE
fix: scrub stale discord-reply skill when skill reply is disabled

### DIFF
--- a/c_lord/session_dir.py
+++ b/c_lord/session_dir.py
@@ -152,7 +152,7 @@ class SessionDirManager:
         # final answers via REST API instead of relying on capture-pane
         # scraping. Gated by USE_SKILL_REPLY env so old path stays default.
         # Runs on every call to keep api_url / api_secret in sync.
-        from .skills.injector import inject_skills, skills_enabled
+        from .skills.injector import inject_skills, remove_injected_skills, skills_enabled
 
         if skills_enabled():
             try:
@@ -160,6 +160,13 @@ class SessionDirManager:
             except OSError as exc:
                 # Don't fail session creation on a skill write error.
                 logger.warning("Failed to inject skills for thread %d: %s", thread_id, exc)
+        else:
+            # jsonl bridge mode etc.: scrub any stale skill left by a prior
+            # skill-mode session so Claude isn't pointed at a dead REST API.
+            try:
+                remove_injected_skills(target)
+            except OSError as exc:
+                logger.warning("Failed to remove stale skills for thread %d: %s", thread_id, exc)
 
         return target
 

--- a/c_lord/skills/__init__.py
+++ b/c_lord/skills/__init__.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 from .discord_prompt_choice import render_discord_prompt_choice_skill
 from .discord_reply import DISCORD_REPLY_SKILL, render_discord_reply_skill
-from .injector import inject_skills
+from .injector import inject_skills, remove_injected_skills
 
 __all__ = [
     "DISCORD_REPLY_SKILL",
     "inject_skills",
+    "remove_injected_skills",
     "render_discord_prompt_choice_skill",
     "render_discord_reply_skill",
 ]

--- a/c_lord/skills/injector.py
+++ b/c_lord/skills/injector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 from pathlib import Path
 
 from .discord_prompt_choice import render_discord_prompt_choice_skill
@@ -12,6 +13,10 @@ from .discord_reply import render_discord_reply_skill
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_URL = "http://127.0.0.1:8080"
+
+# Skill directories inject_skills writes. Kept here so remove_injected_skills
+# stays symmetric with what we create.
+INJECTED_SKILL_NAMES: tuple[str, ...] = ("discord-reply", "discord-prompt-choice")
 
 
 def inject_skills(
@@ -81,6 +86,28 @@ def inject_skills(
         choice_path,
     )
     return written
+
+
+def remove_injected_skills(session_dir: str | os.PathLike[str]) -> list[str]:
+    """Remove c-lord skill dirs previously written by :func:`inject_skills`.
+
+    Used when skill-based reply is disabled (e.g. ``CLORD_BRIDGE_MODE=jsonl``)
+    so a stale skill left over from an earlier skill-mode session can't mislead
+    Claude into POSTing to a REST API that is no longer running. Idempotent and
+    only touches c-lord-managed skill dirs — user skills are left untouched.
+
+    Returns:
+        Absolute paths of the skill dirs that were removed.
+    """
+    skills_root = Path(session_dir) / ".claude" / "skills"
+    removed: list[str] = []
+    for name in INJECTED_SKILL_NAMES:
+        skill_dir = skills_root / name
+        if skill_dir.is_dir():
+            shutil.rmtree(skill_dir, ignore_errors=True)
+            removed.append(str(skill_dir))
+            logger.info("Removed injected skill %s (skill reply disabled)", skill_dir)
+    return removed
 
 
 def skills_enabled() -> bool:

--- a/tests/test_session_dir.py
+++ b/tests/test_session_dir.py
@@ -146,9 +146,7 @@ class TestCreateSessionDir:
         assert result == str(session_dir)
         mock_run.assert_not_called()
 
-    def test_injects_skills_when_flag_enabled(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_injects_skills_when_flag_enabled(self, tmp_path: Path, monkeypatch) -> None:
         """Issue #52: with USE_SKILL_REPLY=true the discord-reply SKILL.md
         is dropped into the freshly cloned session dir."""
         monkeypatch.setenv("USE_SKILL_REPLY", "true")
@@ -169,9 +167,7 @@ class TestCreateSessionDir:
         assert skill.exists(), "discord-reply SKILL.md should be injected"
         assert "987" in skill.read_text()
 
-    def test_reinjects_skills_on_existing_session_dir(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_reinjects_skills_on_existing_session_dir(self, tmp_path: Path, monkeypatch) -> None:
         """When the dir already exists, the skill is still (re)written so
         api_url / api_secret stay in sync with current env values."""
         monkeypatch.setenv("USE_SKILL_REPLY", "true")
@@ -193,9 +189,7 @@ class TestCreateSessionDir:
         assert "http://second:2" in body
         assert "http://first:1" not in body
 
-    def test_skips_inject_when_flag_explicitly_disabled(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_skips_inject_when_flag_explicitly_disabled(self, tmp_path: Path, monkeypatch) -> None:
         """Issue #53: opt-out via USE_SKILL_REPLY=0 stops injection."""
         monkeypatch.setenv("USE_SKILL_REPLY", "0")
         base = str(tmp_path / "sessions")
@@ -212,6 +206,22 @@ class TestCreateSessionDir:
 
         skill = Path(target) / ".claude" / "skills" / "discord-reply" / "SKILL.md"
         assert not skill.exists(), "skills must not be injected when explicitly opted out"
+
+    def test_removes_stale_skill_when_disabled(self, tmp_path: Path, monkeypatch) -> None:
+        """jsonl bridge mode (skills disabled): a stale skill injected by a
+        previous skill-mode session is scrubbed so Claude isn't told to POST to
+        the now-dead REST API."""
+        monkeypatch.setenv("USE_SKILL_REPLY", "0")
+        base = str(tmp_path / "sessions")
+        existing = Path(base) / "555"
+        skill_dir = existing / ".claude" / "skills" / "discord-reply"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("stale")
+
+        mgr = SessionDirManager(base_dir=base, source_repo="/repo")
+        mgr.create_session_dir(555)
+
+        assert not skill_dir.exists(), "stale skill must be removed when skills disabled"
 
     def test_injects_skills_by_default(self, tmp_path: Path, monkeypatch) -> None:
         """Issue #53: with the env unset, skill injection is on by default."""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -8,6 +8,7 @@ import pytest
 
 from c_lord.skills import (
     inject_skills,
+    remove_injected_skills,
     render_discord_prompt_choice_skill,
     render_discord_reply_skill,
 )
@@ -184,6 +185,45 @@ class TestInjectSkills:
         assert "88" in body
         assert "http://x:2222" in body
         assert "/api/prompt-choice" in body
+
+
+class TestRemoveInjectedSkills:
+    """When skill reply is disabled (e.g. CLORD_BRIDGE_MODE=jsonl) a stale skill
+    from a previous skill-mode session must be scrubbed so it can't point Claude
+    at a now-dead REST API."""
+
+    def test_removes_both_injected_skill_dirs(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x")
+        reply = session_dir / ".claude" / "skills" / "discord-reply"
+        choice = session_dir / ".claude" / "skills" / "discord-prompt-choice"
+        assert reply.exists() and choice.exists()
+
+        removed = remove_injected_skills(session_dir)
+
+        assert not reply.exists()
+        assert not choice.exists()
+        assert str(reply) in removed
+        assert str(choice) in removed
+
+    def test_idempotent_when_absent(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        assert remove_injected_skills(session_dir) == []
+
+    def test_leaves_user_skills_intact(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x")
+        other = session_dir / ".claude" / "skills" / "my-custom-skill"
+        other.mkdir(parents=True)
+        (other / "SKILL.md").write_text("custom")
+
+        remove_injected_skills(session_dir)
+
+        assert other.exists()
+        assert (other / "SKILL.md").read_text() == "custom"
 
 
 class TestSkillsEnabled:


### PR DESCRIPTION
## Summary
- In jsonl bridge mode (`CLORD_BRIDGE_MODE=jsonl`) the REST API server never starts and skills are not injected — but a `discord-reply` `SKILL.md` left over from an earlier skill-mode session stays in the session dir and tells Claude it is "the only way" to reach Discord, pointing it at a now-dead endpoint (curl times out, exit 28).
- Add `remove_injected_skills()` and call it from `create_session_dir()` whenever `skills_enabled()` is `False`, so stale c-lord skills are scrubbed on the next message. Only c-lord-managed skill dirs (`discord-reply`, `discord-prompt-choice`) are removed; user skills are left untouched.
- Export `remove_injected_skills` from the `c_lord.skills` public API.

## Why
When the operator switches from skill-mode to jsonl mode, the TranscriptMirror becomes the delivery path and the skill must not be used (it would double-post and the REST API is down). Previously the switch left stale skill files behind, misleading Claude.

## Test plan
- [x] `uv run ruff check c_lord/` (CI scope) — passes
- [x] `uv run ruff format --check c_lord/` (CI scope) — passes
- [x] `uv run pytest tests/ -q` — 1167 passed
- New unit tests: `TestRemoveInjectedSkills` (removes both injected dirs, idempotent, leaves user skills intact) + `test_removes_stale_skill_when_disabled` (cleanup runs from `create_session_dir` when disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)