### PR TITLE
fix: テーブル画像の横幅を広げる (MAX_COL_WIDTH 44→84)

### DIFF
--- a/c_lord/discord_ui/table_renderer.py
+++ b/c_lord/discord_ui/table_renderer.py
@@ -44,7 +44,7 @@ PAD_X = 20  # horizontal cell padding
 PAD_Y = 14  # vertical cell padding
 LINE_GAP = 8  # extra space between wrapped lines
 EMOJI_GAP = 2  # space after an emoji glyph
-MAX_COL_WIDTH = 44  # max display width (CJK = 2) per column before wrapping
+MAX_COL_WIDTH = 84  # max display width (CJK = 2) per column before wrapping
 
 BORDER_COLOR = (208, 213, 221)
 HEADER_BG = (68, 114, 196)


### PR DESCRIPTION
## What does this PR do?

テーブル画像の折り返し閾値 `MAX_COL_WIDTH` を 44→84(表示幅単位)に上げ、横幅を広げる。大半の行が1行に収まり、長いURLのみ折り返す。参照テーブルで **714px → ~1177px**。

## Why?

#204 のカラー化後、折り返しが多く縦長・狭く感じるとのユーザー要望。

Closes #205

## Acceptance Criteria (copied from the issue)

- [x] `MAX_COL_WIDTH = 84` になっている
- [x] 参照テーブル(URL含む)のレンダリング幅が 1000px 以上になる(変更前 714px → 1177px)
- [x] 折り返し・カラー絵文字・余白は引き続き機能(table テスト全 green: 34 passed)
- [x] `pytest`+`ruff check`+`ruff format --check`+`pyright c_lord/` 全 green

## Staging Evidence

```
RED (before, MAX_COL_WIDTH=44): reference table size=(714, 714)
GREEN (after,  MAX_COL_WIDTH=84): reference table size≈(1177-1215, ...) — 大半1行・長URLのみ折り返し
```
幅 44/64/84/110 の描画比較を Discord スレッドに投稿し、84(1215px)を採用。カラー絵文字・余白は維持。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: 既存 table テストで回帰なし(34 passed)。本変更はレイアウト定数で、幅は描画比較で目視検証
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright c_lord/` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #205` used (100% of ACs met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)