### PR TITLE
fix: event-driven thread lamp (🟢/🟡) instead of 60s-poll-only (#236)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -135,6 +135,17 @@ class ClaudeChatCog(commands.Cog):
             return False  # DM — no role info
         return self._allowed_user_ids is None
 
+    def is_processing(self, thread_id: int) -> bool:
+        """True while a Claude turn is actively running for ``thread_id``.
+
+        This is the lamp's source of truth for 🟢 ``running`` (#236): the entry
+        registers in ``_active_tasks`` the moment a turn starts and is popped in
+        the ``finally`` block when it finishes. Consumed by
+        :class:`ThreadStateSyncLoop` so the poll never rolls an in-flight thread
+        back to 🟡 ``waiting`` during a brief no-spinner window.
+        """
+        return thread_id in self._active_tasks
+
     @property
     def active_session_count(self) -> int:
         """Number of Claude sessions currently running in this cog."""
@@ -297,6 +308,41 @@ class ClaudeChatCog(commands.Cog):
             # is non-empty, but guards against odd states (e.g. row was
             # just deleted concurrently).
             topic = parse_topic_from_name(thread.name) or "新しいスレッド"
+
+        new_name = build_name(topic, state, window_number)
+        if (thread.name or "") == new_name:
+            return
+        with contextlib.suppress(discord.HTTPException, TimeoutError, asyncio.TimeoutError):
+            await asyncio.wait_for(thread.edit(name=new_name), timeout=5.0)
+
+    async def _set_lamp_state(
+        self,
+        thread: discord.Thread,
+        state: str,
+        tmux_manager,  # TmuxManager | None
+    ) -> None:
+        """Persist ``state`` and repaint the thread-name lamp immediately (#236).
+
+        Lightweight counterpart to :meth:`_apply_thread_naming` — reuses the
+        already-stored topic (no LLM retitle) and the stable ``work{N}`` window
+        number, so the leading 🟢/🟡 flips the instant a turn starts/ends instead
+        of waiting for the ≤60s state-sync poll. No-op when no topic exists yet
+        (the next user-driven naming pass will catch up).
+        """
+        from ..thread_name import build_name
+
+        await self.repo.set_state(thread.id, state)
+
+        record = await self.repo.get(thread.id)
+        topic = record.topic if record else None
+        if not topic:
+            return
+
+        window_number: int | None = None
+        if tmux_manager is not None:
+            info = await asyncio.to_thread(tmux_manager.get_window_info, thread.id)
+            if info is not None:
+                window_number = info[1]
 
         new_name = build_name(topic, state, window_number)
         if (thread.name or "") == new_name:
@@ -962,6 +1008,12 @@ class ClaudeChatCog(commands.Cog):
             if current_task is not None:
                 self._active_tasks[thread.id] = current_task
 
+            # Lamp → 🟢 running immediately, event-driven (#236). Persist the
+            # state now so the rename in _apply_thread_naming below paints the
+            # thread green without waiting for the ≤60s state-sync poll.
+            with contextlib.suppress(Exception):
+                await self.repo.set_state(thread.id, "running")
+
             # Mark thread as PROCESSING when Claude starts
             if dashboard is not None:
                 await dashboard.set_state(
@@ -1096,6 +1148,12 @@ class ClaudeChatCog(commands.Cog):
 
                 with contextlib.suppress(Exception):
                     await coordination.post_session_end(thread)
+
+                # Lamp → 🟡 waiting the instant the turn finishes (#236). Runs
+                # after _active_tasks.pop above, so is_processing() is already
+                # False and the next state-sync poll stays consistent.
+                with contextlib.suppress(Exception):
+                    await self._set_lamp_state(thread, "waiting", tmux_manager)
 
                 if dashboard is not None:
                     with contextlib.suppress(Exception):

--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -35,6 +35,7 @@ from ..discord_ui.embeds import stopped_embed
 from ..discord_ui.status import StatusManager
 from ..discord_ui.thread_dashboard import ThreadState, ThreadStatusDashboard
 from ..discord_ui.views import StopView
+from ..utils.logger import log_ctx
 from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
 
@@ -314,6 +315,12 @@ class ClaudeChatCog(commands.Cog):
             return
         with contextlib.suppress(discord.HTTPException, TimeoutError, asyncio.TimeoutError):
             await asyncio.wait_for(thread.edit(name=new_name), timeout=5.0)
+            logger.info(
+                "%s lamp → %s (event-driven) %r",
+                log_ctx(thread_id=thread.id),
+                state,
+                new_name,
+            )
 
     async def _set_lamp_state(
         self,
@@ -349,6 +356,12 @@ class ClaudeChatCog(commands.Cog):
             return
         with contextlib.suppress(discord.HTTPException, TimeoutError, asyncio.TimeoutError):
             await asyncio.wait_for(thread.edit(name=new_name), timeout=5.0)
+            logger.info(
+                "%s lamp → %s (event-driven) %r",
+                log_ctx(thread_id=thread.id),
+                state,
+                new_name,
+            )
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:

--- a/c_lord/setup.py
+++ b/c_lord/setup.py
@@ -264,7 +264,14 @@ async def setup_bridge(
             interval = float(interval_env)
         except ValueError:
             interval = 60.0
-        sync_loop = ThreadStateSyncLoop(bot, session_repo, interval_seconds=interval)
+        sync_loop = ThreadStateSyncLoop(
+            bot,
+            session_repo,
+            interval_seconds=interval,
+            # Let the poll keep an in-flight thread 🟢 instead of rolling it back
+            # to 🟡 during a brief no-spinner window (#236).
+            is_processing=chat_cog.is_processing,
+        )
         sync_loop.start()
         bot.thread_state_sync = sync_loop  # type: ignore[attr-defined]
         logger.info("Started ThreadStateSyncLoop (interval=%.0fs)", interval)

--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -30,6 +30,7 @@ import contextlib
 import logging
 import re
 import subprocess
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import discord
@@ -213,10 +214,17 @@ class ThreadStateSyncLoop:
         session_repo: SessionRepository,
         *,
         interval_seconds: float = _DEFAULT_INTERVAL_SECONDS,
+        is_processing: Callable[[int], bool] | None = None,
     ) -> None:
         self._bot = bot
         self._repo = session_repo
         self._interval = interval_seconds
+        # Optional callback: True while a Claude turn is actively running for the
+        # thread. Lets the poll keep a thread 🟢 running even when it lands in a
+        # brief no-spinner window (session startup, tool gap) instead of rolling
+        # the event-driven lamp back to 🟡 waiting (#236). Default no-op keeps
+        # the loop self-contained for consumers that don't wire it up.
+        self._is_processing: Callable[[int], bool] = is_processing or (lambda _tid: False)
         self._task: asyncio.Task[None] | None = None
         # Per-thread rate-limit backoff: thread_id → monotonic time until next rename is allowed.
         self._rename_backoff: dict[int, float] = {}
@@ -277,6 +285,11 @@ class ThreadStateSyncLoop:
             window_number: int | None = parse_work_number(window_name)
             pane_text = await asyncio.to_thread(_capture_pane_text, session_name, window_name)
             new_state = _pane_lamp_state(pane_text)
+            # Don't roll an actively-processing thread back to 🟡 just because the
+            # poll landed in a brief no-spinner window (startup / tool gap). Only
+            # promote waiting→running; error stays error (#236).
+            if new_state == "waiting" and self._is_processing(thread_id):
+                new_state = "running"
         else:
             new_state = "dead"
             window_id = record.tmux_window_id

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -671,6 +671,16 @@ class TestInterruptOnNewMessage:
         assert isinstance(cog._active_tasks, dict)
         assert len(cog._active_tasks) == 0
 
+    def test_is_processing_reflects_active_tasks(self) -> None:
+        """is_processing() is the lamp's source of truth for 🟢 running (#236):
+        True iff a Claude turn is currently registered for the thread."""
+        cog = _make_cog()
+        assert cog.is_processing(42) is False
+        cog._active_tasks[42] = MagicMock()
+        assert cog.is_processing(42) is True
+        del cog._active_tasks[42]
+        assert cog.is_processing(42) is False
+
 
 class TestZeroConfigCoordination:
     """_get_coordination() must work without any consumer wiring (Zero-Config Principle).
@@ -1821,12 +1831,22 @@ class TestApplyThreadNamingRetitle:
 
         instruction = "次はDockerfileを最適化してCI/CDを改善してください"
 
-        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value="Dockerfileの最適化")):
-            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message=instruction)
+        with patch.object(
+            cc_module.topic_module,
+            "maybe_retitle",
+            new=AsyncMock(return_value="Dockerfileの最適化"),
+        ):
+            await cog._apply_thread_naming(
+                thread=thread, tmux_manager=tmux, first_message=instruction
+            )
 
-        cog.repo.set_topic.assert_awaited_once_with(55555, "Dockerfileの最適化", source="llm_retitle")
+        cog.repo.set_topic.assert_awaited_once_with(
+            55555, "Dockerfileの最適化", source="llm_retitle"
+        )
         thread.edit.assert_awaited_once()
-        call_name = thread.edit.await_args.kwargs.get("name", thread.edit.await_args.args[0] if thread.edit.await_args.args else "")
+        call_name = thread.edit.await_args.kwargs.get(
+            "name", thread.edit.await_args.args[0] if thread.edit.await_args.args else ""
+        )
         assert "Dockerfileの最適化" in call_name
 
     @pytest.mark.asyncio
@@ -1842,8 +1862,12 @@ class TestApplyThreadNamingRetitle:
 
         instruction = "認証リファクタを引き続きお願いします"
 
-        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value=None)):
-            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message=instruction)
+        with patch.object(
+            cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value=None)
+        ):
+            await cog._apply_thread_naming(
+                thread=thread, tmux_manager=tmux, first_message=instruction
+            )
 
         cog.repo.set_topic.assert_not_awaited()
 
@@ -1857,8 +1881,12 @@ class TestApplyThreadNamingRetitle:
         record = self._make_record(topic="認証リファクタ", locked=1)
         cog, thread, tmux = self._make_cog_with_repo(record)
 
-        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value="new")) as mock_retitle:
-            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="何か作業してください")
+        with patch.object(
+            cc_module.topic_module, "maybe_retitle", new=AsyncMock(return_value="new")
+        ) as mock_retitle:
+            await cog._apply_thread_naming(
+                thread=thread, tmux_manager=tmux, first_message="何か作業してください"
+            )
 
         mock_retitle.assert_not_awaited()
 
@@ -1872,8 +1900,16 @@ class TestApplyThreadNamingRetitle:
         record = self._make_record(topic=None)
         cog, thread, tmux = self._make_cog_with_repo(record)
 
-        with patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock()) as mock_retitle, \
-             patch.object(cc_module.topic_module, "generate_topic", new=AsyncMock(return_value=("初回トピック", "llm"))):
-            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="初回メッセージです")
+        with (
+            patch.object(cc_module.topic_module, "maybe_retitle", new=AsyncMock()) as mock_retitle,
+            patch.object(
+                cc_module.topic_module,
+                "generate_topic",
+                new=AsyncMock(return_value=("初回トピック", "llm")),
+            ),
+        ):
+            await cog._apply_thread_naming(
+                thread=thread, tmux_manager=tmux, first_message="初回メッセージです"
+            )
 
         mock_retitle.assert_not_awaited()

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -343,6 +343,130 @@ async def test_sync_one_skips_rename_when_no_topic():
     fake_thread.edit.assert_not_called()
 
 
+# ── #236: is_processing guard (event-driven lamp must not be rolled back) ──────
+
+
+async def test_sync_one_keeps_running_when_processing_despite_waiting_pane():
+    """A thread the cog reports as actively processing must stay ``running`` even
+    when the poll lands in a brief no-spinner window (startup/tool gap) (#236)."""
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock()
+
+    import discord
+
+    with patch.object(discord, "Thread", fake_thread.__class__):
+        bot = MagicMock()
+        bot.get_channel.return_value = fake_thread
+        # Thread 555 is actively being processed by the cog.
+        loop = ThreadStateSyncLoop(
+            bot, repo, interval_seconds=999, is_processing=lambda tid: tid == 555
+        )
+        rec = _Rec(thread_id=555, state="waiting", topic="処理中", tmux_window_id=None)
+        by_tid = {
+            555: {
+                "window_id": "@7",
+                "window_index": "1",
+                "thread_id": "555",
+                "session_name": "clord",
+                "window_name": "work1",
+            }
+        }
+
+        with (
+            patch.object(thread_state_sync, "discord") as discord_mock,
+            # Pane shows the idle prompt — no spinner yet (startup race).
+            patch.object(thread_state_sync, "_capture_pane_text", return_value="● done\n❯\n"),
+        ):
+            discord_mock.Thread = fake_thread.__class__
+            discord_mock.HTTPException = Exception
+            await loop._sync_one(rec, by_tid)
+
+    repo.set_state.assert_awaited_once_with(555, "running")
+
+
+async def test_sync_one_waiting_when_not_processing():
+    """Without the is_processing guard (or when it returns False), a no-spinner
+    pane still resolves to ``waiting`` — existing behavior preserved (#236)."""
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock()
+
+    import discord
+
+    with patch.object(discord, "Thread", fake_thread.__class__):
+        bot = MagicMock()
+        bot.get_channel.return_value = fake_thread
+        loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999, is_processing=lambda tid: False)
+        rec = _Rec(thread_id=556, state="running", topic="入力待ち", tmux_window_id=None)
+        by_tid = {
+            556: {
+                "window_id": "@8",
+                "window_index": "2",
+                "thread_id": "556",
+                "session_name": "clord",
+                "window_name": "work2",
+            }
+        }
+
+        with (
+            patch.object(thread_state_sync, "discord") as discord_mock,
+            patch.object(thread_state_sync, "_capture_pane_text", return_value="● done\n❯\n"),
+        ):
+            discord_mock.Thread = fake_thread.__class__
+            discord_mock.HTTPException = Exception
+            await loop._sync_one(rec, by_tid)
+
+    repo.set_state.assert_awaited_once_with(556, "waiting")
+
+
+async def test_sync_one_error_overrides_processing_guard():
+    """The is_processing guard only promotes waiting→running; an error pane must
+    still win (#236)."""
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock()
+
+    import discord
+
+    with patch.object(discord, "Thread", fake_thread.__class__):
+        bot = MagicMock()
+        bot.get_channel.return_value = fake_thread
+        loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999, is_processing=lambda tid: True)
+        rec = _Rec(thread_id=557, state="running", topic="エラー", tmux_window_id=None)
+        by_tid = {
+            557: {
+                "window_id": "@9",
+                "window_index": "3",
+                "thread_id": "557",
+                "session_name": "clord",
+                "window_name": "work3",
+            }
+        }
+
+        with (
+            patch.object(thread_state_sync, "discord") as discord_mock,
+            patch.object(thread_state_sync, "_capture_pane_text", return_value="APIError: boom\n"),
+        ):
+            discord_mock.Thread = fake_thread.__class__
+            discord_mock.HTTPException = Exception
+            await loop._sync_one(rec, by_tid)
+
+    repo.set_state.assert_awaited_once_with(557, "error")
+
+
 class _FakeHTTPException(Exception):
     """Minimal discord.HTTPException stand-in for rate-limit tests."""
 


### PR DESCRIPTION
## What does this PR do?

スレッド名先頭の状態ランプ（🟢 running / 🟡 waiting）を **イベント駆動** にした。

- `ClaudeChatCog`: ターン開始の瞬間に `state="running"` を永続化 → 直後の `_apply_thread_naming` のリネームで即 🟢。
- 軽量ヘルパー `_set_lamp_state()`: ターン終了時（`finally`）に即 🟡 へ。保存済み topic + `work{N}` 番号を再利用し LLM 呼び出しなし。
- `ClaudeChatCog.is_processing()`: 処理中スレッド集合（`_active_tasks`）を公開。`ThreadStateSyncLoop` が参照し、起動直後/ツール間の「スピナー未表示の一瞬」にポーリングが in-flight スレッドを 🟡 へ巻き戻すのを防ぐ。error/dead は優先。
- ポーリングは error/dead 検出と非 cog セッションのバックストップとして存続。
- `lamp → <state> (event-driven)` の構造化ログ（`log_ctx`）を追加。

## Why?

Closes #236

従来はランプが 60 秒ポーリングのみで駆動され、メッセージ受信後 🟡→🟢 が最大 60 秒遅延。短いターンでは「処理終了間際に緑→すぐ黄色」と不自然だった。受信即 🟢 / 最終返信完了で 🟡 が自然。

## Acceptance Criteria (copied from the issue)

- [x] メッセージ受信 → Claude 起動確定の時点でランプが 🟢 になる（ポーリング tick を待たない）。staging ログで確認。
- [x] 最終返信完了時にランプが 🟡 に戻る（`finally` 経路）。staging ログで確認。
- [x] error / dead 状態は従来どおりポーリングで検出（回帰なし）。`test_sync_one_error_overrides_processing_guard` 担保。
- [x] イベントで 🟢 にした直後の tick が処理中セッションを 🟡 に巻き戻さない。`test_sync_one_keeps_running_when_processing_despite_waiting_pane`。
- [x] 既存テスト green + 新規 RED→GREEN ユニットテスト追加。
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` all green。

## Staging Evidence

staging (`c-lord-parallel-3`, bot `C-lord-3`) に本ブランチをデプロイし、既存セッションスレッドへ webhook 投入。

GREEN (after):
```
10:26:21  webhook 送信
10:26:22  [thread=...] lamp → running (event-driven) '🟢 W5 │ チャンクテスト'   ← 受信から ~1s（処理開始前）
10:26:22  run_claude: enter
10:26:31  run_claude: exit
10:26:32  [thread=...] lamp → waiting (event-driven) '🟡 W5 │ チャンクテスト'   ← 完了から ~1s
```

RED (before) — 修正前はリネームが 60 秒ポーリングのみ（prod ログ）。`(event-driven)` 行はそもそも存在しない（コードパス無し）:
```
09:58:08  state-sync: renamed thread ... → '🟢 ...' (state=running)
09:59:10  state-sync: renamed thread ... → '🟡 ...' (state=waiting)   ← ~62s 後
```

検証後 staging は idle ブランチ (`fix/wire-max-concurrent-sessions`) に復帰・単一インスタンスで再起動済み。
注: staging API (8089) が本セッションから応答しないため AI Lounge への borrow/解放通知は API 経由不可（staging は idle ブランチ駐機＝フリー状態のため借用）。

## TDD evidence

実装前 RED:
```
TypeError: ThreadStateSyncLoop.__init__() got an unexpected keyword argument 'is_processing'
AttributeError: 'ClaudeChatCog' object has no attribute 'is_processing'
```
実装後 GREEN: 該当 2 ファイル 127 passed、全体 1268 passed / 9 skipped。

## Security

cog を変更したが subprocess 起動 / env 処理 / `--resume`・session-id・skill-name 経路には未接触。追加は `repo.set_state`、`thread.edit`（`build_name` で 30 字上限）、純粋コールバックのみ。注入面の変化なし。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)