### PR TITLE
fix: テーブル画像の絵文字文字化け・横幅・余白を改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,27 +358,35 @@ uv add "c-lord[table]"
 # or: pip install "c-lord[table]"
 ```
 
-**Non-Latin / CJK font support:**
+**Non-Latin / CJK + emoji font support:**
 
-By default matplotlib uses DejaVu Sans, which does not include Japanese, Chinese, Korean, or other non-Latin glyphs — they will render as blank boxes. c-lord automatically looks for the following fonts at startup and uses the first one found:
+By default matplotlib uses DejaVu Sans, which does not include Japanese, Chinese, Korean, emoji, or other non-Latin glyphs — they render as blank tofu boxes. c-lord builds a per-glyph **font fallback chain** (CJK → emoji → DejaVu Sans), using the first font found in each group:
 
 | Font file path | Notes |
 |---|---|
-| `~/.local/share/fonts/NotoSansJP.ttf` | Recommended for Japanese |
+| `~/.local/share/fonts/NotoSansJP.ttf` | Recommended for Japanese (CJK group) |
 | `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc` | Covers JP / ZH / KO |
 | `/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc` | Alternative system path |
+| `~/.local/share/fonts/NotoEmoji-Regular.ttf` | **Emoji group** — without it, 🟢✅🔴 etc. render as tofu boxes |
+| `/usr/share/fonts/truetype/noto/NotoEmoji-Regular.ttf` | Alternative system path |
 
-If none of these paths exist, c-lord falls back to a name-based search for Noto Sans JP, Noto Sans CJK JP, IPAexGothic, Hiragino Sans, or Yu Gothic.
+If no CJK font is found, c-lord falls back to a name-based search for Noto Sans JP, Noto Sans CJK JP, IPAexGothic, Hiragino Sans, or Yu Gothic (and Noto Emoji / Symbola for the emoji group). Use the **monochrome** Noto Emoji — matplotlib cannot render color (COLR/CBDT) emoji fonts.
 
-**Quick install for Japanese (Linux):**
+**Quick install for Japanese + emoji (Linux):**
 ```bash
 mkdir -p ~/.local/share/fonts
+# Japanese
 curl -Lo ~/.local/share/fonts/NotoSansJP.ttf \
   https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJK-Regular.ttc
+# Emoji (monochrome)
+curl -Lo ~/.local/share/fonts/NotoEmoji-Regular.ttf \
+  "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0jwv.ttf"
 fc-cache -fv
 ```
 
-> **Note for other CJK languages (Chinese, Korean, Arabic, Thai, etc.):** The same DejaVu Sans limitation applies. To render those languages correctly, install a font that covers the target script (e.g. Noto Sans SC for Simplified Chinese, Noto Sans KR for Korean) and add its path to the `jp_font_paths` list in `c_lord/discord_ui/table_renderer.py`, or set `matplotlib.rcParams['font.sans-serif']` in your instance configuration. Contributions adding multi-language font detection are welcome.
+Long cells are wrapped to a bounded width (`MAX_COL_WIDTH`, display-width aware so CJK counts double) so wide tables stay readable on mobile.
+
+> **Note for other CJK languages (Chinese, Korean, Arabic, Thai, etc.):** The same DejaVu Sans limitation applies. To render those languages correctly, install a font that covers the target script (e.g. Noto Sans SC for Simplified Chinese, Noto Sans KR for Korean) and add its path to the `_JP_FONT_PATHS` list in `c_lord/discord_ui/table_renderer.py`, or set `matplotlib.rcParams['font.sans-serif']` in your instance configuration. Contributions adding multi-language font detection are welcome.
 
 ---
 

--- a/c_lord/discord_ui/table_renderer.py
+++ b/c_lord/discord_ui/table_renderer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import re
+import unicodedata
 from io import BytesIO
 
 # GFM pipe table pattern:
@@ -23,6 +24,26 @@ _TABLE_PATTERN = re.compile(
     r"(?:\|[^\n]+\|\n?)+)",  # one or more data rows
 )
 
+# Rendering layout knobs.
+MAX_COL_WIDTH = 48  # max display width (CJK = 2) per column before wrapping
+FONT_SIZE = 12
+CELL_PAD = 0.08  # horizontal text inset as a fraction of cell width
+COL_WIDTH_INCH = 0.10  # figure inches per display-width unit
+LINE_HEIGHT_INCH = 0.46  # figure inches per wrapped text line (vertical padding)
+
+# Font file paths checked before name-based lookup (faster, deterministic).
+_JP_FONT_PATHS = (
+    os.path.expanduser("~/.local/share/fonts/NotoSansJP.ttf"),
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+)
+_JP_FONT_NAMES = ("Noto Sans JP", "Noto Sans CJK JP", "IPAexGothic", "Hiragino Sans", "Yu Gothic")
+_EMOJI_FONT_PATHS = (
+    os.path.expanduser("~/.local/share/fonts/NotoEmoji-Regular.ttf"),
+    "/usr/share/fonts/truetype/noto/NotoEmoji-Regular.ttf",
+)
+_EMOJI_FONT_NAMES = ("Noto Emoji", "Symbola")
+
 
 def detect_tables(content: str) -> list[str]:
     """Return all GFM pipe table blocks found in *content*."""
@@ -32,6 +53,47 @@ def detect_tables(content: str) -> list[str]:
 def has_tables(content: str) -> bool:
     """Return True if *content* contains at least one GFM pipe table."""
     return bool(_TABLE_PATTERN.search(content))
+
+
+def _display_width(text: str) -> int:
+    """Display width of *text*, counting East Asian Wide/Fullwidth glyphs as 2."""
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in text)
+
+
+def _wrap_cell(text: str, max_width: int) -> str:
+    """Wrap *text* so no line exceeds *max_width* display units.
+
+    Wraps on spaces where possible; hard-breaks tokens (URLs, unspaced CJK)
+    that are themselves wider than *max_width*. Returns newline-joined lines.
+    """
+    if max_width <= 0 or _display_width(text) <= max_width:
+        return text
+
+    lines: list[str] = []
+    for para in text.split("\n"):
+        cur = ""
+        for word in para.split(" "):
+            if _display_width(word) > max_width:
+                if cur:
+                    lines.append(cur)
+                    cur = ""
+                chunk = ""
+                for ch in word:
+                    if chunk and _display_width(chunk + ch) > max_width:
+                        lines.append(chunk)
+                        chunk = ch
+                    else:
+                        chunk += ch
+                cur = chunk
+                continue
+            candidate = f"{cur} {word}" if cur else word
+            if _display_width(candidate) > max_width:
+                lines.append(cur)
+                cur = word
+            else:
+                cur = candidate
+        lines.append(cur)
+    return "\n".join(lines)
 
 
 def _parse_table(table_md: str) -> tuple[list[str], list[list[str]]] | None:
@@ -55,6 +117,37 @@ def _parse_table(table_md: str) -> tuple[list[str], list[list[str]]] | None:
     return headers, rows
 
 
+def _resolve_font(font_manager) -> object | None:
+    """Build a FontProperties with a JP→Emoji→DejaVu fallback chain.
+
+    matplotlib (>=3.6) falls back per glyph through the family list, so a
+    Japanese-capable font handles CJK while an emoji font covers glyphs the JP
+    font lacks (previously rendered as tofu boxes). Returns None only when no
+    custom font is found, leaving matplotlib's default.
+    """
+    families: list[str] = []
+
+    def _register(paths: tuple[str, ...], names: tuple[str, ...]) -> None:
+        for path in paths:
+            if os.path.exists(path):
+                font_manager.fontManager.addfont(path)
+                families.append(font_manager.FontProperties(fname=path).get_name())
+                return
+        available = {f.name for f in font_manager.fontManager.ttflist}
+        for name in names:
+            match = next((n for n in available if name.lower() in n.lower()), None)
+            if match:
+                families.append(match)
+                return
+
+    _register(_JP_FONT_PATHS, _JP_FONT_NAMES)
+    _register(_EMOJI_FONT_PATHS, _EMOJI_FONT_NAMES)
+    if not families:
+        return None
+    families.append("DejaVu Sans")
+    return font_manager.FontProperties(family=families)
+
+
 def render_table_image(table_md: str) -> bytes | None:
     """Render a GFM pipe table as a PNG image.
 
@@ -75,65 +168,55 @@ def render_table_image(table_md: str) -> bytes | None:
     except ImportError:
         return None
 
-    # Try to use a Japanese-capable font if available.
-    # Check well-known file paths first (faster than scanning the full ttflist),
-    # then fall back to name-based lookup.
-    import os
-
-    jp_font_paths = [
-        os.path.expanduser("~/.local/share/fonts/NotoSansJP.ttf"),
-        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-        "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
-    ]
-    jp_font_names = [
-        "Noto Sans JP",
-        "Noto Sans CJK JP",
-        "IPAexGothic",
-        "Hiragino Sans",
-        "Yu Gothic",
-    ]
-
-    # font_prop_obj is a FontProperties instance used to set per-cell fonts.
-    font_prop_obj = None
-    for path in jp_font_paths:
-        if os.path.exists(path):
-            font_manager.fontManager.addfont(path)
-            font_prop_obj = font_manager.FontProperties(fname=path)
-            break
-    if font_prop_obj is None:
-        for fname in jp_font_names:
-            candidates = [
-                f for f in font_manager.fontManager.ttflist if fname.lower() in f.name.lower()
-            ]
-            if candidates:
-                font_prop_obj = font_manager.FontProperties(family=candidates[0].name)
-                break
+    font_prop = _resolve_font(font_manager)
 
     n_cols = len(headers)
-    n_rows = len(rows)
+    rows_padded = [(r + [""] * max(0, n_cols - len(r)))[:n_cols] for r in rows]
 
-    # Normalize row widths
-    rows_padded = [r + [""] * max(0, n_cols - len(r)) for r in rows]
-    rows_padded = [r[:n_cols] for r in rows_padded]
+    # Wrap every cell so no line exceeds MAX_COL_WIDTH; bounds the figure width.
+    headers_w = [_wrap_cell(h, MAX_COL_WIDTH) for h in headers]
+    rows_w = [[_wrap_cell(c, MAX_COL_WIDTH) for c in r] for r in rows_padded]
+    n_rows = len(rows_w)
+    all_rows = [headers_w, *rows_w]
 
-    fig_w = max(4, n_cols * 1.8)
-    fig_h = max(1.2, (n_rows + 1) * 0.45)
+    # Per-column display width (longest wrapped line) and per-row line count.
+    col_w = [
+        max(1, max(_display_width(line) for r in all_rows for line in r[c].split("\n")))
+        for c in range(n_cols)
+    ]
+    total_w = sum(col_w)
+    line_counts = [max(cell.count("\n") + 1 for cell in r) for r in all_rows]
+    total_lines = sum(line_counts)
+
+    fig_w = max(4.0, total_w * COL_WIDTH_INCH + n_cols * 0.25)
+    fig_h = max(1.0, total_lines * LINE_HEIGHT_INCH)
     fig, ax = plt.subplots(figsize=(fig_w, fig_h))
     ax.axis("off")
 
     tbl = ax.table(
-        cellText=rows_padded,
-        colLabels=headers,
+        cellText=rows_w,
+        colLabels=headers_w,
         loc="center",
         cellLoc="left",
     )
     tbl.auto_set_font_size(False)
-    tbl.set_fontsize(11)
-    tbl.auto_set_column_width(range(n_cols))
+    tbl.set_fontsize(FONT_SIZE)
 
-    if font_prop_obj:
+    # Explicit column widths (bounded) and row heights (grow with wrapped lines).
+    for col in range(n_cols):
+        width = col_w[col] / total_w
+        for row in range(n_rows + 1):
+            cell = tbl[row, col]
+            cell.set_width(width)
+            cell.PAD = CELL_PAD
+    for row in range(n_rows + 1):
+        height = line_counts[row] / total_lines
+        for col in range(n_cols):
+            tbl[row, col].set_height(height)
+
+    if font_prop:
         for cell in tbl.get_celld().values():
-            cell.get_text().set_font_properties(font_prop_obj)
+            cell.get_text().set_font_properties(font_prop)
 
     # Style header row
     for col in range(n_cols):
@@ -149,7 +232,7 @@ def render_table_image(table_md: str) -> bytes | None:
             tbl[row, col].set_facecolor(color)
 
     buf = BytesIO()
-    plt.savefig(buf, format="png", bbox_inches="tight", dpi=150, pad_inches=0.1)
+    plt.savefig(buf, format="png", bbox_inches="tight", dpi=150, pad_inches=0.15)
     plt.close(fig)
     buf.seek(0)
     return buf.read()

--- a/tests/test_table_renderer.py
+++ b/tests/test_table_renderer.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from c_lord.discord_ui.table_renderer import detect_tables, has_tables, render_table_image
+from c_lord.discord_ui.table_renderer import (
+    _display_width,
+    _wrap_cell,
+    detect_tables,
+    has_tables,
+    render_table_image,
+)
 
 # ---------------------------------------------------------------------------
 # Sample fixtures
@@ -85,6 +91,67 @@ class TestHasTables:
 
     def test_false_when_no_table(self) -> None:
         assert has_tables(NO_TABLE) is False
+
+
+# ===========================================================================
+# _display_width
+# ===========================================================================
+
+
+class TestDisplayWidth:
+    def test_ascii_counts_one_each(self) -> None:
+        assert _display_width("abc") == 3
+
+    def test_empty_is_zero(self) -> None:
+        assert _display_width("") == 0
+
+    def test_cjk_counts_two_each(self) -> None:
+        assert _display_width("あい") == 4
+
+    def test_mixed_ascii_and_cjk(self) -> None:
+        # "AB漢" -> 1 + 1 + 2
+        assert _display_width("AB漢") == 4
+
+
+# ===========================================================================
+# _wrap_cell
+# ===========================================================================
+
+
+class TestWrapCell:
+    def test_short_text_unchanged(self) -> None:
+        assert _wrap_cell("hello", 40) == "hello"
+
+    def test_zero_width_disables_wrap(self) -> None:
+        long = "x" * 100
+        assert _wrap_cell(long, 0) == long
+
+    def test_wraps_on_spaces(self) -> None:
+        result = _wrap_cell("alpha beta gamma", 10)
+        for line in result.split("\n"):
+            assert _display_width(line) <= 10
+        # round-trips back to the original words
+        assert result.replace("\n", " ") == "alpha beta gamma"
+
+    def test_hard_breaks_long_token(self) -> None:
+        # A long unbroken token (e.g. a URL) must still be split.
+        url = "https://github.com/yousan/c-lord/pull/188"
+        result = _wrap_cell(url, 15)
+        lines = result.split("\n")
+        assert len(lines) > 1
+        for line in lines:
+            assert _display_width(line) <= 15
+        assert "".join(lines) == url
+
+    def test_wraps_cjk_by_display_width(self) -> None:
+        # No spaces in CJK text -> must break by character width.
+        text = "これはとても長い日本語のテキストです"
+        result = _wrap_cell(text, 8)
+        lines = result.split("\n")
+        assert len(lines) > 1
+        for line in lines:
+            assert _display_width(line) <= 8
+        assert "".join(lines) == text
 
 
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

`CLORD_RENDER_TABLE_IMAGES` のテーブル画像レンダリングを3点改善:
- **文字化け解消**: JP→Emoji→DejaVu のグリフ単位フォントフォールバック連鎖を構築。NotoSansJP に無い絵文字 (🟢✅🔴) をモノクロ Noto Emoji が埋める
- **横幅制限+折り返し**: 表示幅 (East Asian Width 対応、CJK=2) ベースで各列に `MAX_COL_WIDTH=48` 上限。超過セル (URL等) は折り返し
- **余白拡大**: 行高を折り返し行数に応じて拡大、`CELL_PAD` / フォントサイズ / `pad_inches` を増量

参照テーブルで **1389×237px(横長・豆腐□) → 777×470px(絵文字描画・折り返し)**。

## Why?

出力テーブル画像が読みづらかった: 絵文字が豆腐□に文字化け、長文セルで横幅が 1543px に伸びる、行が縦に詰まる。

Closes #192

## Acceptance Criteria (copied from the issue)

- [x] 絵文字 🟢 を含むテーブルが、豆腐 □ ではなく絵文字グリフとして描画される(JP→Emoji→DejaVu のフォントフォールバック連鎖)
- [x] `MAX_COL_WIDTH` 表示幅を超えるセルは複数行に折り返され、どの行も上限を超えない(CJK は表示幅2でカウント)
- [x] 参照テーブルのレンダリング幅が 1000px 未満になる(変更前 1389 / 実出力 1543 → 777px)
- [x] 行高が折り返し行数に応じて拡大し、セル余白が増える
- [x] `_display_width` / `_wrap_cell` のユニットテストを追加し、`pytest` + `ruff check` + `ruff format --check` + `pyright` が全 green

## Staging Evidence

本番 venv (matplotlib 3.10.9) + 配置済みフォントで参照テーブルを旧/新コードで描画比較:

RED (before, origin/main のコード):
```
before: 43498B (1389, 237)
UserWarning: Glyph 128994 (\N{LARGE GREEN CIRCLE}) missing from font(s) Noto Sans JP.
  ← 絵文字が豆腐□になる文字化けの機械的証拠
```
GREEN (after, 本PRのコード):
```
after: 49437B (777, 470)
  ← glyph-missing 警告なし(フォールバックで絵文字描画)、幅 1389→777px、折り返し+余白で縦増
```
実出力画像(ユーザー報告)でも変更前は 1543px・TDD行に豆腐□があり、新コードの再描画で豆腐消滅・URL折り返し・余白増を目視確認済み。

> 注: 絵文字描画には system に **モノクロ** Noto Emoji が必要 (matplotlib はカラー COLR/CBDT 絵文字を描画不可)。本番 HOME の `~/.local/share/fonts/NotoEmoji-Regular.ttf` に配置済み。README のフォント節も更新。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes (1193 passed, 5 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #192` used (100% of ACs met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)