### PR TITLE
fix: skip #67 discord-reply fallback notice in jsonl bridge mode

### DIFF
--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -212,7 +212,13 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
     # Issue #67: surface a fallback notice when the turn finished cleanly but
     # Claude never called the discord-reply skill — otherwise the user is left
     # staring at silence (only the "no activity 30s" stall warning).
-    if not run_errored and not processor.pending_ask:
+    # Only meaningful when the skill path is active: in jsonl bridge mode the
+    # reply arrives via the transcript mirror (which never calls record_reply),
+    # so the skill-reply tracker is always empty and this would false-fire every
+    # turn. Skip it there.
+    from ..skills.injector import skills_enabled
+
+    if not run_errored and not processor.pending_ask and skills_enabled():
         from ..skills.reply_tracker import was_replied_since
 
         if not was_replied_since(config.thread.id, turn_started_at):

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -441,6 +441,39 @@ class TestNoReplyFallback:
             if isinstance(content, str):
                 assert "discord-reply" not in content
 
+    @pytest.mark.asyncio
+    async def test_no_fallback_in_jsonl_mode(
+        self, thread: MagicMock, runner: MagicMock, repo: MagicMock, monkeypatch
+    ) -> None:
+        """In jsonl bridge mode the reply comes via the transcript mirror, not the
+        discord-reply skill, so the skill-reply tracker is always empty. The #67
+        fallback must be skipped there — otherwise it fires a false notice every turn."""
+        from c_lord.skills.reply_tracker import reset_tracker
+
+        reset_tracker()
+        monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+        monkeypatch.delenv("USE_SKILL_REPLY", raising=False)
+
+        events = [
+            StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1"),
+            StreamEvent(
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                session_id="sess-1",
+            ),
+        ]
+        runner.run = self._make_async_gen(events)
+
+        await run_claude_in_thread(thread, runner, repo, "hello", None)
+
+        for call in thread.send.call_args_list:
+            for arg in call.args:
+                if isinstance(arg, str):
+                    assert "discord-reply" not in arg
+            content = call.kwargs.get("content")
+            if isinstance(content, str):
+                assert "discord-reply" not in content
+
 
 class TestMakeErrorEmbed:
     """Unit tests for the _make_error_embed router function."""


### PR DESCRIPTION
## What does this PR do?
- Skip the Issue #67 "Claude finished without calling the discord-reply skill" fallback notice when `skills_enabled()` is False (i.e. `CLORD_BRIDGE_MODE=jsonl`).

## Why?

In jsonl bridge mode the reply is delivered by the TranscriptMirror, not the discord-reply skill. The #67 fallback fires when `was_replied_since()` is False, but that tracker is updated **only** by `record_reply()` in `ext/api_server.py` (the skill/`/api/reply` path) — the mirror never calls it, and the API server isn't even running in jsonl mode. So `was_replied_since` is always False and the fallback false-fires **every turn**, spamming logs and appending a misleading grey notice after answers that were actually delivered fine via the mirror.

Closes #213

## Acceptance Criteria (copied from the issue)

- [x] When `skills_enabled()` is False (e.g. `CLORD_BRIDGE_MODE=jsonl`), a turn that finishes without a `/api/reply` call does NOT send the fallback notice.
- [x] When skills are enabled (default), existing behavior is unchanged: a turn with no reply call still sends the fallback (regression test stays green).
- [x] No fallback on error turns (existing behavior preserved).

## Staging Evidence

Verified on the staging machine (`/home/yousan/c-lord-parallel-3`, `CLORD_BRIDGE_MODE=jsonl`):

RED — real-world reproduction (live **prod** log, jsonl mode, old code): the fallback fires on essentially every thread:
```
22:39:07 [WARNING] c_lord.cogs._run_helper: [thread=1509030455754625154 ...] Claude finished without calling discord-reply — posting fallback notice
22:52:46 [WARNING] ... [thread=1509034423671328821 ...] Claude finished without calling discord-reply — posting fallback notice
22:54:08 [WARNING] ... [thread=1509007120874475550 ...] Claude finished without calling discord-reply — posting fallback notice
(… recurs for every thread, every turn …)
```

GREEN — the condition the fix keys on, on the staging checkout:
```
$ CLORD_BRIDGE_MODE=jsonl .venv/bin/python -c "from c_lord.skills.injector import skills_enabled; print(skills_enabled())"
False
```
With the fix, `if … and skills_enabled():` short-circuits to False in jsonl mode → the fallback branch is never taken. The unit test below proves the branch logic; this confirms the live staging env satisfies the skip condition.

**Limitation (transparent):** a full Discord round-trip GREEN (watch the warning disappear after a real turn) isn't reproducible from the automation shell — the bot only starts a Claude turn from a genuine user message, which can't be posted from here (bot token posts as the bot, which is ignored). The change is a guarded conditional with no runtime deps, fully exercised by the unit test.

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line below
- [x] `uv run pytest tests/` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass (CI)
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #213` — this PR satisfies 100% of the issue's ACs (mirror→record_reply is explicitly out of scope)

### TDD RED (before the fix)
```
FAILED tests/test_run_helper.py::TestNoReplyFallback::test_no_fallback_in_jsonl_mode
WARNING c_lord.cogs._run_helper:_run_helper.py:219 [thread=67670001] Claude finished without calling discord-reply — posting fallback notice
```
GREEN after: `TestNoReplyFallback` = 4 passed (new test + 3 existing regression tests).
