### PR TITLE
feat: text/mention twins for config commands (clord-init / model-set)

### DIFF
--- a/c_lord/cogs/channel_repo.py
+++ b/c_lord/cogs/channel_repo.py
@@ -16,6 +16,7 @@ Usage::
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -32,6 +33,9 @@ from ..session_dir import SessionDirManager
 from ..tmux import TmuxSessionManager
 
 logger = logging.getLogger(__name__)
+
+# Posts a reply for either a slash interaction or a !text twin (#209 follow-up).
+_Responder = Callable[..., Awaitable[None]]
 
 
 class ChannelRepoCog(commands.Cog):
@@ -158,9 +162,78 @@ class ChannelRepoCog(commands.Cog):
             return False  # DM — no role info
         return self._allowed_user_ids is None
 
+    # Lets clord-init / clord-thread-init run from a slash interaction or a
+    # !text twin without duplicating the body (#209 follow-up).
+    @staticmethod
+    def _slash_respond(interaction: discord.Interaction) -> _Responder:
+        async def respond(content: str | None = None, *, ephemeral: bool = False) -> None:
+            await interaction.response.send_message(content, ephemeral=ephemeral)
+
+        return respond
+
+    @staticmethod
+    def _ctx_respond(ctx: commands.Context) -> _Responder:
+        async def respond(content: str | None = None, *, ephemeral: bool = False) -> None:
+            await ctx.send(content or "")
+
+        return respond
+
     # ------------------------------------------------------------------
     # Slash command
     # ------------------------------------------------------------------
+
+    async def _clord_init_impl(
+        self,
+        *,
+        channel_id: int | None,
+        user: discord.Member | discord.User,
+        repo: str | None,
+        remove: bool,
+        respond: _Responder,
+    ) -> None:
+        """Shared core for /clord-init and !clord-init (#209 follow-up)."""
+        if not self._is_allowed(user):
+            await respond("You are not authorized to use this command.", ephemeral=True)
+            return
+
+        assert channel_id is not None
+
+        # --- Remove binding ---
+        if remove:
+            deleted = await self._repo.delete(channel_id)
+            self.evict_cache(channel_id)
+            if deleted:
+                await respond(f"Removed repository binding for <#{channel_id}>.", ephemeral=True)
+            else:
+                await respond("No binding found for this channel.", ephemeral=True)
+            return
+
+        # --- Show bindings (no args) ---
+        if repo is None:
+            channel_bindings = await self._repo.list_all()
+            thread_bindings = (
+                await self._thread_repo.list_all() if self._thread_repo is not None else []
+            )
+            if not channel_bindings and not thread_bindings:
+                await respond("No channel-repo bindings configured.", ephemeral=True)
+                return
+
+            lines = []
+            for b in channel_bindings:
+                tmux_name = derive_session_name(b["source_repo"])
+                lines.append(f"<#{b['channel_id']}> → `{b['source_repo']}` (tmux: `{tmux_name}`)")
+            for b in thread_bindings:
+                ch_ref = f" (channel <#{b['channel_id']}>)" if b.get("channel_id") else ""
+                lines.append(f"  thread <#{b['thread_id']}>{ch_ref} → `{b['source_repo']}`")
+            await respond("\n".join(lines), ephemeral=True)
+            return
+
+        # --- Bind channel to repo ---
+        await self._repo.save(channel_id=channel_id, source_repo=repo)
+        self.evict_cache(channel_id)
+
+        tmux_display = derive_session_name(repo)
+        await respond(f"Bound <#{channel_id}> → `{repo}` (tmux: `{tmux_display}`)", ephemeral=True)
 
     @app_commands.command(
         name="clord-init",
@@ -178,59 +251,100 @@ class ChannelRepoCog(commands.Cog):
         remove: bool = False,
     ) -> None:
         """Bind / unbind / show channel-repo bindings."""
-        if not self._is_allowed(interaction.user):
-            await interaction.response.send_message(
-                "You are not authorized to use this command.", ephemeral=True
-            )
+        await self._clord_init_impl(
+            channel_id=interaction.channel_id,
+            user=interaction.user,
+            repo=repo,
+            remove=remove,
+            respond=self._slash_respond(interaction),
+        )
+
+    @commands.command(name="clord-init")
+    async def clord_init_text(self, ctx: commands.Context, arg: str | None = None) -> None:
+        """Text/mention twin of /clord-init — webhook-invokable for E2E (#209).
+
+        Usage: ``!clord-init`` (show) / ``!clord-init <repo-url>`` (bind) /
+        ``!clord-init remove`` (unbind this channel).
+        Gated by ``_is_allowed`` only (no Discord Manage-Server check, unlike the
+        slash command), so restrict the allowlist in production accordingly.
+        """
+        repo: str | None = None
+        remove = False
+        if arg == "remove":
+            remove = True
+        elif arg:
+            repo = arg
+        await self._clord_init_impl(
+            channel_id=ctx.channel.id,
+            user=ctx.author,
+            repo=repo,
+            remove=remove,
+            respond=self._ctx_respond(ctx),
+        )
+
+    async def _clord_thread_init_impl(
+        self,
+        *,
+        thread_id: int | None,
+        channel: object,
+        client: discord.Client,
+        user: discord.Member | discord.User,
+        repo: str | None,
+        remove: bool,
+        respond: _Responder,
+    ) -> None:
+        """Shared core for /clord-thread-init and !clord-thread-init (#209 follow-up)."""
+        if not self._is_allowed(user):
+            await respond("You are not authorized to use this command.", ephemeral=True)
             return
 
-        channel_id = interaction.channel_id
-        assert channel_id is not None
+        if self._thread_repo is None:
+            await respond("Thread-level bindings are not enabled on this bot.", ephemeral=True)
+            return
+
+        assert thread_id is not None
+        channel_id = channel.parent_id if isinstance(channel, discord.Thread) else thread_id
 
         # --- Remove binding ---
         if remove:
-            deleted = await self._repo.delete(channel_id)
-            self.evict_cache(channel_id)
+            deleted = await self._thread_repo.delete(thread_id)
+            self.evict_thread_cache(thread_id)
             if deleted:
-                await interaction.response.send_message(
-                    f"Removed repository binding for <#{channel_id}>.", ephemeral=True
+                await respond(
+                    f"Removed thread repository binding for <#{thread_id}>.", ephemeral=True
                 )
             else:
-                await interaction.response.send_message(
-                    "No binding found for this channel.", ephemeral=True
-                )
+                await respond("No thread binding found.", ephemeral=True)
             return
 
-        # --- Show bindings (no args) ---
+        # --- Show current thread binding (no args) ---
         if repo is None:
-            channel_bindings = await self._repo.list_all()
-            thread_bindings = (
-                await self._thread_repo.list_all() if self._thread_repo is not None else []
-            )
-            if not channel_bindings and not thread_bindings:
-                await interaction.response.send_message(
-                    "No channel-repo bindings configured.", ephemeral=True
+            binding = await self._thread_repo.get(thread_id)
+            if binding is None:
+                await respond("No thread-level binding for this thread.", ephemeral=True)
+            else:
+                await respond(f"Thread <#{thread_id}> → `{binding['source_repo']}`", ephemeral=True)
+            return
+
+        # --- Access check: verify bot can read the thread's parent channel ---
+        bot_channel = client.get_channel(channel_id)
+        if bot_channel is None:
+            try:
+                await client.fetch_channel(channel_id)
+            except discord.Forbidden:
+                await respond(
+                    f"⚠️ Bot がこのスレッドの親チャンネル (<#{channel_id}>) にアクセスできません。\n"
+                    "先に Bot をそのチャンネルに追加してください。",
+                    ephemeral=True,
                 )
                 return
+            except discord.HTTPException:
+                pass  # 他のエラーは無視してbindを続行
 
-            lines = []
-            for b in channel_bindings:
-                tmux_name = derive_session_name(b["source_repo"])
-                lines.append(f"<#{b['channel_id']}> → `{b['source_repo']}` (tmux: `{tmux_name}`)")
-            for b in thread_bindings:
-                ch_ref = f" (channel <#{b['channel_id']}>)" if b.get("channel_id") else ""
-                lines.append(f"  thread <#{b['thread_id']}>{ch_ref} → `{b['source_repo']}`")
-            await interaction.response.send_message("\n".join(lines), ephemeral=True)
-            return
-
-        # --- Bind channel to repo ---
-        await self._repo.save(channel_id=channel_id, source_repo=repo)
-        self.evict_cache(channel_id)
-
-        tmux_display = derive_session_name(repo)
-        await interaction.response.send_message(
-            f"Bound <#{channel_id}> → `{repo}` (tmux: `{tmux_display}`)", ephemeral=True
-        )
+        # --- Bind thread to repo ---
+        await self._thread_repo.save(thread_id=thread_id, source_repo=repo, channel_id=channel_id)
+        self.evict_thread_cache(thread_id)
+        await respond(f"Bound thread <#{thread_id}> → `{repo}`", ephemeral=True)
 
     @app_commands.command(
         name="clord-thread-init",
@@ -248,69 +362,35 @@ class ChannelRepoCog(commands.Cog):
         remove: bool = False,
     ) -> None:
         """Bind / unbind a thread-level repo override."""
-        if not self._is_allowed(interaction.user):
-            await interaction.response.send_message(
-                "You are not authorized to use this command.", ephemeral=True
-            )
-            return
-
-        if self._thread_repo is None:
-            await interaction.response.send_message(
-                "Thread-level bindings are not enabled on this bot.", ephemeral=True
-            )
-            return
-
-        thread_id = interaction.channel_id
-        assert thread_id is not None
-        channel_id = (
-            interaction.channel.parent_id
-            if isinstance(interaction.channel, discord.Thread)
-            else thread_id
+        await self._clord_thread_init_impl(
+            thread_id=interaction.channel_id,
+            channel=interaction.channel,
+            client=interaction.client,
+            user=interaction.user,
+            repo=repo,
+            remove=remove,
+            respond=self._slash_respond(interaction),
         )
 
-        # --- Remove binding ---
-        if remove:
-            deleted = await self._thread_repo.delete(thread_id)
-            self.evict_thread_cache(thread_id)
-            if deleted:
-                await interaction.response.send_message(
-                    f"Removed thread repository binding for <#{thread_id}>.", ephemeral=True
-                )
-            else:
-                await interaction.response.send_message("No thread binding found.", ephemeral=True)
-            return
+    @commands.command(name="clord-thread-init")
+    async def clord_thread_init_text(self, ctx: commands.Context, arg: str | None = None) -> None:
+        """Text/mention twin of /clord-thread-init — webhook-invokable for E2E (#209).
 
-        # --- Show current thread binding (no args) ---
-        if repo is None:
-            binding = await self._thread_repo.get(thread_id)
-            if binding is None:
-                await interaction.response.send_message(
-                    "No thread-level binding for this thread.", ephemeral=True
-                )
-            else:
-                await interaction.response.send_message(
-                    f"Thread <#{thread_id}> → `{binding['source_repo']}`", ephemeral=True
-                )
-            return
-
-        # --- Access check: verify bot can read the thread's parent channel ---
-        bot_channel = interaction.client.get_channel(channel_id)
-        if bot_channel is None:
-            try:
-                await interaction.client.fetch_channel(channel_id)
-            except discord.Forbidden:
-                await interaction.response.send_message(
-                    f"⚠️ Bot がこのスレッドの親チャンネル (<#{channel_id}>) にアクセスできません。\n"
-                    "先に Bot をそのチャンネルに追加してください。",
-                    ephemeral=True,
-                )
-                return
-            except discord.HTTPException:
-                pass  # 他のエラーは無視してbindを続行
-
-        # --- Bind thread to repo ---
-        await self._thread_repo.save(thread_id=thread_id, source_repo=repo, channel_id=channel_id)
-        self.evict_thread_cache(thread_id)
-        await interaction.response.send_message(
-            f"Bound thread <#{thread_id}> → `{repo}`", ephemeral=True
+        Usage: ``!clord-thread-init`` (show) / ``!clord-thread-init <repo>`` (bind) /
+        ``!clord-thread-init remove``. Gated by ``_is_allowed`` only.
+        """
+        repo: str | None = None
+        remove = False
+        if arg == "remove":
+            remove = True
+        elif arg:
+            repo = arg
+        await self._clord_thread_init_impl(
+            thread_id=ctx.channel.id,
+            channel=ctx.channel,
+            client=ctx.bot,
+            user=ctx.author,
+            repo=repo,
+            remove=remove,
+            respond=self._ctx_respond(ctx),
         )

--- a/c_lord/cogs/session_manage.py
+++ b/c_lord/cogs/session_manage.py
@@ -202,20 +202,17 @@ class SessionManageCog(commands.Cog):
         respond, _ = self._ctx_io(ctx)
         await self._model_show_impl(channel=ctx.channel, respond=respond)
 
-    @model_group.command(name="set", description="Change the global Claude model for new sessions")
-    @app_commands.describe(model="Model to use for all new Claude sessions")
-    @app_commands.choices(model=_MODEL_CHOICES)
-    async def model_set(self, interaction: discord.Interaction, model: str) -> None:
-        """Set the global default model stored in settings_repo."""
+    async def _model_set_impl(self, *, model: str, respond: _Responder) -> None:
+        """Shared core for /model set and !model-set (#209 follow-up)."""
         if model not in _VALID_MODELS:
-            await interaction.response.send_message(
+            await respond(
                 f"❌ Unknown model `{model}`. Valid choices: {', '.join(sorted(_VALID_MODELS))}",
                 ephemeral=True,
             )
             return
 
         if self.settings_repo is None:
-            await interaction.response.send_message(
+            await respond(
                 "❌ Settings repository is unavailable — model cannot be persisted.",
                 ephemeral=True,
             )
@@ -228,7 +225,24 @@ class SessionManageCog(commands.Cog):
             description=f"Global model set to **`{model}`**.\nAll new sessions will use this model.",  # noqa: E501
             color=COLOR_SUCCESS,
         )
-        await interaction.response.send_message(embed=embed)
+        await respond(embed=embed)
+
+    @model_group.command(name="set", description="Change the global Claude model for new sessions")
+    @app_commands.describe(model="Model to use for all new Claude sessions")
+    @app_commands.choices(model=_MODEL_CHOICES)
+    async def model_set(self, interaction: discord.Interaction, model: str) -> None:
+        """Set the global default model stored in settings_repo."""
+        respond, _ = self._slash_io(interaction)
+        await self._model_set_impl(model=model, respond=respond)
+
+    @commands.command(name="model-set")
+    async def model_set_text(self, ctx: commands.Context, model: str | None = None) -> None:
+        """Text/mention twin of /model set — webhook-invokable for E2E (#209)."""
+        if not model:
+            await ctx.send(f"Usage: `!model-set <{'/'.join(sorted(_VALID_MODELS))}>`")
+            return
+        respond, _ = self._ctx_io(ctx)
+        await self._model_set_impl(model=model, respond=respond)
 
     async def _resume_info_impl(self, *, channel: object, respond: _Responder) -> None:
         """Shared core for /resume-info and !resume-info (#209 follow-up)."""

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -104,6 +104,14 @@ Only available when the bot operator has enabled the upgrade slash command.
 | `!sessions` | List all known sessions | `!sessions` | `/sessions` |
 | `!session-dirs` | List active session directories | `!session-dirs` | `/session-dirs` |
 | `!tmux-list` | List active tmux windows | `!tmux-list` | `/tmux-list` |
+| `!clord-init [repo\|remove]` | Bind / unbind / show channel→repo | `!clord-init https://…` | `/clord-init` |
+| `!clord-thread-init [repo\|remove]` | Bind / unbind / show thread→repo | `!clord-thread-init remove` | `/clord-thread-init` |
+| `!model-set <model>` | Change the global Claude model | `!model-set opus` | `/model set` |
+
+> **Manage-Server note.** `/clord-init` and `/clord-thread-init` are gated by
+> Discord's *Manage Server* permission. Their `!text` twins have **no** such
+> Discord-level gate — they are gated only by `_is_allowed` (owner/role
+> allowlist). Keep the allowlist restricted in production.
 
 Each text command is **functionally identical to its slash equivalent** — it
 calls the same underlying handler. Text commands accept either prefix:

--- a/tests/e2e/test_text_command_twins.py
+++ b/tests/e2e/test_text_command_twins.py
@@ -138,6 +138,35 @@ def test_readonly_info_twins_via_webhook(
 
 
 @pytest.mark.e2e
+@pytest.mark.parametrize(
+    "command",
+    ["!clord-init", "!clord-thread-init", "!model-set"],
+)
+def test_config_twins_non_mutating_via_webhook(
+    discord_client: DiscordE2EClient,
+    bot_id: str,
+    command: str,
+) -> None:
+    """Config twins fire from a webhook (non-mutating forms: show / usage)."""
+    # Bare forms don't change state: clord-init/-thread-init "show", model-set "usage".
+    seed = discord_client.create_seed_message(f"[E2E] {command} test")
+    thread = discord_client.create_thread(seed["id"], f"E2E: {command}")
+    thread_id = thread["id"]
+
+    wh_msg = discord_client.webhook_post(command, thread_id=thread_id)
+
+    reply = discord_client.wait_for_bot_reply(
+        thread_id,
+        after_message_id=wh_msg["id"],
+        bot_id=bot_id,
+        timeout=30.0,
+        poll=2.0,
+    )
+    assert reply is not None, f"Bot did not reply to {command} within 30s"
+    assert reply["content"] or reply.get("embeds"), f"Bot reply to {command} was empty"
+
+
+@pytest.mark.e2e
 def test_mention_prefix_via_webhook(
     discord_client: DiscordE2EClient,
     bot_id: str,

--- a/tests/test_channel_repo.py
+++ b/tests/test_channel_repo.py
@@ -415,3 +415,55 @@ class TestClordThreadInitAccessCheck:
             "content", interaction.response.send_message.call_args[0][0]
         )
         assert "アクセス" in msg or "access" in msg.lower()
+
+
+# ===========================================================================
+# Text/mention twins (#209 follow-up) — webhook-invokable config commands
+# ===========================================================================
+
+
+def _make_ctx(channel_id: int = 555, author_id: int = 1) -> MagicMock:
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    ctx.author = MagicMock()
+    ctx.author.id = author_id
+    ctx.channel = MagicMock()
+    ctx.channel.id = channel_id
+    ctx.bot = MagicMock()
+    ctx.bot.get_channel = MagicMock(return_value=MagicMock())
+    return ctx
+
+
+class TestClordInitTextTwin:
+    async def test_show_no_bindings(self, cog: ChannelRepoCog) -> None:
+        ctx = _make_ctx()
+        await cog.clord_init_text.callback(cog, ctx, arg=None)
+        ctx.send.assert_called_once()
+
+    async def test_bind(self, cog: ChannelRepoCog, repo: ChannelRepository) -> None:
+        ctx = _make_ctx(channel_id=777)
+        await cog.clord_init_text.callback(cog, ctx, arg="https://github.com/org/r.git")
+        binding = await repo.get(777)
+        assert binding is not None
+        assert "Bound" in ctx.send.call_args.args[0]
+
+    async def test_remove(self, cog: ChannelRepoCog, repo: ChannelRepository) -> None:
+        await repo.save(channel_id=888, source_repo="https://x/y.git")
+        ctx = _make_ctx(channel_id=888)
+        await cog.clord_init_text.callback(cog, ctx, arg="remove")
+        assert await repo.get(888) is None
+
+
+class TestClordThreadInitTextTwin:
+    async def test_show_no_binding(self, cog: ChannelRepoCog) -> None:
+        ctx = _make_ctx(channel_id=5555)
+        await cog.clord_thread_init_text.callback(cog, ctx, arg=None)
+        ctx.send.assert_called_once()
+        assert "thread" in ctx.send.call_args.args[0].lower()
+
+    async def test_bind(self, cog: ChannelRepoCog, thread_repo: ThreadRepository) -> None:
+        ctx = _make_ctx(channel_id=5555)
+        await cog.clord_thread_init_text.callback(cog, ctx, arg="https://github.com/org/t.git")
+        binding = await thread_repo.get(5555)
+        assert binding is not None
+        assert "Bound thread" in ctx.send.call_args.args[0]

--- a/tests/test_session_manage.py
+++ b/tests/test_session_manage.py
@@ -288,6 +288,33 @@ class TestReadonlyTextTwins:
         assert "clord-init" in ctx.send.call_args.args[0]
 
 
+class TestModelSetTextTwin:
+    """!model-set mirrors /model set (E2E-invokable, #209)."""
+
+    async def test_missing_model_shows_usage(self):
+        cog = _make_cog()
+        ctx = _make_ctx()
+        await cog.model_set_text.callback(cog, ctx, model=None)
+        ctx.send.assert_called_once()
+        assert "Usage" in ctx.send.call_args.args[0]
+
+    async def test_invalid_model(self):
+        cog = _make_cog()
+        ctx = _make_ctx()
+        await cog.model_set_text.callback(cog, ctx, model="nope")
+        assert "Unknown model" in ctx.send.call_args.args[0]
+
+    async def test_valid_model_persisted(self):
+        cog = _make_cog()
+        cog.settings_repo = MagicMock()
+        cog.settings_repo.set = AsyncMock()
+        ctx = _make_ctx()
+        await cog.model_set_text.callback(cog, ctx, model="opus")
+        cog.settings_repo.set.assert_called_once()
+        assert cog.settings_repo.set.call_args.args[1] == "opus"
+        assert ctx.send.call_args.kwargs.get("embed") is not None
+
+
 class TestHelperFunctions:
     """Tests for _is_tmux_session and _format_session_short."""
 


### PR DESCRIPTION
## What does this PR do?

Adds text/mention twins for the config slash commands (#209 follow-up):

- `!clord-init [repo|remove]` ↔ `/clord-init`
- `!clord-thread-init [repo|remove]` ↔ `/clord-thread-init`
- `!model-set <model>` ↔ `/model set`

Each slash body is extracted into a `_*_impl(..., respond)` core shared with the text twin (no copy-paste).

## Why?

Slash commands can't be triggered by webhooks, so these config flows couldn't be E2E/manual-QA tested.

Closes #228

## ⚠️ Security note

`/clord-init` and `/clord-thread-init` are gated by Discord's **Manage Server** permission (`default_permissions(manage_guild=True)`). The `!text` twins have **no** Discord-level permission gate — they are gated only by `_is_allowed` (owner/role allowlist), same as the existing `!attach`. Production should keep the allowlist restricted. Documented in `docs/COMMANDS.md`.

## Acceptance Criteria (copied from the issue)

- [x] `!clord-init` show/bind/remove behaves like `/clord-init`
- [x] `!clord-thread-init` show/bind/remove behaves like `/clord-thread-init`
- [x] `!model-set <model>` behaves like `/model set` (invalid rejected, valid persisted); bare → usage
- [x] `@bot …` mention also fires
- [x] Existing slash tests stay green
- [x] Unit tests for each twin
- [x] Staging: each twin fired via webhook (non-mutating forms); RED reproduced (CommandNotFound)
- [x] `docs/COMMANDS.md` updated (incl. Manage-Server note) + E2E tests added

## Staging Evidence

Borrowed staging (jsonl), restored afterward. Prod untouched.

**RED (before):**
```
discord.ext.commands.errors.CommandNotFound: Command "clord-init" is not found
```

**GREEN (after — non-mutating forms):**
```
!clord-init         → '<#1503196656265597082> → `/home/yousan/c-lord-parallel-3` (tmux: …)'
!clord-thread-init  → 'No thread-level binding for this thread.'
!model-set          → 'Usage: `!model-set <haiku/opus/sonnet>`'
!model-set zzz      → '❌ Unknown model `zzz`. Valid choices: haiku, opus, sonnet'
```

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: new twin tests (8 pass); behavioural RED reproduced on staging (CommandNotFound)
- [x] `uv run pytest tests/` passes (1261 passed, 9 skipped)
- [x] `ruff check` + `ruff format --check` + `pyright` on `c_lord/` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes; self-review done
- [x] `Closes #228` — 100% of ACs met

🤖 Generated with [Claude Code](https://claude.com/claude-code)
