### PR TITLE
fix: 2000字超の最終返答が途中で切れる（返答経路にメッセージ分割が無い）(#235)

### DIFF
--- a/c_lord/cogs/transcript_mirror.py
+++ b/c_lord/cogs/transcript_mirror.py
@@ -189,7 +189,6 @@ class TranscriptMirrorCog(commands.Cog):
             channel = await self._resolve_channel(bot, thread_id)
             if channel is None:
                 return
-            body = text if len(text) <= 1990 else text[:1985] + "…"
             send = getattr(channel, "send", None)
             if send is None:
                 logger.warning(
@@ -198,16 +197,13 @@ class TranscriptMirrorCog(commands.Cog):
                     type(channel).__name__,
                 )
                 return
-            send_kwargs: dict = {"content": body}
-            if silent_posts_enabled():
-                send_kwargs["silent"] = True
             try:
-                await send(**send_kwargs)
+                await self._send_chunks(send, text, silent=silent_posts_enabled())
             except discord.HTTPException as exc:
                 logger.warning(
                     "TranscriptMirror sink failed: thread=%d body_len=%d status=%s — %s",
                     thread_id,
-                    len(body),
+                    len(text),
                     getattr(exc, "status", "?"),
                     exc,
                     exc_info=True,
@@ -227,7 +223,6 @@ class TranscriptMirrorCog(commands.Cog):
             channel = await self._resolve_channel(bot, thread_id)
             if channel is None:
                 return
-            body = text if len(text) <= 1990 else text[:1985] + "…"
             send = getattr(channel, "send", None)
             if send is None:
                 return
@@ -238,29 +233,14 @@ class TranscriptMirrorCog(commands.Cog):
             table_files = [
                 discord.File(BytesIO(img), filename=fname) for fname, img in get_table_images(text)
             ]
-            send_kwargs: dict = {"content": body}
-            if table_files:
-                send_kwargs["files"] = table_files
-            trigger_id = self._trigger_messages.get(thread_id)
-            if trigger_id is None:
-                with contextlib.suppress(Exception):
-                    record = await self._session_repo.get(thread_id)
-                    if record is not None:
-                        trigger_id = record.trigger_message_id
-            if trigger_id is not None and reply_to_trigger_enabled():
-                send_kwargs["reference"] = discord.MessageReference(
-                    message_id=trigger_id,
-                    channel_id=thread_id,
-                    fail_if_not_exists=False,
-                )
-                send_kwargs["mention_author"] = False
+            reference = await self._build_trigger_reference(thread_id)
             try:
-                await send(**send_kwargs)
+                await self._send_chunks(send, text, reference=reference, files=table_files or None)
             except discord.HTTPException as exc:
                 logger.warning(
                     "TranscriptMirror reply_sink failed: thread=%d body_len=%d status=%s — %s",
                     thread_id,
-                    len(body),
+                    len(text),
                     getattr(exc, "status", "?"),
                     exc,
                     exc_info=True,
@@ -280,7 +260,6 @@ class TranscriptMirrorCog(commands.Cog):
             channel = await self._resolve_channel(bot, thread_id)
             if channel is None:
                 return
-            body = text if len(text) <= 1990 else text[:1985] + "…"
             send = getattr(channel, "send", None)
             if send is None:
                 return
@@ -292,48 +271,86 @@ class TranscriptMirrorCog(commands.Cog):
                 discord.File(BytesIO(img), filename=fname) for fname, img in get_table_images(text)
             ]
             files = [discord.File(file_path, filename="progress.txt")] + table_files
-            send_kwargs: dict = {"content": body, "files": files}
-            trigger_id = self._trigger_messages.get(thread_id)
-            if trigger_id is None:
-                with contextlib.suppress(Exception):
-                    record = await self._session_repo.get(thread_id)
-                    if record is not None:
-                        trigger_id = record.trigger_message_id
-            if trigger_id is not None and reply_to_trigger_enabled():
-                send_kwargs["reference"] = discord.MessageReference(
-                    message_id=trigger_id,
-                    channel_id=thread_id,
-                    fail_if_not_exists=False,
-                )
-                send_kwargs["mention_author"] = False
+            reference = await self._build_trigger_reference(thread_id)
             try:
-                await send(**send_kwargs)
+                await self._send_chunks(send, text, reference=reference, files=files)
                 return
             except discord.HTTPException as exc:
                 logger.warning(
                     "TranscriptMirror file_sink failed (with attachment): "
                     "thread=%d body_len=%d status=%s — retrying without attachment — %s",
                     thread_id,
-                    len(body),
+                    len(text),
                     getattr(exc, "status", "?"),
                     exc,
                     exc_info=True,
                 )
-            # Fallback: plain text without attachment
+            # Fallback: text without attachment (still chunked so it is not truncated).
             try:
-                await send(body)
+                await self._send_chunks(send, text, reference=reference)
             except discord.HTTPException as exc:
                 logger.warning(
                     "TranscriptMirror file_sink fallback also failed: "
                     "thread=%d body_len=%d status=%s — %s",
                     thread_id,
-                    len(body),
+                    len(text),
                     getattr(exc, "status", "?"),
                     exc,
                     exc_info=True,
                 )
 
         return file_sink
+
+    async def _build_trigger_reference(self, thread_id: int) -> discord.MessageReference | None:
+        """Resolve the trigger message for ``thread_id`` into a reply reference.
+
+        Returns ``None`` when reply-to-trigger is disabled or no trigger id is
+        known. Shared by ``reply_sink`` and ``file_sink``.
+        """
+        if not reply_to_trigger_enabled():
+            return None
+        trigger_id = self._trigger_messages.get(thread_id)
+        if trigger_id is None:
+            with contextlib.suppress(Exception):
+                record = await self._session_repo.get(thread_id)
+                if record is not None:
+                    trigger_id = record.trigger_message_id
+        if trigger_id is None:
+            return None
+        return discord.MessageReference(
+            message_id=trigger_id,
+            channel_id=thread_id,
+            fail_if_not_exists=False,
+        )
+
+    @staticmethod
+    async def _send_chunks(
+        send,
+        text: str,
+        *,
+        silent: bool = False,
+        reference: discord.MessageReference | None = None,
+        files: list[discord.File] | None = None,
+    ) -> None:
+        """Send ``text`` split into Discord-sendable chunks (Issue #235).
+
+        Long bodies are split instead of truncated. The quote-reply
+        ``reference`` rides on the first chunk; ``files`` ride on the last.
+        """
+        from ..discord_ui.reply_chunker import chunk_discord_content
+
+        chunks = chunk_discord_content(text)
+        last = len(chunks) - 1
+        for idx, chunk in enumerate(chunks):
+            kwargs: dict = {"content": chunk}
+            if silent:
+                kwargs["silent"] = True
+            if idx == 0 and reference is not None:
+                kwargs["reference"] = reference
+                kwargs["mention_author"] = False
+            if idx == last and files:
+                kwargs["files"] = files
+            await send(**kwargs)
 
     @staticmethod
     async def _resolve_channel(bot, thread_id: int):

--- a/c_lord/discord_ui/reply_chunker.py
+++ b/c_lord/discord_ui/reply_chunker.py
@@ -1,0 +1,105 @@
+"""Split long reply content into Discord-sendable chunks.
+
+Discord rejects any message body longer than 2000 characters. The
+``/api/reply`` path (``c_lord/ext/api_server.py``) used to call ``send`` once
+with the raw ``content``, so any answer longer than the limit was truncated /
+rejected — the user saw the reply cut off mid-sentence. This module splits
+content into ``<= limit`` pieces, preferring line boundaries and keeping
+code fences (```` ``` ````) balanced within each chunk so every piece renders
+as valid Markdown on its own.
+
+This is intentionally a server-side concern: Claude posts its final answer via
+the injected ``discord-reply`` skill (#53) and should not have to reason about
+Discord's length limit. Chunking here means consumers get full-length replies
+just by updating the package (zero-config principle).
+"""
+
+from __future__ import annotations
+
+#: Discord's hard limit on a message ``content`` body.
+DISCORD_MAX = 2000
+
+_FENCE = "```"
+#: Room reserved in every chunk for a trailing close-fence line ("\n```").
+_FENCE_RESERVE = len("\n" + _FENCE)
+
+
+def _hard_split(text: str, size: int) -> list[str]:
+    """Split a single oversized token into ``<= size`` pieces."""
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+def chunk_discord_content(content: str, limit: int = DISCORD_MAX) -> list[str]:
+    """Split ``content`` into chunks each no longer than ``limit`` characters.
+
+    Splitting happens on line boundaries where possible. When a code fence is
+    open at a chunk boundary, the chunk is closed with ```` ``` ```` and the next
+    chunk re-opens it (preserving the language hint) so each chunk is
+    self-contained valid Markdown. Lines longer than ``limit`` are hard-split.
+
+    Args:
+        content: The full reply body (may contain newlines / code fences).
+        limit: Maximum length of each returned chunk. Defaults to Discord's
+            2000-char message limit.
+
+    Returns:
+        A non-empty list of chunks. ``content`` short enough to fit returns
+        ``[content]`` unchanged.
+
+    Raises:
+        ValueError: If ``limit`` is not positive.
+    """
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    if len(content) <= limit:
+        return [content]
+
+    # Reserve room so closing/continuation fences never push a chunk over the
+    # hard limit. We reserve unconditionally to keep the accounting simple and
+    # always safe.
+    usable = max(1, limit - _FENCE_RESERVE)
+
+    chunks: list[str] = []
+    current: list[str] = []
+    cur_len = 0
+    open_fence: str | None = None  # opening fence line text while inside a block
+
+    def finalize() -> None:
+        nonlocal current, cur_len
+        text = "\n".join(current)
+        if open_fence is not None:
+            text = f"{text}\n{_FENCE}"  # close the fence for this chunk
+        if text != "":
+            chunks.append(text)
+        current = []
+        cur_len = 0
+        if open_fence is not None:
+            # Re-open the fence at the start of the next chunk.
+            current.append(open_fence)
+            cur_len = len(open_fence)
+
+    for raw_line in content.split("\n"):
+        is_fence = raw_line.lstrip().startswith(_FENCE)
+
+        segments = [raw_line] if len(raw_line) <= usable else _hard_split(raw_line, usable)
+        for seg in segments:
+            added = (1 if current else 0) + len(seg)
+            if current and cur_len + added > usable:
+                finalize()
+                added = (1 if current else 0) + len(seg)
+            if current:
+                cur_len += 1
+            current.append(seg)
+            cur_len += len(seg)
+
+        if is_fence:
+            open_fence = raw_line if open_fence is None else None
+
+    if current:
+        text = "\n".join(current)
+        if open_fence is not None:
+            text = f"{text}\n{_FENCE}"
+        if text != "":
+            chunks.append(text)
+
+    return chunks or [content[:limit]]

--- a/c_lord/ext/api_server.py
+++ b/c_lord/ext/api_server.py
@@ -722,27 +722,40 @@ class ApiServer:
         ]
 
         all_files = table_files + ([attachment] if attachment else [])
-        send_kwargs: dict = {"content": content}
-        if len(all_files) == 1:
-            send_kwargs["file"] = all_files[0]
-        elif len(all_files) > 1:
-            send_kwargs["files"] = all_files
+
+        # Issue: long replies were cut off at Discord's 2000-char limit. Split
+        # the body into multiple sequential messages. The quote-reply reference
+        # rides on the first chunk; attachments ride on the last.
+        from ..discord_ui.reply_chunker import chunk_discord_content
+
+        chunks = chunk_discord_content(content)
 
         # Issue #115: reply to the trigger message that started this Claude turn.
         from ..transcript.mirror import reply_to_trigger_enabled
 
+        reference = None
         if reply_to_trigger_enabled() and self.session_repo is not None:
             record = await self.session_repo.get(thread_id)
             trigger_id = getattr(record, "trigger_message_id", None) if record else None
             if trigger_id is not None:
-                send_kwargs["reference"] = discord.MessageReference(
+                reference = discord.MessageReference(
                     message_id=trigger_id,
                     channel_id=thread_id,
                     fail_if_not_exists=False,
                 )
-                send_kwargs["mention_author"] = False
 
-        await raw.send(**send_kwargs)  # type: ignore[union-attr]
+        last_idx = len(chunks) - 1
+        for idx, chunk in enumerate(chunks):
+            send_kwargs: dict = {"content": chunk}
+            if idx == 0 and reference is not None:
+                send_kwargs["reference"] = reference
+                send_kwargs["mention_author"] = False
+            if idx == last_idx and all_files:
+                if len(all_files) == 1:
+                    send_kwargs["file"] = all_files[0]
+                else:
+                    send_kwargs["files"] = all_files
+            await raw.send(**send_kwargs)  # type: ignore[union-attr]
 
         # Issue #67: record the successful reply so run_helper can detect
         # turns where Claude never invoked the discord-reply skill.

--- a/c_lord/skills/discord_reply.py
+++ b/c_lord/skills/discord_reply.py
@@ -72,8 +72,10 @@ JSON
 1. Call this skill exactly once per turn, at the very end, with your final answer.
 2. Do not include intermediate progress in `content` — write it to a file and
    pass the absolute path via `progress_file`.
-3. Keep `content` under ~1800 characters (Discord limit is 2000; leave room
-   for chrome). If your answer is longer, paginate or attach it.
+3. Send your full answer in `content` — c-lord splits messages longer than
+   Discord's 2000-char limit into multiple posts automatically, so do NOT
+   truncate or cut off your answer to fit. For very long detail dumps (logs,
+   large diffs) prefer writing to a file and passing `progress_file`.
 4. Markdown is supported (bold, lists, code fences). URLs render as text only
    (no preview embeds, by design).
 """
@@ -140,8 +142,10 @@ JSON
 1. Call this skill exactly once per turn, at the very end, with your final answer.
 2. Do not include intermediate progress in `content` — write it to a file and
    pass the absolute path via `progress_file`.
-3. Keep `content` under ~1800 characters (Discord limit is 2000; leave room
-   for chrome). If your answer is longer, paginate or attach it.
+3. Send your full answer in `content` — c-lord splits messages longer than
+   Discord's 2000-char limit into multiple posts automatically, so do NOT
+   truncate or cut off your answer to fit. For very long detail dumps (logs,
+   large diffs) prefer writing to a file and passing `progress_file`.
 4. Markdown is supported (bold, lists, code fences). URLs render as text only
    (no preview embeds, by design).
 5. The Bearer token above must be sent with every request. Do not log or

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -690,6 +690,65 @@ class TestReplyEndpoint:
         assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_long_content_is_chunked_across_multiple_messages(
+        self, reply_client: TestClient, thread_mock: MagicMock
+    ) -> None:
+        """Regression: replies longer than Discord's 2000-char limit were cut
+        off. The endpoint must split them into multiple sends, each <= 2000,
+        with no content lost."""
+        long_content = "\n".join(f"sentence number {i} here." for i in range(400))
+        assert len(long_content) > 2000
+
+        resp = await reply_client.post(
+            "/api/reply",
+            json={"thread_id": 555666777, "content": long_content},
+        )
+        assert resp.status == 200
+        assert thread_mock.send.call_count >= 2
+
+        sent_bodies: list[str] = []
+        for call in thread_mock.send.call_args_list:
+            body = call.kwargs.get("content")
+            if body is None and call.args:
+                body = call.args[0]
+            assert body is not None
+            assert len(body) <= 2000
+            sent_bodies.append(body)
+
+        # Every original sentence survives across the chunks, in order.
+        joined = "\n".join(sent_bodies)
+        for i in range(400):
+            assert f"sentence number {i} here." in joined
+
+    @pytest.mark.asyncio
+    async def test_long_content_attaches_files_to_last_chunk_only(
+        self, reply_client: TestClient, thread_mock: MagicMock, tmp_path
+    ) -> None:
+        """When content is chunked, the optional attachment must ride on the
+        final message (not be dropped or duplicated across chunks)."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text("detail\n")
+        long_content = "\n".join(f"row {i}" for i in range(700))
+        assert len(long_content) > 2000
+
+        resp = await reply_client.post(
+            "/api/reply",
+            json={
+                "thread_id": 555666777,
+                "content": long_content,
+                "progress_file": str(progress),
+            },
+        )
+        assert resp.status == 200
+        calls = thread_mock.send.call_args_list
+        assert len(calls) >= 2
+        # Only the final send carries the file.
+        for call in calls[:-1]:
+            assert "file" not in call.kwargs and "files" not in call.kwargs
+        last = calls[-1].kwargs
+        assert "file" in last or "files" in last
+
+    @pytest.mark.asyncio
     async def test_successful_reply_records_in_tracker(self, reply_client: TestClient) -> None:
         """Issue #67: api_server records each /api/reply call so run_helper
         can detect turns where the skill was never invoked."""

--- a/tests/test_reply_chunker.py
+++ b/tests/test_reply_chunker.py
@@ -1,0 +1,66 @@
+"""Tests for c_lord.discord_ui.reply_chunker.
+
+Regression for the "reply text is cut off at the end" bug: the ``/api/reply``
+path sent ``content`` to Discord with a single ``send`` call, so any answer
+longer than Discord's 2000-char limit was truncated / rejected. The chunker
+splits long content into multiple Discord-sendable pieces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from c_lord.discord_ui.reply_chunker import DISCORD_MAX, chunk_discord_content
+
+
+class TestChunkDiscordContent:
+    def test_short_content_passes_through_unchanged(self) -> None:
+        assert chunk_discord_content("hello") == ["hello"]
+
+    def test_content_exactly_at_limit_is_single_chunk(self) -> None:
+        text = "x" * DISCORD_MAX
+        chunks = chunk_discord_content(text)
+        assert chunks == [text]
+
+    def test_long_plain_text_splits_into_multiple_chunks(self) -> None:
+        # 5000 chars of newline-separated lines.
+        text = "\n".join(f"line {i} " + "y" * 40 for i in range(120))
+        assert len(text) > DISCORD_MAX
+        chunks = chunk_discord_content(text)
+        assert len(chunks) >= 2
+        for c in chunks:
+            assert len(c) <= DISCORD_MAX
+            assert c != ""
+
+    def test_no_content_is_lost_when_splitting_plain_lines(self) -> None:
+        lines = [f"line-{i}" for i in range(2000)]
+        text = "\n".join(lines)
+        chunks = chunk_discord_content(text)
+        # Every original line survives somewhere, in order.
+        rejoined = "\n".join(chunks)
+        for ln in lines:
+            assert ln in rejoined
+
+    def test_oversized_single_line_is_hard_split(self) -> None:
+        text = "z" * (DISCORD_MAX * 2 + 17)
+        chunks = chunk_discord_content(text)
+        assert len(chunks) >= 3
+        for c in chunks:
+            assert len(c) <= DISCORD_MAX
+        assert "".join(chunks) == text
+
+    def test_code_fence_is_balanced_in_every_chunk(self) -> None:
+        # A code block big enough to span multiple chunks.
+        body = "\n".join("a" * 80 for _ in range(60))
+        text = f"```python\n{body}\n```"
+        assert len(text) > DISCORD_MAX
+        chunks = chunk_discord_content(text)
+        assert len(chunks) >= 2
+        for c in chunks:
+            # Even number of fence markers => every chunk is self-contained.
+            assert c.count("```") % 2 == 0
+            assert len(c) <= DISCORD_MAX
+
+    def test_invalid_limit_raises(self) -> None:
+        with pytest.raises(ValueError):
+            chunk_discord_content("x", limit=0)

--- a/tests/test_transcript_mirror_cog.py
+++ b/tests/test_transcript_mirror_cog.py
@@ -84,9 +84,11 @@ async def test_start_for_noop_when_not_jsonl_mode(
     assert cog.start_for(1, str(tmp_path)) is False
 
 
-async def test_sink_truncates_long_messages(
+async def test_sink_chunks_long_messages_without_truncation(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Issue #235: long bodies must be split into multiple sends, not
+    truncated to 1985 chars + '…'."""
     monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
     bot = MagicMock()
     channel = MagicMock()
@@ -96,9 +98,64 @@ async def test_sink_truncates_long_messages(
     cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
     sink = cog._make_sink(7)
     await sink("a" * 3000)
-    sent = channel.send.call_args.kwargs.get("content") or channel.send.call_args[0][0]
-    assert len(sent) <= 2000
-    assert sent.endswith("…")
+    assert channel.send.call_count >= 2
+    bodies = []
+    for call in channel.send.call_args_list:
+        body = call.kwargs.get("content") or (call.args[0] if call.args else "")
+        assert len(body) <= 2000
+        assert not body.endswith("…")  # no lossy truncation
+        bodies.append(body)
+    assert sum(len(b) for b in bodies) == 3000  # full content preserved
+
+
+async def test_reply_sink_chunks_long_messages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Issue #235: final assistant text longer than 2000 chars is chunked."""
+    monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    reply_sink = cog._make_reply_sink(7)
+    text = "\n".join(f"answer line {i}" for i in range(300))
+    assert len(text) > 2000
+    await reply_sink(text)
+    assert channel.send.call_count >= 2
+    for call in channel.send.call_args_list:
+        body = call.kwargs.get("content") or (call.args[0] if call.args else "")
+        assert len(body) <= 2000
+        assert not body.endswith("…")
+
+
+async def test_file_sink_chunks_and_attaches_to_last_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Issue #235: when the final answer is chunked, the progress.txt
+    attachment rides on the last message only."""
+    monkeypatch.setenv("CLORD_BRIDGE_MODE", "jsonl")
+    bot = MagicMock()
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+    progress_file = tmp_path / "progress.txt"
+    progress_file.write_text("tool output\n")
+
+    cog = TranscriptMirrorCog(bot, session_repo=_make_repo([]))
+    file_sink = cog._make_file_sink(7)
+    text = "\n".join(f"answer line {i}" for i in range(300))
+    assert len(text) > 2000
+    await file_sink(text, str(progress_file))
+
+    calls = channel.send.call_args_list
+    assert len(calls) >= 2
+    for call in calls[:-1]:
+        assert "file" not in call.kwargs and "files" not in call.kwargs
+        body = call.kwargs.get("content") or (call.args[0] if call.args else "")
+        assert len(body) <= 2000
+    assert "files" in calls[-1].kwargs or "file" in calls[-1].kwargs
 
 
 async def test_sink_falls_back_to_fetch_channel(


### PR DESCRIPTION
## Summary

Closes #235.

Discord 上で Claude の最終返答が途中で切れる（文末欠落）バグの修正。**返答配信経路にメッセージ分割が無く**、Discord の 2000 文字上限で長文が切り捨て／送信失敗していた。

根本原因は 2 経路:
1. **経路B（本番アクティブ, `CLORD_BRIDGE_MODE=jsonl` / transcript mirror）** — `transcript_mirror.py` の 3 sink が `text[:1985] + "…"` で **ハード切り詰め**。これがユーザーに見えていた切れの真因。
2. **経路A（skill push, `/api/reply`）** — `content` を単一 `send()` で送信し 2000 字超で失敗。

\#53 で `chunk_message` が削除されて以降、どちらの返答経路にも分割処理が無かった。

## Changes

- **新規** `c_lord/discord_ui/reply_chunker.py::chunk_discord_content` — 改行境界で分割し、コードフェンス（```）を各チャンク内で閉じ直す純粋関数。
- `cogs/transcript_mirror.py` — 3 sink（`sink`/`reply_sink`/`file_sink`）を共通 `_send_chunks` ヘルパー経由に変更。quote-reply reference は先頭チャンク、添付は末尾チャンク。trigger reference 解決を `_build_trigger_reference` に集約。
- `ext/api_server.py` `/api/reply` — content を複数メッセージに順次分割送信。
- `skills/discord_reply.py` — 「~1800 字以内に収めろ」という自己切り詰め指示を「サーバが自動分割するので全文送れ」に緩和。

## Acceptance Criteria (Issue #235)

- [x] `reply_chunker.py` に純粋関数 `chunk_discord_content(content, limit=2000)`、各チャンク `len <= 2000`（`tests/test_reply_chunker.py`）
- [x] 2000 字超のコードブロック入力で各チャンクのバッククォート三連符が偶数（フェンスが閉じている）
- [x] 経路B: 3 sink が 1990 字超で `send` を 2 回以上呼び、各 body `len <= 2000`、`…` 切り詰め無し（`tests/test_transcript_mirror_cog.py`）
- [x] 経路B file_sink: 分割時、添付は最後の送信にのみ付与
- [x] 経路A: `/api/reply` に 2000 字超で `send` 2 回以上、全文欠落なし（`tests/test_api_server.py`）
- [x] `pytest` 全グリーン / `ruff check` / `ruff format --check`（c_lord/）/ `pyright` グリーン
- [x] staging（jsonl）で RED 再現 + GREEN 確認（下記 Staging Evidence）

## Definition of Done checklist

- [x] Issue の全 AC を本文にコピーしチェック
- [x] **TDD evidence**: RED → GREEN を確認（下記）
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` 全グリーン
- [x] Staging behavior verified（下記 Staging Evidence）
- [x] 無関係な変更なし / セルフレビュー済み（security-audit: string 処理のみ、subprocess/env/secret に無関係）
- [x] `Closes #235`（本 PR は #235 の全 AC を満たす）

## TDD evidence (RED → GREEN)

RED（実装前、失敗を確認）:
```
tests/test_reply_chunker.py — ModuleNotFoundError: No module named 'c_lord.discord_ui.reply_chunker'
tests/test_api_server.py::...test_long_content_attaches_files_to_last_chunk_only
    assert len(calls) >= 2  → AssertionError: assert 1 >= 2
tests/test_transcript_mirror_cog.py::test_file_sink_chunks_and_attaches_to_last_only
    assert len(calls) >= 2  → AssertionError: assert 1 >= 2
```
GREEN（実装後）: `1275 passed, 9 skipped`。

## Staging Evidence

環境: `/home/yousan/c-lord-parallel-3`（bot `C-lord-3`, `CLORD_BRIDGE_MODE=jsonl` = 本番と同じアクティブ経路B）。同一プロンプト（「行1〜130 を省略せず全行出力」）を webhook 経由で投入。

**RED（修正前 = `feature/clord-text-twin`, 切り詰めコード）**:
```
[C-lord-3] len=1986 ellipsis=True files=0
   head='行1: これは2000文字を超える返答が…'
   tail='...行34: これは2000文字…'
→ 単一メッセージ 1986字・末尾「…」・行34 で打ち切り（行35〜130 が欠落）
```

**GREEN（修正後 = `fix/reply-chunking`）**:
```
=== GREEN chunk messages: 4 ===
  len=1970 <=2000:True ellipsis:False lines=33 range=1..33
  len=1979 <=2000:True ellipsis:False lines=33 range=34..66
  len=1979 <=2000:True ellipsis:False lines=33 range=67..99
  len=1890 <=2000:True ellipsis:False lines=31 range=100..130
--- distinct 行N: 130/130 | over2000: 0 | ellipsis: 0 ---
missing: NONE — ✅ full content delivered, no truncation
```
staging は検証後 idle ブランチ（`fix/wire-max-concurrent-sessions`）に復帰・単一インスタンスで再起動済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
