### PR TITLE
fix: recover final answer dropped across bot restart in jsonl mirror (#215)

### DIFF
--- a/c_lord/cogs/transcript_mirror.py
+++ b/c_lord/cogs/transcript_mirror.py
@@ -31,6 +31,7 @@ from ..transcript.mirror import (
     silent_posts_enabled,
     verbosity_mode,
 )
+from ..transcript.recovery import last_completed_final_answer
 from ..transcript.resolver import derive_project_dir
 
 if TYPE_CHECKING:
@@ -64,14 +65,65 @@ class TranscriptMirrorCog(commands.Cog):
         # Sessions are bounded by Discord usage; 10k is well above realistic.
         rows = await self._session_repo.list_all(limit=10_000)
         started = 0
+        recovered = 0
         for row in rows:
-            if row.working_dir and self.start_for(row.thread_id, row.working_dir):
+            if not row.working_dir:
+                continue
+            # Issue #215: re-deliver a final answer that was written to the
+            # jsonl while the bot was down (mirror not tailing). The resumed
+            # mirror tails from EOF and would otherwise skip it forever.
+            try:
+                if await self._recover_final_answer(row.thread_id, row.working_dir, row):
+                    recovered += 1
+            except Exception:
+                logger.warning(
+                    "TranscriptMirrorCog: final-answer recovery failed thread=%d",
+                    row.thread_id,
+                    exc_info=True,
+                )
+            if self.start_for(row.thread_id, row.working_dir):
                 started += 1
         logger.info(
-            "TranscriptMirrorCog: started %d mirror(s) from %d session row(s)",
+            "TranscriptMirrorCog: started %d mirror(s) from %d session row(s), "
+            "recovered %d dropped final answer(s)",
             started,
             len(rows),
+            recovered,
         )
+
+    async def _recover_final_answer(self, thread_id: int, working_dir: str, row) -> bool:
+        """Re-deliver the last completed turn's final answer if it was dropped.
+
+        Returns True if a recovery post was made. Dedup is by the assistant
+        event uuid: a final answer whose uuid already matches the stored
+        ``mirror_replied_uuid`` was delivered live and is left alone.
+        """
+        fa = last_completed_final_answer(derive_project_dir(working_dir))
+        if fa is None:
+            return False
+        stored = getattr(row, "mirror_replied_uuid", None)
+        if fa.uuid == stored:
+            return False  # already delivered live
+        if stored is None:
+            # First time we track this session (e.g. right after the column was
+            # added by migration). We cannot tell whether the pre-fix mirror
+            # delivered this answer, so assume it did and only seed the cursor —
+            # otherwise every existing thread would be spammed with its last
+            # answer on the first deploy. Genuine drops are caught on the *next*
+            # restart, when the cursor is set and a newer turn differs.
+            await self._session_repo.set_mirror_replied_uuid(thread_id, fa.uuid)
+            return False
+        # Cursor is set and a newer completed turn's final answer differs from
+        # it → that answer was written while the mirror was down. Re-deliver it.
+        reply_sink = self._make_reply_sink(thread_id)
+        await reply_sink(fa.text)
+        await self._session_repo.set_mirror_replied_uuid(thread_id, fa.uuid)
+        logger.info(
+            "TranscriptMirrorCog: recovered dropped final answer thread=%d uuid=%s",
+            thread_id,
+            fa.uuid,
+        )
+        return True
 
     def start_for(self, thread_id: int, working_dir: str) -> bool:
         """Spawn a mirror for ``thread_id`` if one is not already running.
@@ -88,12 +140,14 @@ class TranscriptMirrorCog(commands.Cog):
         sink = self._make_sink(thread_id)
         reply_sink = self._make_reply_sink(thread_id)
         file_sink = self._make_file_sink(thread_id)
+        reply_cursor_sink = self._make_cursor_sink(thread_id)
         mirror = TranscriptMirror(
             thread_id=thread_id,
             project_dir=project_dir,
             sink=sink,
             reply_sink=reply_sink,
             file_sink=file_sink,
+            reply_cursor_sink=reply_cursor_sink,
             verbosity=verbosity_mode(),
         )
         mirror.start()
@@ -113,6 +167,19 @@ class TranscriptMirrorCog(commands.Cog):
     async def cog_unload(self) -> None:
         await asyncio.gather(*(m.stop() for m in self._mirrors.values()), return_exceptions=True)
         self._mirrors.clear()
+
+    def _make_cursor_sink(self, thread_id: int):
+        """Return an awaitable that records the delivered final-answer uuid.
+
+        Issue #215: persists ``mirror_replied_uuid`` after each completed turn
+        so a restart can tell the final answer was already delivered.
+        """
+
+        async def cursor_sink(uuid: str) -> None:
+            with contextlib.suppress(Exception):
+                await self._session_repo.set_mirror_replied_uuid(thread_id, uuid)
+
+        return cursor_sink
 
     def _make_sink(self, thread_id: int):
         """Return an awaitable callable that posts intermediate messages silently."""

--- a/c_lord/database/models.py
+++ b/c_lord/database/models.py
@@ -137,6 +137,10 @@ _MIGRATIONS = [
     "ALTER TABLE sessions ADD COLUMN topic_source TEXT",
     # Issue #115: silent posts + reply threading
     "ALTER TABLE sessions ADD COLUMN trigger_message_id INTEGER",
+    # Issue #215: uuid of the last final answer the mirror delivered, so a
+    # restart can detect & re-deliver a final answer dropped while the bot
+    # was down (mirror not tailing).
+    "ALTER TABLE sessions ADD COLUMN mirror_replied_uuid TEXT",
 ]
 
 

--- a/c_lord/database/repository.py
+++ b/c_lord/database/repository.py
@@ -30,6 +30,8 @@ class SessionRecord:
     topic_source: str | None = None
     # Issue #115: trigger message for reply threading
     trigger_message_id: int | None = None
+    # Issue #215: uuid of the last final answer the mirror delivered
+    mirror_replied_uuid: str | None = None
 
 
 class SessionRepository:
@@ -175,6 +177,19 @@ class SessionRepository:
             await db.execute(
                 "UPDATE sessions SET trigger_message_id = ? WHERE thread_id = ?",
                 (message_id, thread_id),
+            )
+            await db.commit()
+
+    async def set_mirror_replied_uuid(self, thread_id: int, uuid: str) -> None:
+        """Persist the uuid of the last final answer the mirror delivered.
+
+        Used by TranscriptMirror (live) and TranscriptMirrorCog (restart
+        recovery) to dedupe re-delivery of a dropped final answer (Issue #215).
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "UPDATE sessions SET mirror_replied_uuid = ? WHERE thread_id = ?",
+                (uuid, thread_id),
             )
             await db.commit()
 

--- a/c_lord/transcript/mirror.py
+++ b/c_lord/transcript/mirror.py
@@ -117,6 +117,7 @@ class TranscriptMirror:
         sink: Sink,
         reply_sink: Sink | None = None,
         file_sink: FileSink | None = None,
+        reply_cursor_sink: Sink | None = None,
         verbosity: str = "minimal",
         poll_interval: float = 0.5,
     ) -> None:
@@ -125,6 +126,10 @@ class TranscriptMirror:
         self._sink = sink
         self._reply_sink = reply_sink
         self._file_sink = file_sink
+        # Issue #215: called with the uuid of the last assistant_text of each
+        # completed turn, so a restart can tell whether the final answer was
+        # already delivered and avoid re-posting it.
+        self._reply_cursor_sink = reply_cursor_sink
         self._verbosity = verbosity
         self._poll_interval = poll_interval
         self._task: asyncio.Task[None] | None = None
@@ -159,6 +164,25 @@ class TranscriptMirror:
         # tool event → flush silently; result/user_input/stop → flush as reply.
         _pending_text: str | None = None
         _pending_progress: list[str] = []  # snapshot of progress_buf at capture time
+        # Issue #215: uuid of the most recent assistant_text event of the
+        # current turn. Committed at each turn boundary so a restart knows the
+        # final answer was delivered.
+        _last_text_uuid: str | None = None
+
+        async def _commit_cursor() -> None:
+            nonlocal _last_text_uuid
+            if self._reply_cursor_sink is not None and _last_text_uuid:
+                try:
+                    await self._reply_cursor_sink(_last_text_uuid)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning(
+                        "TranscriptMirror cursor sink failed for thread=%d",
+                        self.thread_id,
+                        exc_info=True,
+                    )
+            _last_text_uuid = None
 
         async def _flush_pending_silently() -> None:
             nonlocal _pending_text, _pending_progress
@@ -183,6 +207,7 @@ class TranscriptMirror:
                 if self._verbosity == "minimal" and _is_turn_end(event):
                     # Turn boundary: flush pending as the final reply.
                     await _flush_pending_as_reply()
+                    await _commit_cursor()
                     continue
 
                 rendered = render_event(event)
@@ -200,10 +225,12 @@ class TranscriptMirror:
                             await _flush_pending_silently()
                         _pending_text = _format_body(rendered)
                         _pending_progress = list(progress_buf)
+                        _last_text_uuid = event.get("uuid") or _last_text_uuid
                         progress_buf.clear()
                     elif rendered.kind == "user_input":
                         # Human turn: previous assistant turn is over → flush as reply.
                         await _flush_pending_as_reply()
+                        await _commit_cursor()
                         await self._post(rendered)
                     else:
                         await _flush_pending_silently()
@@ -217,6 +244,7 @@ class TranscriptMirror:
             if self._verbosity == "minimal":
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await _flush_pending_as_reply()
+                    await _commit_cursor()
             logger.info("TranscriptMirror stopped: thread=%d", self.thread_id)
 
     async def _flush_as_reply(self, text: str, progress: list[str]) -> None:

--- a/c_lord/transcript/recovery.py
+++ b/c_lord/transcript/recovery.py
@@ -1,0 +1,79 @@
+"""Recover the final answer of the last completed turn from a JSONL transcript.
+
+Issue #215: when the bot is killed mid/post-turn, the final ``assistant_text``
+is written to the JSONL while the mirror is not tailing.  On restart the mirror
+resumes at end-of-file (``from_start=False``) and skips that line, so the user
+never receives the answer.  :func:`last_completed_final_answer` lets the mirror
+cog detect such an undelivered answer on startup and re-deliver it once,
+deduplicated by the assistant event ``uuid``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from .formatter import render_event
+from .resolver import latest_session_jsonl
+
+
+@dataclass(frozen=True)
+class FinalAnswer:
+    """The final assistant text of a completed turn, with its event uuid."""
+
+    uuid: str
+    text: str
+
+
+def _is_turn_end(event: dict) -> bool:
+    """True for JSONL events that mark the end of a Claude turn.
+
+    Mirrors :func:`c_lord.transcript.mirror._is_turn_end` — both the legacy
+    ``{"type": "result"}`` and current ``{"type": "system",
+    "subtype": "turn_duration"}`` shapes count.
+    """
+    t = event.get("type")
+    return t == "result" or (t == "system" and event.get("subtype") == "turn_duration")
+
+
+def last_completed_final_answer(project_dir: Path) -> FinalAnswer | None:
+    """Return the final answer of the last completed turn, or ``None``.
+
+    The "final answer" is the last assistant event that renders as plain
+    ``assistant_text`` (the rendering the mirror would post as the reply) at or
+    before the last turn-end marker in the most recent ``*.jsonl``.  Returns
+    ``None`` when there is no completed turn carrying a final text answer.
+    """
+    jsonl = latest_session_jsonl(project_dir)
+    if jsonl is None:
+        return None
+    events: list[dict] = []
+    try:
+        with jsonl.open("r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return None
+
+    last_end = -1
+    for i, ev in enumerate(events):
+        if _is_turn_end(ev):
+            last_end = i
+    if last_end < 0:
+        return None
+
+    for ev in reversed(events[: last_end + 1]):
+        if ev.get("type") != "assistant":
+            continue
+        uuid = ev.get("uuid")
+        rendered = render_event(ev)
+        if uuid and rendered is not None and rendered.kind == "assistant_text" and rendered.body:
+            return FinalAnswer(uuid=uuid, text=rendered.body)
+    return None

--- a/tests/test_transcript_mirror_cog.py
+++ b/tests/test_transcript_mirror_cog.py
@@ -710,3 +710,170 @@ async def test_file_sink_no_reference_when_db_raises(
     channel.send.assert_called_once()
     call_kwargs = channel.send.call_args.kwargs
     assert "reference" not in call_kwargs
+
+
+# ── Issue #215: recover undelivered final answer on restart ───────────
+
+
+def _recovery_repo(rows: list, *, trigger_message_id=None) -> MagicMock:
+    """A repo with list_all + get + set_mirror_replied_uuid for recovery tests."""
+    repo = MagicMock()
+    repo.list_all = AsyncMock(return_value=rows)
+    record = MagicMock()
+    record.trigger_message_id = trigger_message_id
+    repo.get = AsyncMock(return_value=record)
+    repo.set_mirror_replied_uuid = AsyncMock()
+    return repo
+
+
+def _session_row(thread_id: int, working_dir: str, replied_uuid):
+    r = MagicMock()
+    r.thread_id = thread_id
+    r.working_dir = working_dir
+    r.mirror_replied_uuid = replied_uuid
+    return r
+
+
+async def test_on_ready_recovers_undelivered_final_answer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Issue #215: a newer completed turn's final answer (uuid != the stored
+    cursor) was written while the bot was down → re-delivered on on_ready."""
+    monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project = tmp_path / ".claude" / "projects" / "-some-cwd"
+    project.mkdir(parents=True)
+    (project / "s.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                # Previous turn, already delivered (cursor points here).
+                {
+                    "type": "assistant",
+                    "uuid": "u-old",
+                    "message": {"content": [{"type": "text", "text": "previous answer"}]},
+                },
+                {"type": "system", "subtype": "turn_duration"},
+                # The turn that completed while the bot was down (undelivered).
+                {
+                    "type": "assistant",
+                    "uuid": "u-final",
+                    "message": {"content": [{"type": "text", "text": "the dropped final answer"}]},
+                },
+                {"type": "system", "subtype": "turn_duration"},
+            ]
+        )
+        + "\n"
+    )
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    repo = _recovery_repo([_session_row(11, "/some/cwd", "u-old")])
+    cog = TranscriptMirrorCog(bot, session_repo=repo)
+    try:
+        await cog.on_ready()
+    finally:
+        await cog.cog_unload()
+
+    # The dropped final answer was re-delivered exactly once...
+    sent_bodies = [
+        (c.kwargs.get("content") or (c.args[0] if c.args else ""))
+        for c in channel.send.call_args_list
+    ]
+    assert any("the dropped final answer" in b for b in sent_bodies), sent_bodies
+    assert not any("previous answer" in b for b in sent_bodies), sent_bodies
+    # ...and the cursor was advanced so it won't be re-posted next restart.
+    repo.set_mirror_replied_uuid.assert_awaited_once_with(11, "u-final")
+
+
+async def test_on_ready_seeds_cursor_silently_when_null(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """First time a session is tracked (cursor NULL, e.g. right after the
+    migration added the column) the last answer must NOT be re-posted —
+    otherwise every existing thread is spammed on the first deploy. The cursor
+    is seeded silently instead."""
+    monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project = tmp_path / ".claude" / "projects" / "-some-cwd"
+    project.mkdir(parents=True)
+    (project / "s.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                {
+                    "type": "assistant",
+                    "uuid": "u-final",
+                    "message": {"content": [{"type": "text", "text": "pre-existing last answer"}]},
+                },
+                {"type": "system", "subtype": "turn_duration"},
+            ]
+        )
+        + "\n"
+    )
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    repo = _recovery_repo([_session_row(11, "/some/cwd", None)])
+    cog = TranscriptMirrorCog(bot, session_repo=repo)
+    try:
+        await cog.on_ready()
+    finally:
+        await cog.cog_unload()
+
+    sent_bodies = [
+        (c.kwargs.get("content") or (c.args[0] if c.args else ""))
+        for c in channel.send.call_args_list
+    ]
+    assert not any("pre-existing last answer" in b for b in sent_bodies), sent_bodies
+    # Cursor seeded so a genuine drop on the *next* restart can be detected.
+    repo.set_mirror_replied_uuid.assert_awaited_once_with(11, "u-final")
+
+
+async def test_on_ready_does_not_redeliver_when_uuid_matches(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the stored uuid already matches the last final answer, no re-delivery."""
+    monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project = tmp_path / ".claude" / "projects" / "-some-cwd"
+    project.mkdir(parents=True)
+    (project / "s.jsonl").write_text(
+        "\n".join(
+            json.dumps(e)
+            for e in [
+                {
+                    "type": "assistant",
+                    "uuid": "u-final",
+                    "message": {"content": [{"type": "text", "text": "already delivered"}]},
+                },
+                {"type": "system", "subtype": "turn_duration"},
+            ]
+        )
+        + "\n"
+    )
+
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    repo = _recovery_repo([_session_row(11, "/some/cwd", "u-final")])
+    cog = TranscriptMirrorCog(bot, session_repo=repo)
+    try:
+        await cog.on_ready()
+    finally:
+        await cog.cog_unload()
+
+    sent_bodies = [
+        (c.kwargs.get("content") or (c.args[0] if c.args else ""))
+        for c in channel.send.call_args_list
+    ]
+    assert not any("already delivered" in b for b in sent_bodies), sent_bodies
+    repo.set_mirror_replied_uuid.assert_not_awaited()

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -668,3 +668,42 @@ def test_progress_content_not_truncated_when_within_limit(tmp_path: Path) -> Non
 
     small = "tool output line"
     assert _truncate_progress(small) == small
+
+
+# ── Issue #215: cursor sink records the final-answer uuid at turn end ──
+
+
+async def test_reply_cursor_sink_records_final_uuid_on_turn_end(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    cursor: list[str] = []
+
+    async def sink(text: str) -> None:  # pragma: no cover - not asserted here
+        pass
+
+    async def reply_cursor_sink(uuid: str) -> None:
+        cursor.append(uuid)
+
+    mirror = TranscriptMirror(
+        thread_id=7,
+        project_dir=project,
+        sink=sink,
+        reply_cursor_sink=reply_cursor_sink,
+        poll_interval=0.05,
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.15)
+        _write_event(jsonl, {**_assistant_text("the final answer"), "uuid": "u-final"})
+        _write_event(jsonl, {"type": "system", "subtype": "turn_duration"})
+        await asyncio.sleep(0.3)
+    finally:
+        await mirror.stop()
+
+    assert cursor == ["u-final"]

--- a/tests/transcript/test_recovery.py
+++ b/tests/transcript/test_recovery.py
@@ -1,0 +1,87 @@
+"""Tests for c_lord.transcript.recovery — last completed turn final answer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from c_lord.transcript.recovery import FinalAnswer, last_completed_final_answer
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+def _assistant(uuid: str, text: str) -> dict:
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def _tool_use(uuid: str, name: str = "Bash") -> dict:
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "message": {"content": [{"type": "tool_use", "name": name, "input": {"command": "ls"}}]},
+    }
+
+
+def _turn_end() -> dict:
+    return {"type": "system", "subtype": "turn_duration"}
+
+
+def test_returns_none_when_no_jsonl(tmp_path: Path) -> None:
+    assert last_completed_final_answer(tmp_path) is None
+
+
+def test_returns_none_without_turn_end(tmp_path: Path) -> None:
+    _write_jsonl(tmp_path / "s.jsonl", [_assistant("u1", "in-progress, no turn end yet")])
+    assert last_completed_final_answer(tmp_path) is None
+
+
+def test_returns_final_answer_of_completed_turn(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _assistant("u1", "intermediate narration"),
+            _tool_use("u2"),
+            _assistant("u3", "the final answer"),
+            _turn_end(),
+        ],
+    )
+    fa = last_completed_final_answer(tmp_path)
+    assert fa == FinalAnswer(uuid="u3", text="the final answer")
+
+
+def test_ignores_events_after_last_turn_end(tmp_path: Path) -> None:
+    # A new (incomplete) turn started after the last completed turn: its text
+    # must NOT be treated as a completed final answer.
+    _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _assistant("u1", "answer of turn 1"),
+            _turn_end(),
+            _assistant("u2", "turn 2 still generating"),
+        ],
+    )
+    fa = last_completed_final_answer(tmp_path)
+    assert fa is not None
+    assert fa.uuid == "u1"
+
+
+def test_picks_latest_turn_when_multiple(tmp_path: Path) -> None:
+    _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _assistant("u1", "answer 1"),
+            _turn_end(),
+            _assistant("u2", "answer 2"),
+            _turn_end(),
+        ],
+    )
+    fa = last_completed_final_answer(tmp_path)
+    assert fa is not None
+    assert fa.uuid == "u2"
+    assert fa.text == "answer 2"


### PR DESCRIPTION
## What does this PR do?

`TranscriptMirror`（経路B）が **bot 再起動を跨ぐと最終回答を取りこぼす** バグ（#215）を修正する。各完了ターンの最終回答 uuid を `sessions.mirror_replied_uuid` に記録し、`on_ready` で「最後の完了ターンの最終回答」と突き合わせて、食い違えば（=未配信）再配信する。

## Why?

tmux 内の Claude は bot kill 後も生存して最終回答を jsonl に書き切るが、再起動後のミラーは `from_start=False` で末尾から読むため、停止中に書かれた行を恒久スキップしていた（ユーザーに最終回答が届かない）。staging で再現確認済み（#215 コメント）。

Closes #215

## Acceptance Criteria (copied from the issue)

- [x] **RED 再現テスト**: 修正前 `test_on_ready_recovers_undelivered_final_answer` が失敗。失敗行 `AssertionError: []`（`channel.send` が最終回答で呼ばれない）。
- [x] **GREEN**: 修正後に同テスト + 追加テスト（silent seed / cursor 記録 / recovery helper）すべて通過。
- [x] **staging 実機**: 修正前=最終回答が Discord に出ない / 修正後=出る を確認（下記 Staging Evidence）。
- [x] **pytest + ruff check + ruff format --check + pyright all green**（`c_lord/` 対象, 1220 passed）。

## Staging Evidence

環境: `c-lord-parallel-3`（prod 不停止）、thread `1508274772641972374`、本ブランチ `6a6c2e3` をデプロイ。

RED (before — 旧コードで別途確認, #215 コメント参照): 生成中に bot kill → 最終回答が jsonl に書かれる → 再起動（EOF 起点）→ Discord に出ない（恒久スキップ）。

GREEN (after — 本ブランチ):
```
# 初回デプロイ: 一斉再投稿なし（NULL カーソルは silent 初期化）
TranscriptMirrorCog: started 1 mirror(s) from 3 session row(s), recovered 0 dropped final answer(s)

# 長文ターン投入 → 生成中に bot kill → tmux Claude が最終回答(uuid d5487408…, 末尾 80235)を
# jsonl に書き切る（bot ダウン中）。再起動前: 80235 in discord = False（未配信）

# 再起動後:
TranscriptMirrorCog: recovered dropped final answer thread=1508274772641972374 uuid=d5487408-d2bc-47e5-9471-4f1960e5cf18
TranscriptMirrorCog: started 1 mirror(s) from 3 session row(s), recovered 1 dropped final answer(s)
# → Discord 07:41:43 に最終回答「1: 数字の始まりであり…」が配信された（GREEN）
```
既知の別件: 非常に長い回答は sink の 1990 字制限で末尾切り詰めされる（既存挙動・本 PR の scope 外）。

設計注: マイグレーションで `mirror_replied_uuid` は全行 NULL になる。NULL を「未配信」と単純判定すると初回 `on_ready` で全スレッド一斉再投稿になるため、**NULL は既配信とみなしカーソルを silent 初期化**し、**カーソル設定済み かつ 最新の最終回答と食い違う場合のみ再配信**する。staging 初回 `recovered 0` で確認済み。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted（`AssertionError: []`）
- [x] `uv run pytest tests/ -v` passes（1220 passed, 9 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met

## Scope / Related

本 PR は **再起動を跨ぐ最終回答ドロップ（機構①）** のみ。機構②（送信失敗の握り潰し）→ #210、経路A/B 役割・誤誘導 fallback の設計 → #216。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
