### PR TITLE
fix: idle-flush final answer in JSONL mirror when turn_duration is absent (#218)

### DIFF
--- a/c_lord/transcript/mirror.py
+++ b/c_lord/transcript/mirror.py
@@ -83,6 +83,28 @@ def reply_to_trigger_enabled() -> bool:
     return os.getenv("CLORD_REPLY_TO_TRIGGER", "1").strip().lower() not in ("0", "false", "no")
 
 
+def idle_flush_seconds() -> float:
+    """Return the idle-flush window from ``CLORD_MIRROR_IDLE_FLUSH_SECONDS``.
+
+    In ``minimal`` mode the final assistant text is normally flushed (as a
+    pinging reply) when a turn-end marker is seen.  Current Claude Code builds
+    no longer emit ``result`` and do not reliably emit ``system/turn_duration``
+    (Issue #218), so this idle window is a marker-agnostic safety net: when a
+    pending final answer is held and no new JSONL event arrives within this many
+    seconds, it is flushed as the final reply.  Defaults to ``8.0``.
+    """
+    raw = os.getenv("CLORD_MIRROR_IDLE_FLUSH_SECONDS", "8").strip()
+    try:
+        return float(raw)
+    except ValueError:
+        return 8.0
+
+
+# Module-level alias so ``TranscriptMirror.__init__`` can read the env default
+# without the ``idle_flush_seconds`` constructor parameter shadowing the helper.
+idle_flush_seconds_env = idle_flush_seconds
+
+
 def _is_turn_end(event: dict) -> bool:
     """Return True for JSONL events that signal the end of a Claude turn.
 
@@ -120,6 +142,7 @@ class TranscriptMirror:
         reply_cursor_sink: Sink | None = None,
         verbosity: str = "minimal",
         poll_interval: float = 0.5,
+        idle_flush_seconds: float | None = None,
     ) -> None:
         self.thread_id = thread_id
         self.project_dir = project_dir
@@ -132,6 +155,9 @@ class TranscriptMirror:
         self._reply_cursor_sink = reply_cursor_sink
         self._verbosity = verbosity
         self._poll_interval = poll_interval
+        self._idle_flush_seconds = (
+            idle_flush_seconds if idle_flush_seconds is not None else idle_flush_seconds_env()
+        )
         self._task: asyncio.Task[None] | None = None
 
     def start(self) -> None:
@@ -202,8 +228,46 @@ class TranscriptMirror:
             _pending_text = None
             _pending_progress = []
 
-        try:
+        # Drive the tail through a queue so the consumer can apply an idle
+        # timeout (Issue #218) without cancelling the tail generator: a bare
+        # ``async for`` blocks indefinitely between events, leaving no chance to
+        # flush a pending final answer when no turn-end marker is emitted.
+        queue: asyncio.Queue = asyncio.Queue()
+
+        async def _producer() -> None:
             async for event in tail_events(self.project_dir, poll_interval=self._poll_interval):
+                await queue.put(event)
+
+        producer = asyncio.create_task(_producer(), name=f"transcript-tail-{self.thread_id}")
+        idle_timeout = (
+            self._idle_flush_seconds
+            if self._idle_flush_seconds and self._idle_flush_seconds > 0
+            else None
+        )
+        try:
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=idle_timeout)
+                # asyncio.TimeoutError is a distinct class from builtin
+                # TimeoutError on Python 3.10 (merged only in 3.11); the project
+                # supports 3.10, so the aliased form is required for correctness.
+                except asyncio.TimeoutError:  # noqa: UP041
+                    # Idle: no new JSONL event within the window. Flush any held
+                    # final answer as a pinging reply — independent of whether a
+                    # ``result`` / ``turn_duration`` marker was ever written.
+                    if self._verbosity == "minimal" and _pending_text is not None:
+                        logger.info(
+                            "TranscriptMirror idle-flush: thread=%d "
+                            "(final answer with no turn-end marker within %.1fs)",
+                            self.thread_id,
+                            idle_timeout,
+                        )
+                        await _flush_pending_as_reply()
+                        # Record delivery (Issue #215) so a restart does not
+                        # re-post this idle-flushed final answer.
+                        await _commit_cursor()
+                    continue
+
                 if self._verbosity == "minimal" and _is_turn_end(event):
                     # Turn boundary: flush pending as the final reply.
                     await _flush_pending_as_reply()
@@ -241,6 +305,9 @@ class TranscriptMirror:
         except asyncio.CancelledError:
             pass
         finally:
+            producer.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await producer
             if self._verbosity == "minimal":
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await _flush_pending_as_reply()

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -707,3 +707,102 @@ async def test_reply_cursor_sink_records_final_uuid_on_turn_end(tmp_path: Path) 
         await mirror.stop()
 
     assert cursor == ["u-final"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #218: idle flush — final answer must ping even when turn_duration is
+# absent (current Claude Code builds no longer emit `result` and do not
+# reliably emit `system/turn_duration`).
+# ---------------------------------------------------------------------------
+
+
+def test_idle_flush_seconds_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from c_lord.transcript.mirror import idle_flush_seconds
+
+    monkeypatch.delenv("CLORD_MIRROR_IDLE_FLUSH_SECONDS", raising=False)
+    assert idle_flush_seconds() == 8.0
+
+    monkeypatch.setenv("CLORD_MIRROR_IDLE_FLUSH_SECONDS", "3")
+    assert idle_flush_seconds() == 3.0
+
+
+async def test_minimal_idle_flush_pings_without_turn_duration(tmp_path: Path) -> None:
+    """A final assistant_text with no turn_duration must be flushed to the
+    reply_sink (ping path) after the idle window — before stop() is called."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    silent: list[str] = []
+    replies: list[str] = []
+
+    async def sink(text: str) -> None:
+        silent.append(text)
+
+    async def reply_sink(text: str) -> None:
+        replies.append(text)
+
+    mirror = TranscriptMirror(
+        thread_id=7,
+        project_dir=project,
+        sink=sink,
+        reply_sink=reply_sink,
+        poll_interval=0.05,
+        idle_flush_seconds=0.2,
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl, _assistant_text("FINAL ANSWER"))
+        # No turn_duration / result follows. Wait past the idle threshold.
+        await asyncio.sleep(0.6)
+        # Assert BEFORE stop(): the idle flush must have fired live, not at stop.
+        assert any("FINAL ANSWER" in r for r in replies), (replies, silent)
+    finally:
+        await mirror.stop()
+
+
+async def test_minimal_idle_does_not_prematurely_flush_intermediate_text(
+    tmp_path: Path,
+) -> None:
+    """assistant_text immediately followed by a tool_use (within the idle
+    window) must NOT be flushed as a reply — it is intermediate narration."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    replies: list[str] = []
+
+    async def sink(text: str) -> None:
+        pass
+
+    async def reply_sink(text: str) -> None:
+        replies.append(text)
+
+    mirror = TranscriptMirror(
+        thread_id=8,
+        project_dir=project,
+        sink=sink,
+        reply_sink=reply_sink,
+        poll_interval=0.05,
+        idle_flush_seconds=0.5,
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl, _assistant_text("working on it"))
+        await asyncio.sleep(0.1)  # well within idle window
+        _write_event(jsonl, _assistant_tool_use())
+        await asyncio.sleep(0.1)
+        # Intermediate text must not have been flushed as a reply (no ping).
+        assert not any("working on it" in r for r in replies), replies
+    finally:
+        await mirror.stop()


### PR DESCRIPTION
## What does this PR do?

Adds a marker-agnostic **idle flush** to the JSONL transcript mirror so a thread's final answer always reaches Discord as a pinging reply, even when Claude Code emits no recognized turn-end marker.

## Why?

In JSONL bridge mode + `minimal` verbosity (current production default), the final assistant text is flushed via the **pinging** `reply_sink` only when `_flush_pending_as_reply()` fires — which requires `result` / `system/turn_duration` or a human `user_input`. Current Claude Code builds no longer emit `result` and do not reliably emit `turn_duration` (interrupted / `api_error` / some builds), so the held final answer was instead posted via the **silent** sink (no push notification) or not at all until the next human message. Symptom reported: "一部環境で通知されない".

Fix: the tail is driven through an `asyncio.Queue`, consumed with `wait_for(timeout=CLORD_MIRROR_IDLE_FLUSH_SECONDS)` (default 8s); on idle with a pending final answer it is flushed via `reply_sink` (ping) and the delivery cursor (#215) is committed so a restart won't re-post it. The `turn_duration` fast-path is unchanged; idle flush is additive. `tail.py` is untouched.

Closes #218

## Acceptance Criteria (copied from the issue)

- [x] Unit test: final `assistant_text` with no `turn_duration`/`result`, waits past idle, asserts `reply_sink` called **before** `stop()`. Fails on `main` (RED), passes after (GREEN).
- [x] Unit test: `assistant_text` immediately followed by a `tool_use` is **not** flushed as a reply (no premature ping).
- [x] `idle_flush_seconds()` reads `CLORD_MIRROR_IDLE_FLUSH_SECONDS` (default 8), overridable via constructor.
- [x] Existing `tests/transcript/test_mirror.py` tests pass unchanged.
- [x] `ruff check` + `ruff format --check` + `pytest` green.
- [x] Staging RED reproduced + GREEN confirmed (below).

## Staging Evidence

Verified on `c-lord-parallel-3` (bot `C-lord-3`), `CLORD_BRIDGE_MODE=jsonl`, thread `1508274772641972374`, by appending a synthetic `assistant_text` with **no** turn-end marker to the thread's live transcript (the natural trigger — Claude omitting `turn_duration` — is not controllable on demand). `CLORD_MIRROR_IDLE_FLUSH_SECONDS=3` for fast observation.

**RED** — staging on idle branch (no fix). After appending the marker and waiting 13s:
```
→ no `idle-flush` log line
→ RED marker NOT posted to Discord
```

**GREEN** — staging on `fix/jsonl-mirror-idle-flush`. After appending the marker:
```
2026-05-28 17:28:43 [INFO] c_lord.transcript.mirror: TranscriptMirror idle-flush: thread=1508274772641972374 (final answer with no turn-end marker within 3.0s)
→ Discord post: '[idle-flush staging test GREEN 172839] final answer with no turn_durat…'  (posted via reply_sink = ping)
```

Staging restored to idle branch (`fix/wire-max-concurrent-sessions`), single instance, after verification.

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted below
- [x] `uv run pytest tests/ -v` passes (1237 passed, 9 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass (pyright: 0 errors)
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done (2 files: mirror.py, test_mirror.py)
- [x] `Closes #218` used — 100% of the issue's ACs are met

### RED line

```
E   TypeError: TranscriptMirror.__init__() got an unexpected keyword argument 'idle_flush_seconds'
3 failed, 19 deselected
```

> The DoD "detection bug fixture" rule is scoped to the TUI pane detectors (`_has_permission_prompt`, `_is_yn_prompt`, `_has_unknown_interactive`); this change touches none of them (JSONL flush timing). New tests follow the existing `tests/transcript/test_mirror.py` synthetic-event convention; the failure is additionally reproduced on staging with real JSONL.

## Out of scope

- Broadening `_is_turn_end` to new markers (idle flush makes detection marker-agnostic).
- `full` verbosity (posts everything via the silent sink by design; not the reported case).
