### PR TITLE
feat: !clord text/mention twin for /clord (webhook-invokable)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -340,25 +340,34 @@ class ClaudeChatCog(commands.Cog):
         ):
             await self._handle_thread_reply(message)
 
-    @app_commands.command(name="clord", description="Start a new Claude Code session")
-    @app_commands.describe(prompt="Message to send to Claude Code")
-    async def start_session(self, interaction: discord.Interaction, prompt: str) -> None:
-        """Start a new Claude Code session or continue in an existing thread."""
+    async def _clord_impl(
+        self,
+        *,
+        channel: object,
+        channel_id_fallback: int | None,
+        user: discord.Member | discord.User,
+        prompt: str,
+        respond: _Responder,
+        ack: _Responder,
+    ) -> None:
+        """Shared core for /clord and !clord (#209 follow-up).
+
+        In a thread → continue the session; in a channel → create a new thread
+        via ``spawn_session``. ``ack`` defers (slash) or is a no-op (text); after
+        it, all replies go through ``respond``'s post-ack path.
+        """
         # Authorization check
-        if not self._is_allowed(interaction.user):
-            await interaction.response.send_message(
-                "You are not authorized to use this command.", ephemeral=True
-            )
+        if not self._is_allowed(user):
+            await respond("You are not authorized to use this command.", ephemeral=True)
             return
 
         # Unbound channel check: verify /clord-init or /clord-thread-init binding
-        channel = interaction.channel
         if isinstance(channel, discord.Thread):
             parent_channel_id = channel.parent_id or channel.id
             sdm = await self._resolve_session_dir_manager(parent_channel_id, thread_id=channel.id)
             tmux = await self._resolve_tmux_manager(parent_channel_id)
             if sdm is None and tmux is None:
-                await interaction.response.send_message(
+                await respond(
                     "⚠️ このスレッドにはリポジトリが紐づけられていません。\n"
                     "先に `/clord-thread-init repo:<URL>` または"
                     " `/clord-init repo:<URL>` で設定してください。",
@@ -366,18 +375,22 @@ class ClaudeChatCog(commands.Cog):
                 )
                 return
         else:
-            channel_id = channel.id if channel else interaction.channel_id
+            channel_id = (
+                channel.id
+                if isinstance(channel, discord.abc.GuildChannel)
+                else (channel_id_fallback)
+            )
             sdm = await self._resolve_session_dir_manager(channel_id)
             tmux = await self._resolve_tmux_manager(channel_id)
             if sdm is None and tmux is None:
-                await interaction.response.send_message(
+                await respond(
                     "⚠️ このチャンネルにはリポジトリが紐づけられていません。\n"
                     "先に `/clord-init repo:<URL> branch:<branch>` で設定してください。",
                     ephemeral=True,
                 )
                 return
 
-        await interaction.response.defer()
+        await ack()
 
         if isinstance(channel, discord.Thread):
             # Continue in existing thread
@@ -385,16 +398,65 @@ class ClaudeChatCog(commands.Cog):
             session_id = (record.session_id or None) if record else None
             seed_message = await channel.send(prompt)
             await self._run_claude(seed_message, channel, prompt=prompt, session_id=session_id)
-            await interaction.followup.send("Session completed.", silent=True)
+            await respond("Session completed.", silent=True)
         else:
             # Create a new thread via spawn_session (text channels only)
             if not isinstance(channel, discord.TextChannel):
-                await interaction.followup.send(
-                    "This command must be used in a text channel.", ephemeral=True
-                )
+                await respond("This command must be used in a text channel.", ephemeral=True)
                 return
             thread = await self.spawn_session(channel, prompt)
-            await interaction.followup.send(f"Session started → {thread.mention}")
+            await respond(f"Session started → {thread.mention}")
+
+    @app_commands.command(name="clord", description="Start a new Claude Code session")
+    @app_commands.describe(prompt="Message to send to Claude Code")
+    async def start_session(self, interaction: discord.Interaction, prompt: str) -> None:
+        """Start a new Claude Code session or continue in an existing thread."""
+        state = {"acked": False}
+
+        async def ack(*_args: object, **_kwargs: object) -> None:
+            state["acked"] = True
+            await interaction.response.defer()
+
+        async def respond(
+            content: str | None = None, *, ephemeral: bool = False, silent: bool = False
+        ) -> None:
+            if state["acked"]:
+                await interaction.followup.send(content or "", ephemeral=ephemeral, silent=silent)
+            else:
+                await interaction.response.send_message(content, ephemeral=ephemeral)
+
+        await self._clord_impl(
+            channel=interaction.channel,
+            channel_id_fallback=interaction.channel_id,
+            user=interaction.user,
+            prompt=prompt,
+            respond=respond,
+            ack=ack,
+        )
+
+    @commands.command(name="clord")
+    async def clord_text(self, ctx: commands.Context, *, prompt: str | None = None) -> None:
+        """Text/mention twin of /clord — invokable from webhooks for E2E (#209)."""
+        if not prompt:
+            await ctx.send("Usage: `!clord <prompt>`")
+            return
+
+        async def ack(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def respond(
+            content: str | None = None, *, ephemeral: bool = False, silent: bool = False
+        ) -> None:
+            await ctx.send(content or "", silent=silent)
+
+        await self._clord_impl(
+            channel=ctx.channel,
+            channel_id_fallback=ctx.channel.id if ctx.channel else None,
+            user=ctx.author,
+            prompt=prompt,
+            respond=respond,
+            ack=ack,
+        )
 
     async def _stop_impl(self, channel: object, respond: _Responder) -> None:
         """Shared core for /stop and !stop (#209).

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -94,6 +94,7 @@ Only available when the bot operator has enabled the upgrade slash command.
 
 | Command | Description | Example | Slash equivalent |
 |---------|-------------|---------|------------------|
+| `!clord <prompt>` | Start a new session (channel) / continue (thread) | `!clord build X` | `/clord` |
 | `!attach <window>` | Attach this thread to a tmux window | `!attach work13` | `/clord-attach` |
 | `!skill <name> [args]` | Run a Claude Code skill | `!skill recall` | `/skill` |
 | `!stop` | Stop the active session (preserved for resume) | `!stop` | `/stop` |

--- a/tests/e2e/test_text_command_twins.py
+++ b/tests/e2e/test_text_command_twins.py
@@ -5,7 +5,7 @@ E2E harness can only reach them through their ``!``-prefix / mention twins.
 These tests verify each twin fires and the bot replies when triggered the way
 a slash command never could be.
 
-Covered: !skill, !stop, !clear, and a mention-prefixed command.
+Covered: !clord, !skill, !stop, !clear, and a mention-prefixed command.
 """
 
 from __future__ import annotations
@@ -13,6 +13,27 @@ from __future__ import annotations
 import pytest
 
 from .conftest import DiscordE2EClient
+
+
+@pytest.mark.e2e
+def test_clord_twin_via_webhook(
+    discord_client: DiscordE2EClient,
+    bot_id: str,
+) -> None:
+    """!clord in a channel creates a thread + starts a session (like /clord)."""
+    wh_msg = discord_client.webhook_post("!clord [E2E] say hello and stop")
+
+    reply = discord_client.wait_for_bot_reply(
+        discord_client.channel_id,
+        after_message_id=wh_msg["id"],
+        bot_id=bot_id,
+        timeout=30.0,
+        poll=2.0,
+    )
+    assert reply is not None, "Bot did not reply to !clord within 30s"
+    # New-thread mode posts "Session started → <#thread>" (or an unbound-channel
+    # / not-authorized notice). Any non-empty reply means the command fired.
+    assert reply["content"], "Bot reply was empty"
 
 
 @pytest.mark.e2e

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1157,6 +1157,74 @@ class TestStartSessionCommand:
         cog.spawn_session.assert_called_once_with(channel, "hello")
 
 
+class TestClordTextCommand:
+    """!clord mirrors /clord but is invokable from webhooks (E2E)."""
+
+    @pytest.mark.asyncio
+    async def test_missing_prompt_shows_usage(self) -> None:
+        cog = _make_cog()
+        ctx = _make_channel_ctx()
+        await cog.clord_text.callback(cog, ctx, prompt=None)
+        ctx.send.assert_called_once()
+        assert "Usage" in ctx.send.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_rejected(self) -> None:
+        bot = MagicMock()
+        bot.channel_id = 999
+        cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock(), allowed_user_ids={111})
+        ctx = _make_channel_ctx()  # author.id = 1, not in {111}
+        await cog.clord_text.callback(cog, ctx, prompt="hello")
+        ctx.send.assert_called_once()
+        assert "not authorized" in ctx.send.call_args.args[0].lower()
+
+    @pytest.mark.asyncio
+    async def test_channel_spawns_session(self) -> None:
+        cc = _make_channel_cog_mock(tmux_manager=MagicMock())
+        cog = _make_cog(channel_cog=cc)
+        ctx = _make_channel_ctx()
+        ctx.channel.id = 999
+        thread = MagicMock(spec=discord.Thread)
+        thread.mention = "<#12345>"
+        cog.spawn_session = AsyncMock(return_value=thread)
+
+        await cog.clord_text.callback(cog, ctx, prompt="build a feature")
+
+        cog.spawn_session.assert_called_once_with(ctx.channel, "build a feature")
+        assert "<#12345>" in ctx.send.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_thread_continues_session(self) -> None:
+        cc = _make_channel_cog_mock(session_dir_manager=MagicMock())
+        cog = _make_cog(channel_cog=cc)
+        ctx = _make_thread_ctx(thread_id=555, parent_id=999)
+        ctx.channel.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
+        record = MagicMock()
+        record.session_id = "sess-abc"
+        cog.repo.get = AsyncMock(return_value=record)
+        cog._run_claude = AsyncMock()
+
+        await cog.clord_text.callback(cog, ctx, prompt="continue this")
+
+        cog._run_claude.assert_called_once()
+        _, kwargs = cog._run_claude.call_args
+        assert kwargs["session_id"] == "sess-abc"
+        assert kwargs["prompt"] == "continue this"
+
+    @pytest.mark.asyncio
+    async def test_unbound_channel_rejected(self) -> None:
+        cc = _make_channel_cog_mock()  # both managers None
+        cog = _make_cog(channel_cog=cc)
+        ctx = _make_channel_ctx()
+        ctx.channel.id = 4242
+        cog.spawn_session = AsyncMock()
+
+        await cog.clord_text.callback(cog, ctx, prompt="hello")
+
+        cog.spawn_session.assert_not_called()
+        assert "clord-init" in ctx.send.call_args.args[0]
+
+
 class TestAttachWindowCommand:
     """/clord-attach slash command tests."""
 


### PR DESCRIPTION
## What does this PR do?

Adds a `!clord` text / mention twin for `/clord` (start a new session / continue in a thread), so the new-session flow is invokable from a webhook (E2E / manual QA). Follow-up to #209.

`start_session`'s body is extracted into a shared `_clord_impl` that both the slash command and `!clord` call via a `respond`/`ack` indirection — no copy-paste.

## Why?

Slash commands can't be triggered by bots/webhooks. `/clord` (the primary way to start a session) was deferred from #209 because of its thread-creation semantics; this completes it.

Closes #224

## Acceptance Criteria (copied from the issue)

- [x] `!clord <prompt>` in a channel creates a new thread + starts a session (like `/clord`)
- [x] `!clord <prompt>` in a thread continues the session (carries `session_id`)
- [x] `@bot clord <prompt>` mention also fires
- [x] bare `!clord` returns usage
- [x] Same authorization (`_is_allowed`) and unbound-channel error as `/clord`
- [x] Unit tests (RED→GREEN, Discord mocked); existing `/clord` slash tests stay green
- [x] Staging: `!clord` via webhook created a thread + started a session
- [x] `docs/COMMANDS.md` updated + E2E test added

## Staging Evidence

Borrowed the staging bot (`/home/yousan/c-lord-parallel-3`, `jsonl` mode), restored afterward. Prod untouched.

**RED (before — no twin):**
```
discord.ext.commands.errors.CommandNotFound: Command "clord" is not found
```

**GREEN (after — branch deployed):**
```
# !clord [E2E] reply ok then stop   (channel → new thread)
[INFO] c_lord.session_dir: Created session dir for thread 1509535538519080961
[INFO] c_lord.tmux: Created tmux window: work3 (thread=1509535538519080961, ...)
# channel: [C-lord-3] 'Session started → <#1509535538519080961>'
#          [C-lord-3] '[E2E] reply ok then stop' thread=1509535538519080961

# mention: <@1503195981142032405> clord [E2E mention] hi
[C-lord-3] 'Session started → <#1509535648472629288>'
```

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: tests failed before (RED: `AttributeError: 'ClaudeChatCog' object has no attribute 'clord_text'`) and pass after (GREEN: 5 new tests pass)
- [x] `uv run pytest tests/` passes (1247 passed, 9 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #224` — 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)
