### PR TITLE
feat: bridge AskUserQuestion to Discord for non-run_claude turns via mirror (#232)

### DIFF
--- a/c_lord/cogs/transcript_mirror.py
+++ b/c_lord/cogs/transcript_mirror.py
@@ -149,6 +149,7 @@ class TranscriptMirrorCog(commands.Cog):
             file_sink=file_sink,
             reply_cursor_sink=reply_cursor_sink,
             verbosity=verbosity_mode(),
+            ask_bridge_cb=self._make_ask_bridge(thread_id),
         )
         mirror.start()
         self._mirrors[thread_id] = mirror
@@ -180,6 +181,47 @@ class TranscriptMirrorCog(commands.Cog):
                 await self._session_repo.set_mirror_replied_uuid(thread_id, uuid)
 
         return cursor_sink
+
+    def _make_ask_bridge(self, thread_id: int):
+        """Return an async cb that bridges an AskUserQuestion menu to Discord (#232).
+
+        Builds a TmuxClaudeRunner for the thread's tmux window (to deliver the
+        chosen option as menu keystrokes) and shows Discord buttons via
+        ``bridge_pane_ask`` — so a menu raised outside a bot ``run_claude`` turn
+        (e.g. autonomous task-notification continuation) is no longer leaked.
+        """
+        bot = self.bot
+
+        async def ask_bridge(question) -> None:
+            from ..claude.tmux_runner import TmuxClaudeRunner
+            from ..discord_ui.ask_bus import ask_bus
+            from ..discord_ui.ask_handler import bridge_pane_ask
+            from .channel_repo import ChannelRepoCog
+
+            # Defer to the run_claude poll-loop bridge if it already owns this menu.
+            if ask_bus.is_active(thread_id):
+                return
+            channel = await self._resolve_channel(bot, thread_id)
+            if not isinstance(channel, discord.Thread):
+                return
+            parent_id = getattr(channel, "parent_id", None) or thread_id
+            channel_cog = bot.get_cog("ChannelRepoCog")
+            tmux_manager = None
+            if isinstance(channel_cog, ChannelRepoCog):
+                tmux_manager = await channel_cog.resolve_tmux_manager(parent_id)
+            if tmux_manager is None:
+                tmux_manager = getattr(bot, "tmux_manager", None)
+            if tmux_manager is None:
+                logger.warning(
+                    "TranscriptMirror ask-bridge: no tmux manager for thread=%d", thread_id
+                )
+                return
+            runner = TmuxClaudeRunner(tmux_manager=tmux_manager, thread_id=thread_id)
+            await bridge_pane_ask(
+                channel, question, runner, ask_repo=getattr(bot, "ask_repo", None)
+            )
+
+        return ask_bridge
 
     def _make_sink(self, thread_id: int):
         """Return an awaitable callable that posts intermediate messages silently."""

--- a/c_lord/discord_ui/ask_bus.py
+++ b/c_lord/discord_ui/ask_bus.py
@@ -40,6 +40,15 @@ class AskAnswerBus:
         logger.debug("AskAnswerBus: registered waiter for thread %d", thread_id)
         return q
 
+    def is_active(self, thread_id: int) -> bool:
+        """Return True if a bridge is currently waiting for an answer on *thread_id*.
+
+        Used to dedup between the run_claude poll-loop bridge and the always-on
+        transcript-mirror bridge (#232): whichever registers first owns the
+        menu; the other must not show a second set of buttons.
+        """
+        return thread_id in self._waiters
+
     def post_answer(self, thread_id: int, answers: list[str]) -> bool:
         """Deliver *answers* to the coroutine waiting for *thread_id*.
 

--- a/c_lord/transcript/mirror.py
+++ b/c_lord/transcript/mirror.py
@@ -24,9 +24,11 @@ import contextlib
 import logging
 import os
 import tempfile
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from pathlib import Path
 
+from ..claude.types import AskQuestion, _parse_ask_questions
+from ..discord_ui.ask_bus import ask_bus
 from .formatter import RenderedEvent, render_event
 from .tail import tail_events
 
@@ -34,6 +36,36 @@ logger = logging.getLogger(__name__)
 
 Sink = Callable[[str], Awaitable[None]]
 FileSink = Callable[[str, str], Awaitable[None]]
+# Called with the first AskUserQuestion of a tool_use to bridge it to Discord
+# buttons (#232). Constructed by TranscriptMirrorCog (knows tmux + thread).
+AskBridgeCb = Callable[[AskQuestion], Coroutine[object, object, None]]
+
+
+def _first_ask_question(event: dict) -> AskQuestion | None:
+    """Extract the first AskUserQuestion menu from a raw transcript event.
+
+    #232: AskUserQuestion is a main-agent tool whose ``tool_use`` always lands
+    in the JSONL transcript (richer than pane scraping). The mirror tails this,
+    so a menu raised outside a bot ``run_claude`` turn (e.g. autonomous
+    task-notification continuation) can still be bridged. Returns ``None`` when
+    the event is not an AskUserQuestion tool_use. Only the first question is
+    returned — the pane answers one menu at a time (multi-question is a known
+    limitation shared with the in-pane bridge).
+    """
+    content = event.get("message", {}).get("content")
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if (
+            isinstance(block, dict)
+            and block.get("type") == "tool_use"
+            and block.get("name") == "AskUserQuestion"
+        ):
+            questions = _parse_ask_questions(block.get("input", {}) or {})
+            if questions and questions[0].options:
+                return questions[0]
+    return None
+
 
 # Kinds that are buffered (not posted individually) in minimal mode.
 _BUFFERED_KINDS = frozenset({"tool_use", "tool_result"})
@@ -143,12 +175,17 @@ class TranscriptMirror:
         verbosity: str = "minimal",
         poll_interval: float = 0.5,
         idle_flush_seconds: float | None = None,
+        ask_bridge_cb: AskBridgeCb | None = None,
     ) -> None:
         self.thread_id = thread_id
         self.project_dir = project_dir
         self._sink = sink
         self._reply_sink = reply_sink
         self._file_sink = file_sink
+        # #232: bridges an AskUserQuestion menu (detected in the transcript) to
+        # Discord buttons even when no run_claude poll loop is active.
+        self._ask_bridge_cb = ask_bridge_cb
+        self._ask_bridge_task: asyncio.Task[None] | None = None
         # Issue #215: called with the uuid of the last assistant_text of each
         # completed turn, so a restart can tell whether the final answer was
         # already delivered and avoid re-posting it.
@@ -175,6 +212,44 @@ class TranscriptMirror:
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await task
         self._task = None
+        await self._cancel_ask_bridge()
+
+    async def _cancel_ask_bridge(self) -> None:
+        t = self._ask_bridge_task
+        if t is None:
+            return
+        t.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await t
+        self._ask_bridge_task = None
+
+    def _maybe_bridge_ask(self, event: dict) -> None:
+        """Bridge an AskUserQuestion menu found in *event* to Discord buttons (#232).
+
+        Runs regardless of bridge-trigger source (human / task-notification /
+        autonomous). Dedups against the run_claude poll-loop bridge via
+        ``ask_bus.is_active`` (whoever registers first owns the menu) and against
+        itself via the pending task guard. The bridge is spawned as a background
+        task because it awaits the user's click for up to 24h — awaiting inline
+        would freeze transcript tailing.
+        """
+        if self._ask_bridge_cb is None:
+            return
+        if self._ask_bridge_task is not None and not self._ask_bridge_task.done():
+            return
+        if ask_bus.is_active(self.thread_id):
+            return
+        question = _first_ask_question(event)
+        if question is None:
+            return
+        logger.info(
+            "TranscriptMirror: bridging post-turn AskUserQuestion thread=%d header=%r",
+            self.thread_id,
+            question.header,
+        )
+        self._ask_bridge_task = asyncio.create_task(
+            self._ask_bridge_cb(question), name=f"mirror-ask-bridge-{self.thread_id}"
+        )
 
     async def _run(self) -> None:
         logger.info(
@@ -268,6 +343,10 @@ class TranscriptMirror:
                         await _commit_cursor()
                     continue
 
+                # #232: bridge an open AskUserQuestion menu regardless of
+                # verbosity / turn-end / who triggered the turn.
+                self._maybe_bridge_ask(event)
+
                 if self._verbosity == "minimal" and _is_turn_end(event):
                     # Turn boundary: flush pending as the final reply.
                     await _flush_pending_as_reply()
@@ -308,6 +387,7 @@ class TranscriptMirror:
             producer.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await producer
+            await self._cancel_ask_bridge()
             if self._verbosity == "minimal":
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await _flush_pending_as_reply()

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -8,7 +8,13 @@ from pathlib import Path
 
 import pytest
 
-from c_lord.transcript.mirror import TranscriptMirror, bridge_mode_jsonl, verbosity_mode
+from c_lord.discord_ui.ask_bus import ask_bus
+from c_lord.transcript.mirror import (
+    TranscriptMirror,
+    _first_ask_question,
+    bridge_mode_jsonl,
+    verbosity_mode,
+)
 
 
 def _write_event(path: Path, payload: dict) -> None:
@@ -806,3 +812,131 @@ async def test_minimal_idle_does_not_prematurely_flush_intermediate_text(
         assert not any("working on it" in r for r in replies), replies
     finally:
         await mirror.stop()
+
+
+# -- #232: AskUserQuestion bridge for non-run_claude (mirror-driven) sessions ----
+
+
+def _assistant_ask(header: str = "進め方") -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "AskUserQuestion",
+                    "input": {
+                        "questions": [
+                            {
+                                "question": "どの粒度で進めますか?",
+                                "header": header,
+                                "options": [
+                                    {"label": "A案", "description": "その場"},
+                                    {"label": "B案", "description": "新規"},
+                                ],
+                            }
+                        ]
+                    },
+                }
+            ],
+        },
+    }
+
+
+def test_first_ask_question_parses_tool_use() -> None:
+    q = _first_ask_question(_assistant_ask())
+    assert q is not None
+    assert q.header == "進め方"
+    assert q.question == "どの粒度で進めますか?"
+    assert [o.label for o in q.options] == ["A案", "B案"]
+
+
+def test_first_ask_question_ignores_non_ask_events() -> None:
+    assert _first_ask_question(_assistant_text("hi")) is None
+    assert _first_ask_question(_assistant_tool_use(name="Bash")) is None
+    assert _first_ask_question({"type": "assistant", "message": {}}) is None
+
+
+def test_ask_bus_is_active_tracks_waiters() -> None:
+    tid = 23223223
+    assert ask_bus.is_active(tid) is False
+    ask_bus.register(tid)
+    try:
+        assert ask_bus.is_active(tid) is True
+    finally:
+        ask_bus.unregister(tid)
+    assert ask_bus.is_active(tid) is False
+
+
+async def test_mirror_bridges_ask_to_cb(tmp_path: Path) -> None:
+    """#232: an AskUserQuestion menu tailed from the transcript is bridged via
+    the callback even with no run_claude turn active."""
+    import os
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    os.utime(jsonl, (1, 1))
+
+    called = asyncio.Event()
+    captured: dict = {}
+
+    async def sink(text: str) -> None:
+        pass
+
+    async def ask_cb(question) -> None:
+        captured["q"] = question
+        called.set()
+
+    mirror = TranscriptMirror(
+        thread_id=2320001, project_dir=project, sink=sink, poll_interval=0.05, ask_bridge_cb=ask_cb
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.15)
+        _write_event(jsonl, _assistant_ask("進め方"))
+        await asyncio.wait_for(called.wait(), timeout=3)
+    finally:
+        await mirror.stop()
+
+    assert captured["q"].header == "進め方"
+    assert [o.label for o in captured["q"].options] == ["A案", "B案"]
+
+
+async def test_mirror_skips_ask_when_bus_active(tmp_path: Path) -> None:
+    """#232 dedup: when a bridge is already active (run_claude owns the menu via
+    ask_bus), the mirror must NOT spawn a second bridge."""
+    import os
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    os.utime(jsonl, (1, 1))
+
+    tid = 2320002
+    spawned = False
+
+    async def sink(text: str) -> None:
+        pass
+
+    async def ask_cb(question) -> None:
+        nonlocal spawned
+        spawned = True
+
+    ask_bus.register(tid)  # simulate run_claude already bridging
+    mirror = TranscriptMirror(
+        thread_id=tid, project_dir=project, sink=sink, poll_interval=0.05, ask_bridge_cb=ask_cb
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.15)
+        _write_event(jsonl, _assistant_ask())
+        await asyncio.sleep(0.4)
+    finally:
+        await mirror.stop()
+        ask_bus.unregister(tid)
+
+    assert spawned is False


### PR DESCRIPTION
## What does this PR do?

`run_claude`（Discord メッセージ起点のポーリングループ）を**経由しないターン**で開いた `AskUserQuestion` メニューを、TranscriptMirror から検知して Discord ボタンにブリッジする。

- `TranscriptMirror` は既に JSONL を tail している。AskUserQuestion はメインエージェントのツールで `tool_use` が必ず transcript に出るので、そこで検知（`_first_ask_question`）。
- run_claude poll ループのブリッジと **`ask_bus.is_active` で dedup**（先に register した方がメニューを所有）。
- ブリッジは**バックグラウンドタスク**で実行（クリックを最大24h待つため、tail をブロックしない）。
- `TranscriptMirrorCog` が thread の tmux manager から `TmuxClaudeRunner` を構築し、選択を menu keystroke で pane に送る（`bridge_pane_ask` 再利用）。

## Why?

実機（thread `1509023137600114830`, 2026-05-28 21:58 JST）で、`<task-notification>`（バックグラウンド bash 完了通知）駆動の自律継続ターン中にメインが出した AskUserQuestion が Discord に出ず固着した。これは run_claude を経由しない継続ターンのメニューが leak する未カバー領域だった。#179/#219/#222 は run_claude 経路のみを直していた。

Closes #232

## Acceptance Criteria (copied from the issue)

- [x] **漏れのない検証**: 引き金別に決定論的ユニットで網羅（下記）。staging ライブは #179/#222 同様に環境制約（opus 長考/自律継続の決定論的再現が困難）のためベストエフォート＋本番 redeploy 後の実機観測で確認する方針（オーナー合意）。
  - (a) run_claude 駆動: 既存 #179/#219/#222 のテストで回帰担保 + 本 PR の dedup テスト（ask_bus.is_active=run_claude 所有時は mirror が二重ブリッジしない）
  - (b) task-notification 自律継続: `test_mirror_bridges_ask_to_cb` が「run_claude 無しで transcript の AskUserQuestion を検知→bridge」を決定論的に再現（=自律継続経路そのもの）
  - (c) post-turn: #222（peek_pending_ask, merged）+ 本 mirror 経路で二重に担保
- [x] 同一メニューが二重ブリッジされない（`test_mirror_skips_ask_when_bus_active` + バックグラウンドタスク pending ガード）
- [x] メニューが閉じた/回答後は再ブリッジしない（タスク完了後のみ再スポーン、`stop()` でキャンセル）
- [x] 検知は transcript の `tool_use` を主信号にしている（`_first_ask_question`、pane 専用検知に非依存）
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` すべて green

## Staging Evidence

決定論的ユニットを再現の主証拠とする（オーナー合意「決定論テスト主＋staging は可能な範囲」）。本バグはタイミングではなく**経路の欠落**なので、ユニットが本質を直接捕捉する:

```
新規 5 tests（GREEN）:
  test_first_ask_question_parses_tool_use         # tool_use → AskQuestion
  test_first_ask_question_ignores_non_ask_events  # text/Bash/空 は None
  test_ask_bus_is_active_tracks_waiters           # dedup プリミティブ
  test_mirror_bridges_ask_to_cb                   # run_claude 無しで bridge 発火（=自律継続経路）
  test_mirror_skips_ask_when_bus_active           # run_claude 所有時は二重ブリッジしない
full suite: 1247 passed, 9 skipped
```

実機の最終確認は **本番 redeploy 後**に「自律継続中に出たメニュー → Discord にボタン」を観測して行う（このセッションでの観測を #232 にログ追記予定）。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: 新規テストで RED→GREEN（bridge 発火/dedup は実装前は呼ばれない→実装後 awaited once）
- [x] `uv run pytest tests/ -v` passes （1247 passed, 9 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in — 決定論ユニットで代替、実機は redeploy 後観測（オーナー合意）と明記
- [x] No unrelated changes in the diff; self-review done（4 files）
- [x] `Closes #N` used only if 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)
