### PR TITLE
fix: recover missed in-pane AskUserQuestion menu post-turn (#219)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -959,6 +959,19 @@ class TmuxClaudeRunner:
         """Dismiss an open AskUserQuestion menu with Esc (e.g. on timeout) (#166)."""
         await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Escape")
 
+    async def peek_pending_ask(self) -> AskQuestion | None:
+        """Re-capture the pane and return an open AskUserQuestion menu, if any (#219).
+
+        Post-turn safety net: the ``run`` poll loop only bridges a menu while it
+        is active, so a turn that finalizes just before the menu renders (e.g.
+        the 30s stable-response fallback firing during a silent pre-menu thinking
+        phase) leaves Claude blocked on a TUI menu that was never bridged.
+        ``_run_helper`` calls this after the stream ends to recover such a menu
+        and bridge it instead of posting the misleading 'no discord-reply' notice.
+        """
+        raw = await asyncio.to_thread(self._tmux.capture_pane, self._thread_id)
+        return _parse_ask_from_pane(_normalize_capture(raw))
+
     @staticmethod
     def _extract_response(pane_text: str) -> str:
         """Extract Claude's latest response from the TUI pane text.

--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -22,7 +22,12 @@ import time
 
 import discord
 
-from ..discord_ui.ask_handler import ASK_ANSWER_TIMEOUT, collect_ask_answers  # noqa: F401
+from ..claude.tmux_runner import TmuxClaudeRunner
+from ..discord_ui.ask_handler import (  # noqa: F401
+    ASK_ANSWER_TIMEOUT,
+    bridge_pane_ask,
+    collect_ask_answers,
+)
 from ..discord_ui.embeds import error_embed, timeout_embed
 from ..discord_ui.tool_timer import TOOL_TIMER_INTERVAL, LiveToolTimer  # noqa: F401
 from ..lounge import build_lounge_prompt
@@ -222,15 +227,35 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
         from ..skills.reply_tracker import was_replied_since
 
         if not was_replied_since(config.thread.id, turn_started_at):
-            logger.warning(
-                "%s Claude finished without calling discord-reply — posting fallback notice",
-                ctx,
-            )
-            with contextlib.suppress(Exception):
-                await config.thread.send(
-                    "-# ⚠️ Claude finished without calling the `discord-reply` skill. "
-                    "Check the tmux pane for the response, or retry the turn."
+            # #219: the run loop may have finalized just before an AskUserQuestion
+            # menu rendered, leaving Claude blocked on a TUI menu that was never
+            # bridged. Re-check the pane: if a menu is open, bridge it to Discord
+            # buttons instead of posting the misleading 'no discord-reply' notice.
+            pending_pane_ask = None
+            if isinstance(runner, TmuxClaudeRunner):
+                pending_pane_ask = await runner.peek_pending_ask()
+
+            if pending_pane_ask is not None:
+                logger.info(
+                    "%s Recovered open AskUserQuestion menu post-turn — bridging to Discord",
+                    ctx,
                 )
+                await bridge_pane_ask(
+                    config.thread,
+                    pending_pane_ask,
+                    runner,
+                    ask_repo=config.ask_repo,
+                )
+            else:
+                logger.warning(
+                    "%s Claude finished without calling discord-reply — posting fallback notice",
+                    ctx,
+                )
+                with contextlib.suppress(Exception):
+                    await config.thread.send(
+                        "-# ⚠️ Claude finished without calling the `discord-reply` skill. "
+                        "Check the tmux pane for the response, or retry the turn."
+                    )
 
     # After the stream ends, handle pending AskUserQuestion by showing Discord
     # UI and resuming the session with the user's answer.

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -475,6 +475,73 @@ class TestNoReplyFallback:
                 assert "discord-reply" not in content
 
 
+class TestRecoverMissedPaneAsk:
+    """Issue #219: the run loop can finalize a turn just before an
+    AskUserQuestion menu renders, leaving Claude blocked on a TUI menu that was
+    never bridged to Discord buttons (the user sees no choices).  Before posting
+    the #67 'no discord-reply' fallback, run_claude_with_config must re-check the
+    pane and bridge an open menu instead of posting the misleading notice."""
+
+    @pytest.fixture
+    def thread(self) -> MagicMock:
+        t = MagicMock(spec=discord.Thread)
+        t.id = 219219219
+        t.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
+        return t
+
+    @pytest.fixture
+    def repo(self) -> MagicMock:
+        r = MagicMock()
+        r.save = AsyncMock()
+        return r
+
+    def _make_async_gen(self, events):
+        async def gen(*args, **kwargs):
+            for e in events:
+                yield e
+
+        return gen
+
+    @pytest.mark.asyncio
+    async def test_open_menu_is_bridged_and_no_fallback(
+        self, thread: MagicMock, repo: MagicMock
+    ) -> None:
+        from unittest.mock import patch
+
+        from c_lord.claude.tmux_runner import TmuxClaudeRunner
+        from c_lord.claude.types import AskOption, AskQuestion
+        from c_lord.skills.reply_tracker import reset_tracker
+
+        reset_tracker()
+
+        runner = MagicMock(spec=TmuxClaudeRunner)
+        runner.run = self._make_async_gen(
+            [
+                StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1"),
+                StreamEvent(message_type=MessageType.RESULT, is_complete=True, session_id="sess-1"),
+            ]
+        )
+        pending = AskQuestion(
+            question="Which environment?",
+            header="Deploy",
+            options=[AskOption(label="Production", description="本番")],
+        )
+        runner.peek_pending_ask = AsyncMock(return_value=pending)
+
+        with patch("c_lord.cogs._run_helper.bridge_pane_ask", new=AsyncMock()) as bridge:
+            await run_claude_in_thread(thread, runner, repo, "hello", None)
+
+        bridge.assert_awaited_once()
+        # The misleading "no discord-reply" fallback must NOT be posted.
+        for call in thread.send.call_args_list:
+            for arg in call.args:
+                if isinstance(arg, str):
+                    assert "discord-reply" not in arg
+            content = call.kwargs.get("content")
+            if isinstance(content, str):
+                assert "discord-reply" not in content
+
+
 class TestMakeErrorEmbed:
     """Unit tests for the _make_error_embed router function."""
 

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -2175,7 +2175,9 @@ class TestRunYieldsPaneAsk:
         tmux_manager.send_keys.assert_called_once_with(12345, "Enter")
 
     @pytest.mark.asyncio
-    async def test_answer_menu_text_types_onto_row_then_confirms(self, runner, tmux_manager) -> None:
+    async def test_answer_menu_text_types_onto_row_then_confirms(
+        self, runner, tmux_manager
+    ) -> None:
         """#172: free text is typed ONTO the highlighted 'Type something.' row,
         then confirmed with Enter.
 
@@ -2400,3 +2402,30 @@ class TestRunAutoAcceptsTrustPrompt:
         # confirms it.
         enter_calls = [c for c in tmux_manager.send_keys.call_args_list if "Enter" in c.args]
         assert enter_calls, "main loop did not send Enter to accept the trust dialog"
+
+
+# -- Regression tests for #219 (missed AskUserQuestion bridge → fallback notice) --
+
+
+class TestPeekPendingAsk:
+    """Regression for #219: when the run loop finalizes a turn just before an
+    AskUserQuestion menu renders, the menu is never bridged to Discord buttons.
+
+    ``peek_pending_ask`` lets ``_run_helper`` re-check the pane after the stream
+    ends and recover such a menu (so it can be bridged instead of posting the
+    misleading 'no discord-reply' fallback notice).  It must parse a real
+    captured pane (including the current separator layout where ``Chat about
+    this`` follows a separator line) and return ``None`` when no menu is open.
+    """
+
+    @pytest.mark.asyncio
+    async def test_peek_returns_question_for_open_menu(self, runner, tmux_manager) -> None:
+        tmux_manager.capture_pane.return_value = _load_fixture("ask_user_question_3options.txt")
+        q = await runner.peek_pending_ask()
+        assert q is not None
+        assert [o.label for o in q.options] == ["Production", "Staging", "Local"]
+
+    @pytest.mark.asyncio
+    async def test_peek_returns_none_when_no_menu(self, runner, tmux_manager) -> None:
+        tmux_manager.capture_pane.return_value = "● Done.\n\n❯\n──────\n-- INSERT --"
+        assert await runner.peek_pending_ask() is None


### PR DESCRIPTION
## What does this PR do?

tmux pane モードで、Claude がターン末尾に AskUserQuestion メニューを出しているのに **Discord に選択肢ボタンが出ない**問題を修正する。`_run_helper` が #67 fallback 通知を出す直前に pane を再キャプチャ（新規 `TmuxClaudeRunner.peek_pending_ask()`）し、メニューが開いていれば誤通知の代わりに `bridge_pane_ask` でボタン化する。

## Why?

メニュー → Discord ボタンのブリッジは `TmuxClaudeRunner.run()` の poll ループ稼働中のみ行われる。メニュー描画**前**に完了判定（`_RESPONSE_STABLE_FALLBACK` の 30秒 stable、#179 の残穴。AskUserQuestion 直前の静止 thinking フェーズで `is_gen=False` のまま発火）でターンが終了すると、その後出たメニューを見ている poll ループが存在せず永久に取り逃す。結果ユーザーには選択肢ボタンが出ず、#67「discord-reply 未呼び出し」通知だけが出ていた（本番ログで該当スレッドが同通知を15回以上記録）。

Closes #219

## Acceptance Criteria (copied from the issue)

- [x] `TmuxClaudeRunner.peek_pending_ask()` を追加: pane に AskUserQuestion メニューがあるとき `AskQuestion` を返し、無いとき `None` を返す（`TestPeekPendingAsk`）
- [x] `run_claude_with_config`: ターンが discord-reply 未呼び出しで終了し、かつ pane にメニューが開いている場合、`bridge_pane_ask` を呼び、#67 fallback 通知を**出さない**（`TestRecoverMissedPaneAsk`）
- [x] pane にメニューが無い場合は従来どおり #67 fallback 通知を出す（既存 `TestNoReplyFallback` green、回帰なし）
- [x] `ruff check` + `ruff format --check` + `pyright` + `pytest` 全 green
- [x] 実 Claude Code 出力（新セパレータレイアウトを含む実 pane fixture `ask_user_question_3options.txt`）に対し `peek_pending_ask` がメニューを正しく復元

## Staging Evidence

**この race はタイミング依存で webhook から決定論的に再現できない**（Claude が AskUserQuestion 直前に 30秒 stable fallback を踏む静止 thinking フェーズに入る必要がある）。staging での RED/GREEN 再現の代わりに、**本番で実際に「選択肢が出ない」状態で固まっていたライブ tmux pane** に対し復元ロジック（`_parse_ask_from_pane(_normalize_capture(capture_pane))` = `peek_pending_ask` の実体）を実行し、メニューを正しく復元できることを確認した:

RED (修正前の症状 — 本番ログ): 該当スレッドが `Claude finished without calling discord-reply — posting fallback notice` を15回以上記録（選択肢ボタンの代わりに誤通知）。

GREEN (本 PR の復元経路を実 pane に適用):
```
RECOVERED menu from LIVE pane (c-lord:work29):
  header  : '次のステップ'
  question: '修正は完了しテストも green です。ここからどう進めますか？'
  option  : 'PR を2本作成'
  option  : '1本にまとめて PR'
  option  : '作業ツリーのまま'
```
このメニューは bot 再起動前に「ボタンが出ずに固まっていた」実例で、本 PR の経路ならブリッジされていたことを示す。happy-path（メニューを poll ループ中に検出）は既存 in-loop ブリッジ経路が担い、本変更は安全網のみ追加のため非回帰。フル staging デプロイでの happy-path 確認が必要なら追加実施する。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes (1216 passed, 9 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass (pyright 0 errors)
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)

### TDD RED evidence

```
AttributeError: module 'c_lord.cogs._run_helper' does not have the attribute 'bridge_pane_ask'
AttributeError: <TmuxClaudeRunner> does not have the attribute 'peek_pending_ask'
3 failed
```
GREEN: `3 passed`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)