### PR TITLE
feat: text/mention twins for read-only session commands (webhook-invokable)

### DIFF
--- a/c_lord/cogs/session_manage.py
+++ b/c_lord/cogs/session_manage.py
@@ -8,6 +8,7 @@ Provides slash commands for viewing and managing Claude Code sessions:
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 import discord
@@ -24,6 +25,11 @@ if TYPE_CHECKING:
     from ..tmux import TmuxSessionManager
 
 logger = logging.getLogger(__name__)
+
+# Lets each command's core run from either a slash interaction or a !text twin
+# without duplicating the body (#209 follow-up).
+_Responder = Callable[..., Awaitable[None]]
+_Acknowledger = Callable[..., Awaitable[None]]
 
 _ORIGIN_ICON = {
     "discord": "\U0001f4ac",  # 💬
@@ -94,6 +100,53 @@ class SessionManageCog(commands.Cog):
             return runner.model  # type: ignore[return-value]
         return "sonnet"
 
+    # ── Slash/text I/O plumbing (#209 follow-up) ───────────────────────────────
+    # Each read-only command's core takes a (respond, ack) pair so the same body
+    # serves both the slash command and its !text twin.
+
+    def _slash_io(self, interaction: discord.Interaction) -> tuple[_Responder, _Acknowledger]:
+        state = {"acked": False}
+
+        async def ack(*, ephemeral: bool = False) -> None:
+            state["acked"] = True
+            await interaction.response.defer(ephemeral=ephemeral)
+
+        async def respond(
+            content: str | None = None,
+            *,
+            embed: discord.Embed | None = None,
+            ephemeral: bool = False,
+        ) -> None:
+            if state["acked"]:
+                if embed is not None:
+                    await interaction.followup.send(embed=embed, ephemeral=ephemeral)
+                else:
+                    await interaction.followup.send(content or "", ephemeral=ephemeral)
+            elif embed is not None:
+                await interaction.response.send_message(embed=embed, ephemeral=ephemeral)
+            else:
+                await interaction.response.send_message(content, ephemeral=ephemeral)
+
+        return respond, ack
+
+    def _ctx_io(self, ctx: commands.Context) -> tuple[_Responder, _Acknowledger]:
+        async def ack(*, ephemeral: bool = False) -> None:
+            return None
+
+        async def respond(
+            content: str | None = None,
+            *,
+            embed: discord.Embed | None = None,
+            ephemeral: bool = False,
+        ) -> None:
+            # Text channels can't be ephemeral — ``ephemeral`` is ignored.
+            if embed is not None:
+                await ctx.send(embed=embed)
+            else:
+                await ctx.send(content or "")
+
+        return respond, ack
+
     # ── Model commands ────────────────────────────────────────────────────────
 
     model_group = app_commands.Group(
@@ -101,9 +154,8 @@ class SessionManageCog(commands.Cog):
         description="View and change the Claude model used for new sessions",
     )
 
-    @model_group.command(name="show", description="Show the current Claude model")
-    async def model_show(self, interaction: discord.Interaction) -> None:
-        """Display the current global model and, if in a thread, the per-session model."""
+    async def _model_show_impl(self, *, channel: object, respond: _Responder) -> None:
+        """Shared core for /model show and !model-show (#209 follow-up)."""
         effective_model = await self._get_effective_model()
 
         embed = discord.Embed(
@@ -126,8 +178,8 @@ class SessionManageCog(commands.Cog):
             )
 
         # Per-thread session model (if inside a thread)
-        if isinstance(interaction.channel, discord.Thread):
-            record = await self.repo.get(interaction.channel.id)
+        if isinstance(channel, discord.Thread):
+            record = await self.repo.get(channel.id)
             if record and record.model:
                 embed.add_field(
                     name="This thread's last session",
@@ -136,7 +188,19 @@ class SessionManageCog(commands.Cog):
                 )
 
         embed.set_footer(text=f"Effective model for new sessions: {effective_model}")
-        await interaction.response.send_message(embed=embed)
+        await respond(embed=embed)
+
+    @model_group.command(name="show", description="Show the current Claude model")
+    async def model_show(self, interaction: discord.Interaction) -> None:
+        """Display the current global model and, if in a thread, the per-session model."""
+        respond, _ = self._slash_io(interaction)
+        await self._model_show_impl(channel=interaction.channel, respond=respond)
+
+    @commands.command(name="model-show")
+    async def model_show_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /model show — webhook-invokable for E2E (#209)."""
+        respond, _ = self._ctx_io(ctx)
+        await self._model_show_impl(channel=ctx.channel, respond=respond)
 
     @model_group.command(name="set", description="Change the global Claude model for new sessions")
     @app_commands.describe(model="Model to use for all new Claude sessions")
@@ -166,22 +230,18 @@ class SessionManageCog(commands.Cog):
         )
         await interaction.response.send_message(embed=embed)
 
-    @app_commands.command(
-        name="resume-info",
-        description="Show the CLI command to resume this thread's session",
-    )
-    async def resume_info(self, interaction: discord.Interaction) -> None:
-        """Show the claude --resume command for the current thread."""
-        if not isinstance(interaction.channel, discord.Thread):
-            await interaction.response.send_message(
+    async def _resume_info_impl(self, *, channel: object, respond: _Responder) -> None:
+        """Shared core for /resume-info and !resume-info (#209 follow-up)."""
+        if not isinstance(channel, discord.Thread):
+            await respond(
                 "This command can only be used in a Claude chat thread.",
                 ephemeral=True,
             )
             return
 
-        record = await self.repo.get(interaction.channel.id)
+        record = await self.repo.get(channel.id)
         if not record:
-            await interaction.response.send_message(
+            await respond(
                 "No session found for this thread.",
                 ephemeral=True,
             )
@@ -189,8 +249,8 @@ class SessionManageCog(commands.Cog):
 
         if _is_tmux_session(record.session_id):
             # tmux session — show tmux attach instructions
-            thread_id = interaction.channel.id
-            tmux_mgr = await self._resolve_tmux_manager(interaction.channel.parent_id or thread_id)
+            thread_id = channel.id
+            tmux_mgr = await self._resolve_tmux_manager(channel.parent_id or thread_id)
             window_name: str | None = None
             session_name: str | None = None
             if tmux_mgr is not None:
@@ -229,17 +289,25 @@ class SessionManageCog(commands.Cog):
         if record.model:
             embed.add_field(name="Model", value=record.model, inline=True)
 
-        await interaction.response.send_message(embed=embed)
+        await respond(embed=embed)
 
     @app_commands.command(
-        name="sessions",
-        description="List all known Claude Code sessions",
+        name="resume-info",
+        description="Show the CLI command to resume this thread's session",
     )
-    async def sessions_list(
-        self,
-        interaction: discord.Interaction,
-    ) -> None:
-        """List all sessions with origin, summary, and last activity."""
+    async def resume_info(self, interaction: discord.Interaction) -> None:
+        """Show the claude --resume command for the current thread."""
+        respond, _ = self._slash_io(interaction)
+        await self._resume_info_impl(channel=interaction.channel, respond=respond)
+
+    @commands.command(name="resume-info")
+    async def resume_info_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /resume-info — webhook-invokable for E2E (#209)."""
+        respond, _ = self._ctx_io(ctx)
+        await self._resume_info_impl(channel=ctx.channel, respond=respond)
+
+    async def _sessions_list_impl(self, *, respond: _Responder) -> None:
+        """Shared core for /sessions and !sessions (#209 follow-up)."""
         records = await self.repo.list_all(limit=25)
 
         if not records:
@@ -248,7 +316,7 @@ class SessionManageCog(commands.Cog):
                 description="No sessions found.",
                 color=COLOR_INFO,
             )
-            await interaction.response.send_message(embed=embed)
+            await respond(embed=embed)
             return
 
         embed = discord.Embed(
@@ -285,7 +353,22 @@ class SessionManageCog(commands.Cog):
 
             embed.add_field(name=name, value=value, inline=False)
 
-        await interaction.response.send_message(embed=embed)
+        await respond(embed=embed)
+
+    @app_commands.command(
+        name="sessions",
+        description="List all known Claude Code sessions",
+    )
+    async def sessions_list(self, interaction: discord.Interaction) -> None:
+        """List all sessions with origin, summary, and last activity."""
+        respond, _ = self._slash_io(interaction)
+        await self._sessions_list_impl(respond=respond)
+
+    @commands.command(name="sessions")
+    async def sessions_list_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /sessions — webhook-invokable for E2E (#209)."""
+        respond, _ = self._ctx_io(ctx)
+        await self._sessions_list_impl(respond=respond)
 
     # ------------------------------------------------------------------
     # Session directory commands
@@ -337,21 +420,17 @@ class SessionManageCog(commands.Cog):
             return await channel_cog._repo.list_all()
         return []
 
-    @app_commands.command(
-        name="session-dirs",
-        description="List all active Claude Code session directories",
-    )
-    async def session_dirs_list(self, interaction: discord.Interaction) -> None:
-        """Show all session directories and their status (across all bindings)."""
+    async def _session_dirs_list_impl(self, *, respond: _Responder, ack: _Acknowledger) -> None:
+        """Shared core for /session-dirs and !session-dirs (#209 follow-up)."""
         bindings = await self._get_all_bindings()
         if not bindings:
-            await interaction.response.send_message(
+            await respond(
                 "❌ No channel-repo bindings configured. Use `/clord-init` first.",
                 ephemeral=True,
             )
             return
 
-        await interaction.response.defer(ephemeral=True)
+        await ack(ephemeral=True)
 
         import asyncio
 
@@ -363,7 +442,7 @@ class SessionManageCog(commands.Cog):
                 all_dirs.extend(dirs)
 
         if not all_dirs:
-            await interaction.followup.send(
+            await respond(
                 embed=discord.Embed(
                     title="📁 Session Directories",
                     description="No session directories found.",
@@ -382,7 +461,22 @@ class SessionManageCog(commands.Cog):
             value = f"Path: `{d.path}`\nCommit: `{d.commit or 'unknown'}`\nStatus: {status}"
             embed.add_field(name=name, value=value, inline=False)
 
-        await interaction.followup.send(embed=embed)
+        await respond(embed=embed)
+
+    @app_commands.command(
+        name="session-dirs",
+        description="List all active Claude Code session directories",
+    )
+    async def session_dirs_list(self, interaction: discord.Interaction) -> None:
+        """Show all session directories and their status (across all bindings)."""
+        respond, ack = self._slash_io(interaction)
+        await self._session_dirs_list_impl(respond=respond, ack=ack)
+
+    @commands.command(name="session-dirs")
+    async def session_dirs_list_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /session-dirs — webhook-invokable for E2E (#209)."""
+        respond, ack = self._ctx_io(ctx)
+        await self._session_dirs_list_impl(respond=respond, ack=ack)
 
     @app_commands.command(
         name="session-cleanup",
@@ -513,21 +607,17 @@ class SessionManageCog(commands.Cog):
 
         await interaction.followup.send(embed=embed)
 
-    @app_commands.command(
-        name="tmux-list",
-        description="List all active tmux windows for Claude Code",
-    )
-    async def tmux_list(self, interaction: discord.Interaction) -> None:
-        """Show all windows across all channel tmux sessions."""
+    async def _tmux_list_impl(self, *, respond: _Responder, ack: _Acknowledger) -> None:
+        """Shared core for /tmux-list and !tmux-list (#209 follow-up)."""
         bindings = await self._get_all_bindings()
         if not bindings:
-            await interaction.response.send_message(
+            await respond(
                 "❌ No channel-repo bindings configured. Use `/clord-init` first.",
                 ephemeral=True,
             )
             return
 
-        await interaction.response.defer(ephemeral=True)
+        await ack(ephemeral=True)
 
         import asyncio
 
@@ -539,7 +629,7 @@ class SessionManageCog(commands.Cog):
                 all_windows.extend(windows)
 
         if not all_windows:
-            await interaction.followup.send(
+            await respond(
                 embed=discord.Embed(
                     title="🖥️ Tmux Windows",
                     description="No tmux windows found.",
@@ -561,7 +651,22 @@ class SessionManageCog(commands.Cog):
                 inline=False,
             )
 
-        await interaction.followup.send(embed=embed)
+        await respond(embed=embed)
+
+    @app_commands.command(
+        name="tmux-list",
+        description="List all active tmux windows for Claude Code",
+    )
+    async def tmux_list(self, interaction: discord.Interaction) -> None:
+        """Show all windows across all channel tmux sessions."""
+        respond, ack = self._slash_io(interaction)
+        await self._tmux_list_impl(respond=respond, ack=ack)
+
+    @commands.command(name="tmux-list")
+    async def tmux_list_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /tmux-list — webhook-invokable for E2E (#209)."""
+        respond, ack = self._ctx_io(ctx)
+        await self._tmux_list_impl(respond=respond, ack=ack)
 
     @app_commands.command(
         name="workspace-delete",

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -99,6 +99,11 @@ Only available when the bot operator has enabled the upgrade slash command.
 | `!skill <name> [args]` | Run a Claude Code skill | `!skill recall` | `/skill` |
 | `!stop` | Stop the active session (preserved for resume) | `!stop` | `/stop` |
 | `!clear` | Reset the session — next message starts fresh | `!clear` | `/clear` |
+| `!model-show` | Show the current Claude model | `!model-show` | `/model show` |
+| `!resume-info` | Show the CLI command to resume this thread | `!resume-info` | `/resume-info` |
+| `!sessions` | List all known sessions | `!sessions` | `/sessions` |
+| `!session-dirs` | List active session directories | `!session-dirs` | `/session-dirs` |
+| `!tmux-list` | List active tmux windows | `!tmux-list` | `/tmux-list` |
 
 Each text command is **functionally identical to its slash equivalent** — it
 calls the same underlying handler. Text commands accept either prefix:

--- a/tests/e2e/test_text_command_twins.py
+++ b/tests/e2e/test_text_command_twins.py
@@ -5,7 +5,9 @@ E2E harness can only reach them through their ``!``-prefix / mention twins.
 These tests verify each twin fires and the bot replies when triggered the way
 a slash command never could be.
 
-Covered: !clord, !skill, !stop, !clear, and a mention-prefixed command.
+Covered: !clord, !skill, !stop, !clear, the read-only info twins
+(!model-show, !sessions, !session-dirs, !tmux-list, !resume-info), and a
+mention-prefixed command.
 """
 
 from __future__ import annotations
@@ -103,6 +105,36 @@ def test_clear_twin_via_webhook(
     )
     assert reply is not None, "Bot did not reply to !clear within 30s"
     assert reply["content"], "Bot reply was empty"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "command",
+    ["!model-show", "!sessions", "!session-dirs", "!tmux-list", "!resume-info"],
+)
+def test_readonly_info_twins_via_webhook(
+    discord_client: DiscordE2EClient,
+    bot_id: str,
+    command: str,
+) -> None:
+    """Each read-only info twin replies when fired from a webhook (like its slash)."""
+    seed = discord_client.create_seed_message(f"[E2E] {command} test")
+    thread = discord_client.create_thread(seed["id"], f"E2E: {command}")
+    thread_id = thread["id"]
+
+    wh_msg = discord_client.webhook_post(command, thread_id=thread_id)
+
+    reply = discord_client.wait_for_bot_reply(
+        thread_id,
+        after_message_id=wh_msg["id"],
+        bot_id=bot_id,
+        timeout=30.0,
+        poll=2.0,
+    )
+    assert reply is not None, f"Bot did not reply to {command} within 30s"
+    # A reply (embed or text) means the command reached the cog. Embeds have
+    # empty content, so accept either content or an embed.
+    assert reply["content"] or reply.get("embeds"), f"Bot reply to {command} was empty"
 
 
 @pytest.mark.e2e

--- a/tests/test_session_manage.py
+++ b/tests/test_session_manage.py
@@ -221,6 +221,73 @@ class TestResumeInfoTmux:
         assert "claude --resume def-456" in embed.description
 
 
+def _make_ctx(channel: MagicMock | None = None) -> MagicMock:
+    """Return a mocked commands.Context for the !text twins."""
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    if channel is not None:
+        ctx.channel = channel
+    else:
+        ctx.channel = MagicMock(spec=discord.TextChannel)
+    return ctx
+
+
+def _make_thread_ctx(thread_id: int = 12345) -> MagicMock:
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    return _make_ctx(channel=thread)
+
+
+class TestReadonlyTextTwins:
+    """!text twins of the read-only/info slash commands (E2E-invokable, #209)."""
+
+    async def test_model_show_text(self):
+        cog = _make_cog()
+        ctx = _make_ctx()
+        await cog.model_show_text.callback(cog, ctx)
+        ctx.send.assert_called_once()
+        assert ctx.send.call_args.kwargs.get("embed") is not None
+
+    async def test_resume_info_text_outside_thread(self):
+        cog = _make_cog()
+        ctx = _make_ctx()  # not a thread
+        await cog.resume_info_text.callback(cog, ctx)
+        ctx.send.assert_called_once()
+        assert "thread" in ctx.send.call_args.args[0].lower()
+
+    async def test_resume_info_text_shows_command(self):
+        cog = _make_cog()
+        cog.repo.get = AsyncMock(return_value=_make_record(thread_id=555, session_id="def-456"))
+        ctx = _make_thread_ctx(thread_id=555)
+        await cog.resume_info_text.callback(cog, ctx)
+        embed = ctx.send.call_args.kwargs.get("embed")
+        assert embed is not None
+        assert "def-456" in embed.description
+
+    async def test_sessions_text_empty(self):
+        cog = _make_cog()
+        cog.repo.list_all = AsyncMock(return_value=[])
+        ctx = _make_ctx()
+        await cog.sessions_list_text.callback(cog, ctx)
+        assert ctx.send.call_args.kwargs.get("embed") is not None
+
+    async def test_session_dirs_text_no_bindings(self):
+        cog = _make_cog()  # bot.get_cog returns a non-ChannelRepoCog mock → no bindings
+        ctx = _make_ctx()
+        await cog.session_dirs_list_text.callback(cog, ctx)
+        ctx.send.assert_called_once()
+        assert "clord-init" in ctx.send.call_args.args[0]
+
+    async def test_tmux_list_text_no_bindings(self):
+        cog = _make_cog()
+        ctx = _make_ctx()
+        await cog.tmux_list_text.callback(cog, ctx)
+        ctx.send.assert_called_once()
+        assert "clord-init" in ctx.send.call_args.args[0]
+
+
 class TestHelperFunctions:
     """Tests for _is_tmux_session and _format_session_short."""
 


### PR DESCRIPTION
## What does this PR do?

Adds text/mention twins for the read-only/info slash commands so they're invokable from a webhook (E2E / manual QA). Follow-up to #209/#224.

- `!model-show` ↔ `/model show`
- `!resume-info` ↔ `/resume-info`
- `!sessions` ↔ `/sessions`
- `!session-dirs` ↔ `/session-dirs`
- `!tmux-list` ↔ `/tmux-list`

`SessionManageCog` gains shared `_slash_io`/`_ctx_io` plumbing; each command body is extracted into a `_*_impl(respond, ack)` core called by both the slash command and its `!text` twin — no copy-paste.

## Why?

Slash commands can't be triggered by bots/webhooks, so the info/query commands couldn't be exercised by E2E or `E2E_TEST_WEBHOOK_URL` manual QA.

Closes #226

## Acceptance Criteria (copied from the issue)

- [x] `!model-show` / `!resume-info` / `!sessions` / `!session-dirs` / `!tmux-list` return the same output as their slash versions
- [x] `@bot model-show` etc. mention also fires (via `when_mentioned_or`, established in #209)
- [x] Existing slash tests (resume-info / sessions etc.) stay green
- [x] Unit tests for each twin (Discord mocked)
- [x] Staging: each twin fired via webhook (RED: old code → CommandNotFound)
- [x] `docs/COMMANDS.md` updated + E2E tests added

## Staging Evidence

Borrowed staging (`/home/yousan/c-lord-parallel-3`, jsonl), restored to its prior branch afterward. Prod untouched.

**RED (before):**
```
discord.ext.commands.errors.CommandNotFound: Command "sessions" is not found
```

**GREEN (after — branch deployed; bot replies with the same embeds as the slash versions):**
```
!model-show    → embed '🤖 Current Claude Model'
!sessions      → embed '📋 Sessions (6)'
!session-dirs  → embed '📁 Session Directories (5)'
!tmux-list     → embed '🖥️ Tmux Windows (6)'
!resume-info   → embed '🔗 Resume via tmux'   (in a thread)
```

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: new twin tests added (6 pass); behavioural RED reproduced on staging (CommandNotFound)
- [x] `uv run pytest tests/` passes (1253 passed, 9 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #226` — 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)
