### PR TITLE
fix: recover post-turn AskUserQuestion menu in jsonl mode too (#222)

### DIFF
--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -214,48 +214,50 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
         if config.image_paths:
             await _cleanup_image_tempfiles(config.image_paths)
 
-    # Issue #67: surface a fallback notice when the turn finished cleanly but
-    # Claude never called the discord-reply skill — otherwise the user is left
-    # staring at silence (only the "no activity 30s" stall warning).
-    # Only meaningful when the skill path is active: in jsonl bridge mode the
-    # reply arrives via the transcript mirror (which never calls record_reply),
-    # so the skill-reply tracker is always empty and this would false-fire every
-    # turn. Skip it there.
     from ..skills.injector import skills_enabled
 
-    if not run_errored and not processor.pending_ask and skills_enabled():
+    # #219/#222: the run loop may have finalized just before an AskUserQuestion
+    # menu rendered (or Claude called discord-reply and then asked a follow-up),
+    # leaving Claude blocked on a TUI menu that was never bridged. Recover it by
+    # re-checking the pane. This is INDEPENDENT of bridge mode and of whether
+    # discord-reply was called — the menu is read from the pane, not the
+    # skill-reply path — so it must run OUTSIDE the skills_enabled()/was_replied
+    # guards that gate the #67 notice below. (Gating it there left prod's jsonl
+    # mode never recovering a post-turn menu, so the user saw no choices — #222.)
+    pending_pane_ask = None
+    if not run_errored and not processor.pending_ask and isinstance(runner, TmuxClaudeRunner):
+        pending_pane_ask = await runner.peek_pending_ask()
+
+    if pending_pane_ask is not None:
+        logger.info(
+            "%s Recovered open AskUserQuestion menu post-turn — bridging to Discord",
+            ctx,
+        )
+        await bridge_pane_ask(
+            config.thread,
+            pending_pane_ask,
+            runner,
+            ask_repo=config.ask_repo,
+        )
+    elif not run_errored and not processor.pending_ask and skills_enabled():
+        # Issue #67: surface a fallback notice when the skill-reply path was
+        # active but Claude never called discord-reply — otherwise the user is
+        # left staring at silence. Skill-mode only: in jsonl bridge mode the
+        # reply arrives via the transcript mirror (which never calls
+        # record_reply), so the tracker is always empty and this would
+        # false-fire every turn.
         from ..skills.reply_tracker import was_replied_since
 
         if not was_replied_since(config.thread.id, turn_started_at):
-            # #219: the run loop may have finalized just before an AskUserQuestion
-            # menu rendered, leaving Claude blocked on a TUI menu that was never
-            # bridged. Re-check the pane: if a menu is open, bridge it to Discord
-            # buttons instead of posting the misleading 'no discord-reply' notice.
-            pending_pane_ask = None
-            if isinstance(runner, TmuxClaudeRunner):
-                pending_pane_ask = await runner.peek_pending_ask()
-
-            if pending_pane_ask is not None:
-                logger.info(
-                    "%s Recovered open AskUserQuestion menu post-turn — bridging to Discord",
-                    ctx,
+            logger.warning(
+                "%s Claude finished without calling discord-reply — posting fallback notice",
+                ctx,
+            )
+            with contextlib.suppress(Exception):
+                await config.thread.send(
+                    "-# ⚠️ Claude finished without calling the `discord-reply` skill. "
+                    "Check the tmux pane for the response, or retry the turn."
                 )
-                await bridge_pane_ask(
-                    config.thread,
-                    pending_pane_ask,
-                    runner,
-                    ask_repo=config.ask_repo,
-                )
-            else:
-                logger.warning(
-                    "%s Claude finished without calling discord-reply — posting fallback notice",
-                    ctx,
-                )
-                with contextlib.suppress(Exception):
-                    await config.thread.send(
-                        "-# ⚠️ Claude finished without calling the `discord-reply` skill. "
-                        "Check the tmux pane for the response, or retry the turn."
-                    )
 
     # After the stream ends, handle pending AskUserQuestion by showing Discord
     # UI and resuming the session with the user's answer.

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -541,6 +541,81 @@ class TestRecoverMissedPaneAsk:
             if isinstance(content, str):
                 assert "discord-reply" not in content
 
+    @pytest.mark.asyncio
+    async def test_open_menu_bridged_in_jsonl_mode(
+        self, thread: MagicMock, repo: MagicMock, monkeypatch
+    ) -> None:
+        """#222: post-turn menu recovery must run in jsonl bridge mode too.
+
+        The menu is read from the pane, independent of the skill-reply path, so
+        gating it behind skills_enabled() (False in jsonl = production's mode)
+        left prod never recovering a post-turn menu — the user saw no choices.
+        """
+        from unittest.mock import patch
+
+        from c_lord.claude.tmux_runner import TmuxClaudeRunner
+        from c_lord.claude.types import AskOption, AskQuestion
+        from c_lord.skills.reply_tracker import reset_tracker
+
+        reset_tracker()
+        monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+        monkeypatch.delenv("USE_SKILL_REPLY", raising=False)
+
+        runner = MagicMock(spec=TmuxClaudeRunner)
+        runner.run = self._make_async_gen(
+            [
+                StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1"),
+                StreamEvent(message_type=MessageType.RESULT, is_complete=True, session_id="sess-1"),
+            ]
+        )
+        pending = AskQuestion(
+            question="Which environment?",
+            header="Deploy",
+            options=[AskOption(label="Production", description="本番")],
+        )
+        runner.peek_pending_ask = AsyncMock(return_value=pending)
+
+        with patch("c_lord.cogs._run_helper.bridge_pane_ask", new=AsyncMock()) as bridge:
+            await run_claude_in_thread(thread, runner, repo, "hello", None)
+
+        bridge.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_open_menu_bridged_even_after_reply(
+        self, thread: MagicMock, repo: MagicMock
+    ) -> None:
+        """#222: a follow-up menu rendered AFTER discord-reply was called must
+        still be recovered — was_replied_since must not gate menu recovery."""
+        from unittest.mock import patch
+
+        from c_lord.claude.tmux_runner import TmuxClaudeRunner
+        from c_lord.claude.types import AskOption, AskQuestion
+        from c_lord.skills.reply_tracker import record_reply, reset_tracker
+
+        reset_tracker()
+
+        runner = MagicMock(spec=TmuxClaudeRunner)
+
+        async def gen_with_reply(*args, **kwargs):
+            yield StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1")
+            record_reply(thread.id)
+            yield StreamEvent(
+                message_type=MessageType.RESULT, is_complete=True, session_id="sess-1"
+            )
+
+        runner.run = gen_with_reply
+        pending = AskQuestion(
+            question="Which environment?",
+            header="Deploy",
+            options=[AskOption(label="Production", description="本番")],
+        )
+        runner.peek_pending_ask = AsyncMock(return_value=pending)
+
+        with patch("c_lord.cogs._run_helper.bridge_pane_ask", new=AsyncMock()) as bridge:
+            await run_claude_in_thread(thread, runner, repo, "hello", None)
+
+        bridge.assert_awaited_once()
+
 
 class TestMakeErrorEmbed:
     """Unit tests for the _make_error_embed router function."""


### PR DESCRIPTION
## What does this PR do?

post-turn の AskUserQuestion メニュー回収（#219 の `peek_pending_ask` → `bridge_pane_ask`）を **`skills_enabled()` / `was_replied_since` ガードの外**に出し、全ブリッジモードで走るようにする。#67 の「discord-reply 未呼び出し」通知だけは skill モード限定のまま残す。

## Why?

#219 はメニュー回収を `if not run_errored and not processor.pending_ask and skills_enabled():` の内側に置いていた。`skills_enabled()` は `CLORD_BRIDGE_MODE=jsonl`（本番のモード）で **False** なので、**本番では回収が一度も走らず**、ターン後に出たメニューが bridge されないまま固着し、ユーザーには選択肢が出なかった。メニューはペインから読むだけでブリッジモードにも reply 有無にも非依存なので、ガードの外に出すのが正しい。

実機証跡（本番 2026-05-28, thread `1509023137600114830`/work23）: `run_claude exit (20:31:27)` 後もメニュー固着、`menu detected` も `Recovered ... post-turn` もログ無し。bot は #179/#219 入りで稼働中（18:01 起動）にもかかわらず再現 → `skills_enabled()` ガードが原因と確定。

Closes #222

## Acceptance Criteria (copied from the issue)

- [x] jsonl モード（`skills_enabled()==False`）で post-turn メニューが `bridge_pane_ask` で回収される（RED→GREEN）。→ `test_open_menu_bridged_in_jsonl_mode`
- [x] `was_replied_since==True`（discord-reply 呼び出し済み）でもメニューが回収される。→ `test_open_menu_bridged_even_after_reply`
- [x] skill モードの既存 #219 回収 / #67 通知が回帰しない（メニュー無し+未reply→通知／メニュー有り→bridge、jsonl では通知を出さない）。→ `TestRecoverMissedPaneAsk` + `TestNoReplyFallback` 全 green
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` すべて green。

## Staging Evidence

**決定論的ユニットテストで再現の主証拠とする**（#179 と同じ理由で、現 staging 構成では opus 長考エッジのライブ webhook 再現が困難）。本バグはタイミングではなく**ガード条件の欠陥**なので、ユニットテストが本質を直接・決定論的に捕捉する:

```
RED (修正前):
  FAILED TestRecoverMissedPaneAsk::test_open_menu_bridged_in_jsonl_mode
    bridge.assert_awaited_once → Awaited 0 times（jsonl で回収がスキップ）
  FAILED TestRecoverMissedPaneAsk::test_open_menu_bridged_even_after_reply
    Awaited 0 times（reply 済みで回収がスキップ）

GREEN (修正後):
  TestRecoverMissedPaneAsk 3件 + TestNoReplyFallback 4件 = 7 passed
  full suite: 1242 passed, 9 skipped
```

実機での最終確認は **本番 redeploy 後**に「ターン後メニュー → Discord にボタンが出る」を観測して行う（マージ後の deploy 手順に含める）。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes （1242 passed, 9 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written) — ユニットがガード欠陥を決定論的に捕捉、実機は redeploy 後に確認と明記
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)
