### PR TITLE
fix: robust GFM table detection (no outer pipes / trailing ws / CRLF / indent)

### DIFF
--- a/c_lord/discord_ui/table_renderer.py
+++ b/c_lord/discord_ui/table_renderer.py
@@ -13,15 +13,21 @@ import re
 import unicodedata
 from io import BytesIO
 
-# GFM pipe table pattern:
-#   header row  : | ... |
-#   separator   : | ---  / :--- / ---: / :---: |
-#   1+ data rows: | ... |
+# GFM pipe table pattern. Kept deliberately permissive so real-world tables
+# still render instead of leaking as raw pipe text:
+#   - outer leading/trailing pipes are optional (GFM allows `a | b`)
+#   - leading indentation is tolerated (tables nested under a list item)
+#   - trailing whitespace after a row is tolerated
+#   - CRLF (`\r\n`) line endings are tolerated
+# A row is any line containing at least one pipe; the separator is the anchor.
+# The `(?=[^\n]*\|)` lookahead asserts a pipe exists, then the line is matched
+# once with a single greedy `[^\n]+`. This avoids two unbounded `[^\n]*` around
+# a literal `|`, which backtracks cubically on adversarial pipe-heavy input.
+_HEADER = r"[ \t]*(?=[^\n]*\|)[^\n]+\r?\n"  # line with >=1 pipe, newline required
+_DATA_ROW = r"[ \t]*(?=[^\n]*\|)[^\n]+\r?\n?"  # data row; trailing newline optional
+_SEP = r"[ \t]*\|?[ \t]*:?-+:?[ \t]*(?:\|[ \t]*:?-+:?[ \t]*)*\|?[ \t]*\r?\n"
 _TABLE_PATTERN = re.compile(
-    r"(?m)"
-    r"(\|[^\n]+\|\n"  # header row
-    r"\|[-:| ]+\|\n"  # separator row
-    r"(?:\|[^\n]+\|\n?)+)",  # one or more data rows
+    r"(" + _HEADER + _SEP + r"(?:" + _DATA_ROW + r")+)",
 )
 
 # Rendering layout knobs.

--- a/tests/test_table_renderer.py
+++ b/tests/test_table_renderer.py
@@ -54,6 +54,26 @@ Second table:
 {ALIGNED_TABLE}
 """
 
+# Real-world variants that the original strict regex failed to detect, so the
+# table silently fell back to raw pipe text in Discord (#table-rendering).
+
+# GFM allows omitting the outer leading/trailing pipes.
+NO_OUTER_PIPES_TABLE = """\
+Name | Score
+--- | ---
+Alice | 100
+Bob | 85
+"""
+
+# Trailing whitespace after the closing pipe (common from cell-alignment).
+TRAILING_WS_TABLE = "| Name | Score | \n|------|-------| \n| Alice | 100 | \n"
+
+# CRLF line endings (Windows / some clients).
+CRLF_TABLE = "| Name | Score |\r\n|------|-------|\r\n| Alice | 100 |\r\n"
+
+# Leading indentation (e.g. table emitted under a list item).
+INDENTED_TABLE = "  | Name | Score |\n  |------|-------|\n  | Alice | 100 |\n"
+
 
 # ===========================================================================
 # detect_tables
@@ -83,6 +103,18 @@ class TestDetectTables:
     def test_detects_multiple_tables(self) -> None:
         tables = detect_tables(MULTIPLE_TABLES)
         assert len(tables) == 2
+
+    def test_detects_table_without_outer_pipes(self) -> None:
+        assert len(detect_tables(NO_OUTER_PIPES_TABLE)) == 1
+
+    def test_detects_table_with_trailing_whitespace(self) -> None:
+        assert len(detect_tables(TRAILING_WS_TABLE)) == 1
+
+    def test_detects_table_with_crlf(self) -> None:
+        assert len(detect_tables(CRLF_TABLE)) == 1
+
+    def test_detects_indented_table(self) -> None:
+        assert len(detect_tables(INDENTED_TABLE)) == 1
 
 
 class TestHasTables:


### PR DESCRIPTION
## What does this PR do?
- Relax `_TABLE_PATTERN` in `table_renderer.py` so the table-image renderer detects valid GFM tables it previously dropped: missing outer pipes, trailing whitespace, CRLF endings, leading indentation.
- Use a `(?=[^\n]*\|)` lookahead + single greedy line match for rows so detection stays linear-ish instead of backtracking cubically on adversarial pipe-heavy input.

## Why?

With `CLORD_RENDER_TABLE_IMAGES=true`, a valid 4-column table was posted as raw pipes (0 attachments) even though matplotlib + `render_table_image()` worked on the same content. The old regex required every line to start/end with `|`, be LF-terminated right after the closing `|`, and be unindented — so common real-world tables silently fell back to raw text.

Closes #199

## Acceptance Criteria (copied from the issue)

- [x] `detect_tables()` returns 1 for a table written **without outer pipes** (`a | b\n--- | ---\n1 | 2`).
- [x] `detect_tables()` returns 1 for a table whose rows have **trailing whitespace** after the closing pipe.
- [x] `detect_tables()` returns 1 for a table with **CRLF** (`\r\n`) line endings.
- [x] `detect_tables()` returns 1 for a table **indented** with leading spaces.
- [x] Existing detection behavior (simple / aligned / Japanese / mixed / multiple) stays green.
- [x] No false positives on prose lines that merely contain a `|` but have no separator row.
- [x] Detection does not exhibit catastrophic backtracking: `detect_tables('|' * 5000)` returns well under 1s.

## Staging Evidence

Verified on the staging machine (`/home/yousan/c-lord-parallel-3`, separate bot `C-lord-3`, `CLORD_RENDER_TABLE_IMAGES=true`, matplotlib 3.10.9) by driving the **deployed** `get_table_images()` — the real env-flag gate + real matplotlib PNG render — against a 2-table fixture: table **A** has outer pipes (renders under both versions, so it proves the flag is on), table **B** is a no-outer-pipes GFM table (the regression case).

**Why not a full Discord round-trip:** the staging bot ignores webhook-authored channel messages (only text commands are wired through the webhook path) and a genuine user-authored message is needed to trigger a Claude turn — not possible from the automation shell; the bot's REST API server was not listening either. The post-detection layer (`transcript_mirror.reply_sink` / `api_server` wrapping `get_table_images()` output into `discord.File`) is unchanged by this PR and is covered by `tests/test_transcript_mirror_cog.py`. So the evidence exercises everything this PR changes, end to end through render.

RED — staging on old code (`b6f6a4d`, pre-fix regex):
```
detect proper(A): 1
detect nopipe(B): 0      ← regression: no-outer-pipes table dropped
detect combined : 1
get_table_images: 1 image(s); [('table_1.png', 5000)]   ← only table A rendered
```

GREEN — staging on this branch (rebased onto main, bot restarted, logged in 17:17:24):
```
detect proper(A): 1
detect nopipe(B): 1      ← now detected
detect combined : 2
get_table_images: 2 image(s); [('table_1.png', 5000), ('table_2.png', 4919)]   ← both tables rendered as real PNGs
```

TDD RED (unit) before the fix:
```
FAILED tests/test_table_renderer.py::TestDetectTables::test_detects_table_without_outer_pipes
FAILED tests/test_table_renderer.py::TestDetectTables::test_detects_table_with_trailing_whitespace
FAILED tests/test_table_renderer.py::TestDetectTables::test_detects_table_with_crlf
FAILED tests/test_table_renderer.py::TestDetectTables::test_detects_indented_table
```
GREEN after: `13 passed, 5 skipped` (table_renderer); `51 passed, 5 skipped` incl. `test_transcript_mirror_cog` after rebase onto #194.

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted above
- [x] `uv run pytest tests/` passes (full suite green; targeted suites re-run green after rebase onto #194)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass (CI green)
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #199` used — this PR satisfies 100% of the issue's ACs (raw-pipe-stripping UX item is explicitly out of scope of #199)
