### PR TITLE
feat: text/mention twins for ops commands (session-cleanup / workspace-delete)

### DIFF
--- a/c_lord/cogs/session_manage.py
+++ b/c_lord/cogs/session_manage.py
@@ -492,28 +492,19 @@ class SessionManageCog(commands.Cog):
         respond, ack = self._ctx_io(ctx)
         await self._session_dirs_list_impl(respond=respond, ack=ack)
 
-    @app_commands.command(
-        name="session-cleanup",
-        description="Remove clean orphaned session directories",
-    )
-    @app_commands.describe(
-        dry_run="Preview what would be removed without actually removing anything",
-    )
-    async def session_cleanup(
-        self,
-        interaction: discord.Interaction,
-        dry_run: bool = False,
+    async def _session_cleanup_impl(
+        self, *, dry_run: bool, respond: _Responder, ack: _Acknowledger
     ) -> None:
-        """Remove session directories that have no active session and are clean."""
+        """Shared core for /session-cleanup and !session-cleanup (#209 follow-up)."""
         bindings = await self._get_all_bindings()
         if not bindings:
-            await interaction.response.send_message(
+            await respond(
                 "❌ No channel-repo bindings configured. Use `/clord-init` first.",
                 ephemeral=True,
             )
             return
 
-        await interaction.response.defer()
+        await ack()
 
         import asyncio
 
@@ -530,7 +521,7 @@ class SessionManageCog(commands.Cog):
                 managers.append(sdm)
 
         if not managers:
-            await interaction.followup.send(
+            await respond(
                 embed=discord.Embed(
                     title="📁 Session Cleanup",
                     description="No session directory managers found.",
@@ -575,7 +566,7 @@ class SessionManageCog(commands.Cog):
             if not candidates and not skipped:
                 embed.description = "No session directories found."
             embed.set_footer(text="Re-run without dry_run=True to actually remove.")
-            await interaction.followup.send(embed=embed)
+            await respond(embed=embed)
             return
 
         all_results = []
@@ -619,7 +610,33 @@ class SessionManageCog(commands.Cog):
                 inline=False,
             )
 
-        await interaction.followup.send(embed=embed)
+        await respond(embed=embed)
+
+    @app_commands.command(
+        name="session-cleanup",
+        description="Remove clean orphaned session directories",
+    )
+    @app_commands.describe(
+        dry_run="Preview what would be removed without actually removing anything",
+    )
+    async def session_cleanup(
+        self,
+        interaction: discord.Interaction,
+        dry_run: bool = False,
+    ) -> None:
+        """Remove session directories that have no active session and are clean."""
+        respond, ack = self._slash_io(interaction)
+        await self._session_cleanup_impl(dry_run=dry_run, respond=respond, ack=ack)
+
+    @commands.command(name="session-cleanup")
+    async def session_cleanup_text(self, ctx: commands.Context, arg: str | None = None) -> None:
+        """Text/mention twin of /session-cleanup — webhook-invokable for E2E (#209).
+
+        Usage: ``!session-cleanup`` (remove) / ``!session-cleanup dry`` (preview).
+        """
+        dry_run = (arg or "").lower() in {"dry", "dry_run", "dry-run", "true", "1"}
+        respond, ack = self._ctx_io(ctx)
+        await self._session_cleanup_impl(dry_run=dry_run, respond=respond, ack=ack)
 
     async def _tmux_list_impl(self, *, respond: _Responder, ack: _Acknowledger) -> None:
         """Shared core for /tmux-list and !tmux-list (#209 follow-up)."""
@@ -682,22 +699,20 @@ class SessionManageCog(commands.Cog):
         respond, ack = self._ctx_io(ctx)
         await self._tmux_list_impl(respond=respond, ack=ack)
 
-    @app_commands.command(
-        name="workspace-delete",
-        description="Delete the tmux window and session directory for this thread",
-    )
-    async def workspace_delete(self, interaction: discord.Interaction) -> None:
-        """Delete the tmux window and session directory for the current thread."""
-        if not isinstance(interaction.channel, discord.Thread):
-            await interaction.response.send_message(
+    async def _workspace_delete_impl(
+        self, *, channel: object, respond: _Responder, ack: _Acknowledger
+    ) -> None:
+        """Shared core for /workspace-delete and !workspace-delete (#209 follow-up)."""
+        if not isinstance(channel, discord.Thread):
+            await respond(
                 "This command can only be used in a Claude chat thread.",
                 ephemeral=True,
             )
             return
 
-        thread_id = interaction.channel.id
-        parent_channel_id = interaction.channel.parent_id or thread_id
-        await interaction.response.defer()
+        thread_id = channel.id
+        parent_channel_id = channel.parent_id or thread_id
+        await ack()
 
         import asyncio
 
@@ -732,4 +747,19 @@ class SessionManageCog(commands.Cog):
             description="\n".join(results),
             color=COLOR_SUCCESS,
         )
-        await interaction.followup.send(embed=embed)
+        await respond(embed=embed)
+
+    @app_commands.command(
+        name="workspace-delete",
+        description="Delete the tmux window and session directory for this thread",
+    )
+    async def workspace_delete(self, interaction: discord.Interaction) -> None:
+        """Delete the tmux window and session directory for the current thread."""
+        respond, ack = self._slash_io(interaction)
+        await self._workspace_delete_impl(channel=interaction.channel, respond=respond, ack=ack)
+
+    @commands.command(name="workspace-delete")
+    async def workspace_delete_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /workspace-delete — webhook-invokable for E2E (#209)."""
+        respond, ack = self._ctx_io(ctx)
+        await self._workspace_delete_impl(channel=ctx.channel, respond=respond, ack=ack)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -107,6 +107,8 @@ Only available when the bot operator has enabled the upgrade slash command.
 | `!clord-init [repo\|remove]` | Bind / unbind / show channel→repo | `!clord-init https://…` | `/clord-init` |
 | `!clord-thread-init [repo\|remove]` | Bind / unbind / show thread→repo | `!clord-thread-init remove` | `/clord-thread-init` |
 | `!model-set <model>` | Change the global Claude model | `!model-set opus` | `/model set` |
+| `!session-cleanup [dry]` | Remove clean orphaned session dirs (`dry` = preview) | `!session-cleanup dry` | `/session-cleanup` |
+| `!workspace-delete` | Delete this thread's tmux window + session dir | `!workspace-delete` | `/workspace-delete` |
 
 > **Manage-Server note.** `/clord-init` and `/clord-thread-init` are gated by
 > Discord's *Manage Server* permission. Their `!text` twins have **no** such

--- a/tests/e2e/test_text_command_twins.py
+++ b/tests/e2e/test_text_command_twins.py
@@ -167,6 +167,46 @@ def test_config_twins_non_mutating_via_webhook(
 
 
 @pytest.mark.e2e
+def test_session_cleanup_dryrun_twin_via_webhook(
+    discord_client: DiscordE2EClient,
+    bot_id: str,
+) -> None:
+    """!session-cleanup dry (preview, non-destructive) fires from a webhook."""
+    wh_msg = discord_client.webhook_post("!session-cleanup dry")
+    reply = discord_client.wait_for_bot_reply(
+        discord_client.channel_id,
+        after_message_id=wh_msg["id"],
+        bot_id=bot_id,
+        timeout=30.0,
+        poll=2.0,
+    )
+    assert reply is not None, "Bot did not reply to !session-cleanup dry within 30s"
+    assert reply["content"] or reply.get("embeds")
+
+
+@pytest.mark.e2e
+def test_workspace_delete_twin_via_webhook(
+    discord_client: DiscordE2EClient,
+    bot_id: str,
+) -> None:
+    """!workspace-delete fires in a fresh thread (no workspace → harmless reply)."""
+    seed = discord_client.create_seed_message("[E2E] !workspace-delete test")
+    thread = discord_client.create_thread(seed["id"], "E2E: !workspace-delete")
+    thread_id = thread["id"]
+
+    wh_msg = discord_client.webhook_post("!workspace-delete", thread_id=thread_id)
+    reply = discord_client.wait_for_bot_reply(
+        thread_id,
+        after_message_id=wh_msg["id"],
+        bot_id=bot_id,
+        timeout=30.0,
+        poll=2.0,
+    )
+    assert reply is not None, "Bot did not reply to !workspace-delete within 30s"
+    assert reply["content"] or reply.get("embeds")
+
+
+@pytest.mark.e2e
 def test_mention_prefix_via_webhook(
     discord_client: DiscordE2EClient,
     bot_id: str,

--- a/tests/test_session_manage.py
+++ b/tests/test_session_manage.py
@@ -315,6 +315,36 @@ class TestModelSetTextTwin:
         assert ctx.send.call_args.kwargs.get("embed") is not None
 
 
+class TestOpsTextTwins:
+    """!session-cleanup / !workspace-delete (destructive, E2E-invokable, #209)."""
+
+    async def test_session_cleanup_text_no_bindings(self):
+        cog = _make_cog()  # bot.get_cog → non-ChannelRepoCog ⇒ no bindings
+        ctx = _make_ctx()
+        await cog.session_cleanup_text.callback(cog, ctx, arg=None)
+        ctx.send.assert_called_once()
+        assert "clord-init" in ctx.send.call_args.args[0]
+
+    async def test_workspace_delete_text_outside_thread(self):
+        cog = _make_cog()
+        ctx = _make_ctx()  # not a thread
+        await cog.workspace_delete_text.callback(cog, ctx)
+        ctx.send.assert_called_once()
+        assert "thread" in ctx.send.call_args.args[0].lower()
+
+    async def test_workspace_delete_text_in_thread(self):
+        cog = _make_cog()
+        cog._resolve_tmux_manager = AsyncMock(return_value=None)
+        cog._resolve_session_dir_manager = AsyncMock(return_value=None)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 555
+        thread.parent_id = 999
+        ctx = _make_ctx(channel=thread)
+        await cog.workspace_delete_text.callback(cog, ctx)
+        # Unbound → an embed explaining nothing to delete / clord-init hint
+        assert ctx.send.call_args.kwargs.get("embed") is not None
+
+
 class TestHelperFunctions:
     """Tests for _is_tmux_session and _format_session_short."""
 


### PR DESCRIPTION
## What does this PR do?

Adds text/mention twins for the ops slash commands (#209 follow-up, final batch):

- `!session-cleanup [dry]` ↔ `/session-cleanup`
- `!workspace-delete` ↔ `/workspace-delete`

Each slash body is extracted into a `_*_impl(..., respond, ack)` core shared with the text twin.

**`/upgrade` is intentionally excluded** — it triggers a package upgrade + bot restart, which is unsafe to fire from a webhook for E2E. (Per the decision to skip `upgrade`.)

## Why?

Slash commands can't be triggered by webhooks, so these ops flows couldn't be E2E/manual-QA tested.

Closes #230

## Acceptance Criteria (copied from the issue)

- [x] `!session-cleanup` behaves like `/session-cleanup` (default removes; `dry` previews)
- [x] `!workspace-delete` behaves like `/workspace-delete` (thread-only; deletes tmux window + session dir)
- [x] `@bot …` mention also fires
- [x] Existing slash tests stay green
- [x] Unit tests for each twin
- [x] Staging: fired via webhook (session-cleanup dry-run; workspace-delete in a workspace-less thread). RED reproduced (CommandNotFound)
- [x] `docs/COMMANDS.md` updated + E2E tests added
- [x] `/upgrade` excluded — stated here and in the issue

## Staging Evidence

Borrowed staging (jsonl), restored afterward. Prod untouched.

**RED (before):**
```
discord.ext.commands.errors.CommandNotFound: Command "session-cleanup" is not found
```

**GREEN (after — non-destructive forms):**
```
!session-cleanup dry        → embed '📁 Session Cleanup — Dry Run'
!workspace-delete (fresh thread, no workspace)
                            → embed '🗑️ Workspace Deleted'
                              'ℹ️ No tmux window found / ℹ️ Session directory: …'
```

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: new twin tests (3 pass); behavioural RED reproduced on staging (CommandNotFound)
- [x] `uv run pytest tests/` passes (1264 passed, 9 skipped)
- [x] `ruff check` + `ruff format --check` + `pyright` on `c_lord/` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes; self-review done
- [x] `Closes #230` — 100% of ACs met

🤖 Generated with [Claude Code](https://claude.com/claude-code)
