### PR TITLE
docs: staging bot の占有・解放プロトコルを CLAUDE.md に定義 (#207)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,8 @@ Issue → branch → PR → **動作確認 + セルフレビュー** → merge �
 
 **前提**: staging 環境 (本番と独立した bot / channel) が `/home/yousan/c-lord-parallel-3` で常時稼働している。詳細は memory `project_staging_env.md` 参照。本番 (`/home/yousan/c-lord`) は kill しない。
 
+⚠️ **staging bot は単一の共有リソース** (`c-lord-parallel-3`, bot user `C-lord-3`)。複数セッション/人間が同時に検証すると、二重起動 (同一トークンが Discord イベントを二重処理) やブランチ切替による他セッションの中断が起きる。staging を借りる前に必ず [Staging bot の占有・解放プロトコル](#staging-bot-の占有解放プロトコル) に従って占有を宣言し、検証後は原状復帰すること。
+
 **手順** (バグ修正の例):
 ```bash
 # 1. RED 再現 — staging 上で問題が発生することを webhook 経由で確認
@@ -426,6 +428,74 @@ curl -X POST ... (上と同じ)
 - 純粋なリファクタで挙動が変わらないことが自明 (それでも `pytest` は必須)
 
 それ以外で staging 検証を省略するときは PR 本文に省略理由を書く。
+
+### Staging bot の占有・解放プロトコル
+
+staging 検証は **単一の bot** (`/home/yousan/c-lord-parallel-3`, bot user `C-lord-3`) を複数の Claude セッション/人間で共有している。占有の取り決めがないと、(1) 同一トークンの **二重起動** (Discord イベント/スラッシュコマンドを二重処理する有害な状態)、(2) 他セッションが検証中にブランチを切り替えられて **検証が中断** される、といった衝突が起きる (実害: 2026-05-27 の二重起動 + 検証中断)。
+
+仕組みは既にある (AI Lounge `POST /api/lounge` が共有 Discord coordination channel へ転送される)。足りないのは「今どのセッションが staging を握っているか」を宣言・解放する運用ルール。staging を borrow するときは下記 3 ステップを必ず守ること。
+
+#### Step 1 — 占有を宣言する (borrow 開始時)
+
+まず AI Lounge を **読んで** 他セッションが staging を使っていないか確認し、空いていれば占有を宣言する。Lounge は共有 Discord channel に転送されるので、他セッション・人間の双方に見える。
+
+```bash
+# 1a. 直近の Lounge を読む (他セッションが staging を借りていないか確認)
+curl -s "${CLORD_API_URL:-http://127.0.0.1:8080}/api/lounge?limit=20" \
+  | python3 -c "import sys,json;[print(f\"[{m['posted_at']}] {m['label']}: {m['message']}\") for m in json.load(sys.stdin)['messages']]"
+
+# 1b. 空いていれば占有を宣言する (label は自分が分かる名前に)
+curl -s -X POST "${CLORD_API_URL:-http://127.0.0.1:8080}/api/lounge" \
+  -H "Content-Type: application/json" \
+  -d '{"label":"<自分のニックネーム>","message":"staging (c-lord-parallel-3) を borrow します: PR #NNN の検証。完了したら解放通知します。"}'
+```
+
+`CLORD_API_URL` は bot が spawn したセッションには注入済み。手動起動した Claude では prod の `http://127.0.0.1:8080` (staging は `8089`) を直接指定する。誰かが既に borrow 中なら、完了通知を待つか Lounge で調整してから着手する。
+
+#### Step 2 — 単一インスタンスで起動する (kill → 残存確認 → 起動)
+
+起動前に **既存の `c-lord-parallel-3` インスタンスを必ず停止** し、二重起動を防ぐ。素の `pgrep -f c_lord.main` は prod・他 clone・**自分の実行シェルの eval 文字列** にもマッチして自滅・巻き添えの罠がある。staging だけを `c-lord-parallel-3` パスで絞ること。
+
+```bash
+cd /home/yousan/c-lord-parallel-3
+
+# 2a. 既存 staging インスタンスを停止 (parallel-3 パスで限定)
+pgrep -f "c-lord-parallel-3.*c_lord.main" | xargs -r kill; sleep 3
+
+# 2b. 残存ゼロを確認してから起動する (count が 0 でなければ PID を直指定で kill)
+#     ※ PID 直指定 (kill <PID>) が最も安全。パターン kill が自分のシェルに当たる事故を避けられる
+echo "remaining: $(pgrep -f 'c-lord-parallel-3.*c_lord.main' | wc -l)"   # ← 0 であること
+
+# 2c. 単一インスタンスで起動
+nohup uv run python -m c_lord.main > /tmp/clord-bot-staging.log 2>&1 &
+
+# 2d. 起動後、インスタンスが「ちょうど 1 つ」であることを再確認 (二重起動防止)
+sleep 2; echo "running: $(pgrep -f 'c-lord-parallel-3.*c_lord.main' | wc -l)"  # ← 1 であること
+```
+
+**本番 (`/home/yousan/c-lord`) は絶対に kill しない。** prod の再起動は別パス (`/home/yousan/c-lord/.venv`) で絞る ([Standard Development Flow](#standard-development-flow-mandatory) の Prod redeploy 参照)。
+
+#### Step 3 — 原状復帰して解放を通知する (borrow 終了時)
+
+検証が終わったら staging を **idle ブランチに戻して再起動** し (他セッションが次に借りたとき既知の状態から始められるように)、Lounge へ解放を通知する。idle ブランチは memory `project_staging_env.md` の "Default branch when idle" を参照 (現状 `fix/wire-max-concurrent-sessions`)。
+
+```bash
+cd /home/yousan/c-lord-parallel-3
+
+# 3a. idle ブランチへ戻す (検証で切り替えていた場合)
+git checkout fix/wire-max-concurrent-sessions   # ← project_staging_env.md の idle ブランチ
+
+# 3b. 単一インスタンスで再起動 (Step 2 と同じ kill → 確認 → 起動)
+pgrep -f "c-lord-parallel-3.*c_lord.main" | xargs -r kill; sleep 3
+echo "remaining: $(pgrep -f 'c-lord-parallel-3.*c_lord.main' | wc -l)"   # ← 0
+nohup uv run python -m c_lord.main > /tmp/clord-bot-staging.log 2>&1 &
+sleep 2; echo "running: $(pgrep -f 'c-lord-parallel-3.*c_lord.main' | wc -l)"  # ← 1
+
+# 3c. Lounge へ解放を通知
+curl -s -X POST "${CLORD_API_URL:-http://127.0.0.1:8080}/api/lounge" \
+  -H "Content-Type: application/json" \
+  -d '{"label":"<自分のニックネーム>","message":"staging を解放しました。idle ブランチに復帰済み。次の人どうぞ。"}'
+```
 
 ## AI Agent Configuration
 


### PR DESCRIPTION
## What does this PR do?

共有 staging bot (`c-lord-parallel-3`) の占有・解放プロトコルを `CLAUDE.md` に明文化する。ランタイム挙動は変更なし（純粋なドキュメント）。

- 新セクション「Staging bot の占有・解放プロトコル」を追加（3 ステップ: 占有宣言 → 単一インスタンス起動 → 原状復帰 + 解放通知）
- 既存「動作確認スキーム (必須)」の前提に新セクションへの参照リンクを追加

## Why?

staging 検証は単一の bot を複数セッション/人間で共有しており、二重起動 (同一トークンが Discord イベントを二重処理) やブランチ切替による検証中断が起きていた (実害: 2026-05-27)。仕組み (AI Lounge) は既にあるが、占有を宣言・解放する運用ルールが無かったため明文化する。

Closes #207

## Acceptance Criteria (copied from the issue)

- [x] `CLAUDE.md` に「Staging bot の占有・解放プロトコル」セクションが追加されている。
- [x] そのセクションに、staging を borrow する前に AI Lounge (`POST /api/lounge`) へ占有宣言を投稿する手順が、コピペ可能な curl 例つきで書かれている。(Step 1)
- [x] そのセクションに、staging bot 起動前に既存の `c-lord-parallel-3` インスタンスを必ず停止し単一インスタンスで起動するためのコピペ可能なレシピ（kill → 残存確認 → 起動）が書かれている。pgrep で parallel-3 のインスタンス数を数える確認コマンドを含む。(Step 2)
- [x] そのセクションに、検証完了後に元のブランチへ戻し再起動して原状復帰する手順と、Lounge へ解放を通知する手順が書かれている。(Step 3)
- [x] 既存の「動作確認スキーム (必須)」セクションから、この新セクションへの参照リンクが張られている。

## Staging Evidence

純粋なドキュメント PR (CLAUDE.md のみ) のため staging 検証は省略 (DoD の skip 例外に該当)。ランタイム挙動の変更なし。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

> **Label exemptions** (`documentation` label): items 1–2 and 5 below are waived.
> `Closes` discipline (item 7) is **always enforced**, regardless of label.

- [x] Every Acceptance Criterion above is checked
- [ ] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted （documentation ラベルにより免除）
- [x] `uv run pytest tests/ -v` passes (CI green)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass (CI green)
- [ ] Staging Evidence above is filled in （純粋ドキュメントのため省略理由を記載）
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met — 全 AC 達成済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)