### PR TITLE
docs: 開発プロセス・証跡ルールの再定義 (.github テンプレ + CLAUDE.md + DESIGN_DECISIONS)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,18 +4,55 @@ about: Something isn't working as expected
 labels: bug
 ---
 
-## What happened?
+<!-- One Issue = one concern. If this bug bundles a second problem or an
+     open-ended design task, split it into a separate Issue. -->
 
-<!-- Describe the bug -->
+## Why does this matter? (何のため)
 
-## What did you expect?
+<!-- Why is this a problem from a USER's point of view? What can't they do, or
+     what is confusing/broken when they use it? This is the spine: an Issue is
+     read after it's closed to trace "why was this decided this way", so state
+     the intent, not just the symptom. -->
+
+## What happened? (現象)
+
+<!-- Describe the bug in user-facing terms. Attach evidence — screenshots are
+     the主役 (a text log alone hides layout/UI problems). A Discord screenshot
+     (ideally tmux behaviour × Discord screen) is what the maintainer judges
+     "spec vs bug" from. Paste long logs inside <details>. -->
+
+<details>
+<summary>logs / pane capture (optional)</summary>
+
+```
+<tmux pane capture or log excerpt>
+```
+</details>
+
+## What did you expect? (期待)
 
 <!-- What should have happened instead -->
 
-## How to reproduce
+## How to reproduce (再現手順)
+
+<!-- Reproduction is required. Prefer steps that reproduce on STAGING — a fix
+     is only "done" once RED→GREEN is shown on the real bot, not just in mocks. -->
 
 1. ...
 2. ...
+
+## Acceptance Criteria (二値)
+
+<!-- Each AC must be objectively true/false: a command to run, an observable
+     output, a state to assert. No "should probably" / "consider". -->
+
+- [ ] AC 1: …
+- [ ] AC 2: …
+
+## Out of scope / follow-ups (スコープ外)
+
+<!-- Anything explicitly NOT handled here. Link the follow-up Issue — silence is
+     not a decision. -->
 
 ## Environment
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,14 +4,34 @@ about: Suggest a new feature
 labels: enhancement
 ---
 
-## What problem are you trying to solve?
+<!-- One Issue = one concern. If the title needs an "and", it is probably two
+     Issues — split it. -->
 
-<!-- Describe the use case -->
+## Why? (何のため)
 
-## Proposed solution
+<!-- The spine. Why is this worth doing, from a USER's point of view? What
+     becomes possible or less painful? An Issue is read after it's closed to
+     trace the reasoning, so make the intent explicit — not just "add X". -->
 
-<!-- How would you like it to work? -->
+## Proposed solution (提案)
 
-## Alternatives considered
+<!-- How would you like it to work? Add a sketch / before-after preview /
+     screenshot where it helps the reader picture the result. -->
 
-<!-- Any other approaches you've thought about -->
+## Acceptance Criteria (二値)
+
+<!-- Each AC must be objectively true/false (a command, an observable output, a
+     state to assert). Decide open questions before filing — no "A案 or B案"
+     left in the AC list. -->
+
+- [ ] AC 1: …
+- [ ] AC 2: …
+
+## Alternatives considered (検討した代替案)
+
+<!-- Any other approaches you've thought about, and why not -->
+
+## Out of scope / follow-ups (スコープ外)
+
+<!-- What this Issue does NOT cover. Link the follow-up Issue if deferred —
+     silence is not a decision. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,21 @@
+<!-- 30-second summary first. A reviewer should be able to judge this PR from the
+     top: What / Why / Proof / Tests / Scope. Be comprehensive; fold long logs or
+     code into <details><summary>…</summary> so the body stays readable. -->
+
 ## What does this PR do?
 
 <!-- Brief description of the change -->
 
 ## Why?
 
-<!-- What problem does this solve? -->
-<!-- Link the issue. Use "Closes #N" ONLY if this PR satisfies 100% of that
-     issue's Acceptance Criteria. Otherwise use "Refs #N" and keep it open. -->
+<!-- What problem does this solve, from a user's point of view? -->
+
+<!-- Link the issue on ITS OWN LINE (not inside a bullet list — GitHub won't
+     parse the keyword reliably inside a `- ` item). Use "Closes #N" or
+     "Resolves #N" ONLY if this PR satisfies 100% of that issue's Acceptance
+     Criteria. Otherwise use "Refs #N" and keep the issue open. -->
+
+Refs #
 
 ## Acceptance Criteria (copied from the issue)
 
@@ -15,23 +24,39 @@
 - [ ] AC 1: …
 - [ ] AC 2: …
 
-## Staging Evidence
+## Staging Evidence (証跡)
 
 <!-- REQUIRED for behavior changes (bug fixes / features).
      Skip ONLY for pure-docs or provably no-behavior-change refactors —
      and if you skip, write the reason here.
-     Paste log excerpts: RED = problem reproduced before the fix,
-     GREEN = problem gone after the fix, on the staging bot. -->
 
-<!-- RED (before):
+     Show RED→GREEN reproduced ON STAGING (not just mocks):
+       RED  = problem reproduced before the fix
+       GREEN = problem gone after the fix
+     Include timestamp / thread / branch hash, and clickable URLs.
+
+     Discord-side proof: a Discord screenshot is the主役 and is normally
+     USER-PROVIDED (the server-side agent has no GUI and cannot screenshot the
+     Discord client). The agent supplements with tmux pane captures and
+     REST-fetched message text. Fold long excerpts into <details>. -->
+
+<details>
+<summary>RED (before) — reproduced on staging</summary>
+
 ```
-<log excerpt showing the problem on staging>
+<log excerpt / pane capture showing the problem>
 ```
-GREEN (after):
+</details>
+
+<details>
+<summary>GREEN (after) — fixed on staging</summary>
+
 ```
-<log excerpt showing it fixed on staging>
+<log excerpt / pane capture showing it fixed>
 ```
--->
+</details>
+
+Discord screenshot (user-provided): <attach / link>
 
 ## Definition of Done checklist
 
@@ -46,4 +71,4 @@ See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.
 - [ ] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
 - [ ] Staging Evidence above is filled in (or a skip reason is written)
 - [ ] No unrelated changes in the diff; self-review done
-- [ ] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)
+- [ ] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met (else `Refs #N`), and written on its own line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,19 @@ CONTRIBUTING.md          # Contribution guidelines
 2. Export from `__init__.py` if it's part of the public API
 3. Test edge cases (empty strings, very long strings, Unicode, code blocks)
 
+## 開発の行動規範 (Working Conduct) — Issue/PR の前提
+
+このリポジトリで AI が作業するときの上位ルール。Issue/PR/証跡の各規律はこの上に乗る。
+背景と経緯は `docs/DESIGN_DECISIONS.md` → "Working agreements" を参照。
+
+- **質問にはまず答える。質問を黙って作業に変換しない。** 「なぜここで〜なの？」「これは仕様？バグ？」は**診断の依頼**であって作業指示ではない。spec か bug かを、**実機の挙動の証跡**（スクショ / メッセージ URL / 観測）と**経緯 (Why)** で答えてから作業に入る。「コードが X だから」は挙動の説明であって仕様判定の答えにはならない（コードは意図を語れない）。
+- **自走の範囲＝合意済みの作業。** 「やる」と決まった作業は **PR → 手動QA → マージ → 本番デプロイ → 本番実測**まで自走してよい（途中で逐一停止しなくてよい）。ただし起点の問いはまだ作業ではない → 診断して合意してから着手する。
+- **柔らかい依頼（「ここ直ってる？」）は「答え→行動」の順で分離する。** 例:「直っていません。これは仕様ではなくバグです。→ 直しました: PR #NNN / Evidence: <URL>」。先頭で事実に答えれば、相手が「答えだけ欲しかった」場合も意図のズレに気づける。安価で可逆なら先回り可。**設計変更・破壊操作・不可逆な判断は推察で走らず一行確認**。
+- **迎合しない・鵜呑みにしない。** 事実ベースで判断し、報告と食い違えば指摘する。ユーザーの仮説も自分のデータで確認し、違えばその判断を優先して伝える。
+- **コードより先に実機の挙動を見る。** 内部実装を熟知した開発者目線ではなく、**利用者目線で「使って不便か」**を確認する。これが無いと、その Issue/PR が何のためにあるか（Why）が掴めない。
+- **報告は簡潔・日本語・URL はクリッカブルに。** 完了は `#NNN done / PR #MMM / Evidence: <URL>` を1行で。実機未確認なら「テスト緑・実機未確認」と正直に書く（過大申告しない）。
+- **Issue/PR はテンプレートに従う** (`.github/ISSUE_TEMPLATE/`, `.github/pull_request_template.md`)。テンプレが各規律を書式で強制する。
+
 ## Definition of Done (DoD) — single source of truth
 
 **A change is "done" only when every box below is checked. This list is the one
@@ -352,9 +365,9 @@ A PR may be merged only when:
 - [ ] **TDD evidence**: the new test failed before the change (RED) and passes after (GREEN). Paste the RED failure line.
 - [ ] **Detection bug fixture rule**: if the fix targets a TUI prompt detection function (`_has_permission_prompt`, `_is_yn_prompt`, `_has_unknown_interactive`), add a real captured pane snapshot to `tests/fixtures/panes/` **before** writing the fix. The fixture must reproduce the bug (i.e. the broken detection returns a wrong value on that snapshot).
 - [ ] **`pytest` + `ruff check` + `ruff format --check` + `pyright` all green** (CI covers this).
-- [ ] **Staging behavior verified** (unless the [skip exceptions](#動作確認スキーム-必須) apply): RED reproduced + GREEN confirmed on staging, with log excerpts pasted under a `## Staging Evidence` heading. **An empty Staging Evidence section = not done.**
-- [ ] **No unrelated changes** in the diff; self-review done.
-- [ ] **Closes gating**: use `Closes #N` **only if this PR satisfies 100% of that Issue's ACs**. If any AC is deferred, use `Refs #N` instead and leave the Issue open with a comment naming what remains. Never let a partial PR auto-close an Issue.
+- [ ] **Staging behavior verified** (unless the [skip exceptions](#動作確認スキーム-必須) apply): RED reproduced + GREEN confirmed **on staging** (not just mocks), with log excerpts pasted under a `## Staging Evidence` heading (timestamp / thread / branch hash, clickable URLs). **Discord 側の証跡はユーザー提供のスクリーンショットが主**（サーバ上の AI は GUI を持たず Discord クライアントの画面を撮れない）。AI は **tmux ペインキャプチャ + REST 取得メッセージ本文**で補強する。長いログは `<details>` で畳む。**An empty Staging Evidence section = not done.**
+- [ ] **No unrelated changes** in the diff; self-review done (`git diff main` が当該変更だけかを確認)。
+- [ ] **Closes gating**: use `Closes #N` / `Resolves #N` **only if this PR satisfies 100% of that Issue's ACs**. If any AC is deferred, use `Refs #N` instead and leave the Issue open with a comment naming what remains. **キーワードは箇条書き (`- `) の中に入れず独立行に正確に書く**（リスト内だと GitHub が拾わない）。Never let a partial PR auto-close an Issue.
 
 If you cannot check a box, the change is not done — do not merge. State the
 blocker in the PR instead of silently dropping it.
@@ -364,6 +377,10 @@ blocker in the PR instead of silently dropping it.
 Most "completed but actually missing half" failures start at the Issue, not the
 PR. When you (or Opus) author an Issue:
 
+- **修正の前に必ず Issue 化し、ブランチを紐付ける。** 勝手に直し始めない（診断と合意が先）。
+- **Why を必ず書く（背骨）。** 「この修正/実装は何のためか」を利用者目線で明記する。Issue は**クローズ後も「どういう考えでそうなったか」を辿る記録**なので、症状だけでなく意図を残す。Why が無いと次の判断ができない。
+- **証跡（スクショ）を Issue にも残す。** テキストログだけでは表出しない問題（レイアウト・UI・ランプ状態など）があるため、**スクリーンショット**（理想は tmux の動作 × Discord の動作を合成した画像）で「リアルな問題」を示す。ユーザー提供のスクショは可能な限り Issue に入れる。網羅性を優先し、長いログ/コードは `<details><summary>` で畳んで可読性を保つ。
+- **本文は常に「現在の真実」に保つ。** 相談で方針が変わったら 概要/原因/AC を実態に書き換える。ただし**重要な書き換えは日付つきコメントで「何を・なぜ変えたか」を一次記録として残す**（後続コメントがどの版の本文を前提にしていたか辿れるように）。積み残しは新規 Issue 乱立ではなく**再オープン＋コメント**で残す。
 - **One Issue = one concern.** Do not bundle a bug fix with a design/enhancement task, or two unrelated behaviors, in one Issue. Bundling lets an agent satisfy the easy/testable half, write `Closes`, and auto-close the rest into oblivion. Split into separate Issues.
 - **Acceptance Criteria must be binary and unambiguous** — each AC is a checkbox that is objectively true or false (a command to run, an observable output, a state to assert). No "should probably", no "consider", no open options ("A案 or B案") left in the AC. Decide before filing; move discussion out of the AC list.
 - **Keep scope narrow.** If the Issue's title needs an "and", it is probably two Issues. A wide守備範囲 is where definitions go soft and items leak.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -259,3 +259,54 @@ Three compounding root causes, none of them "the bot is buggy":
 caution, and the operational rules above (kill by explicit PID, count with
 `ps`, launch with `setsid -f`) are the standard procedure. Net: one bot per
 env, no token churn, no cross-clone collateral.
+
+## 14. Working agreements (how Issues / PRs / evidence are run)
+
+**Decision:** The maintainer's working conduct is codified in three layers, kept
+separate so commands stay terse and rationale stays traceable:
+
+1. **CLAUDE.md = commands only** — the "開発の行動規範 (Working Conduct)" section
+   plus the Issue/PR/DoD rules. Imperative, short.
+2. **`.github` templates = enforcement by form** — the Issue and PR templates make
+   each rule a field the author must fill (Why, binary ACs, scope-out, Staging
+   Evidence with screenshots, `<details>` for long logs).
+3. **This file = the why** — rationale and the conversation that produced each rule.
+
+The agreed rules:
+
+- **Answer the question first; don't silently turn a question into work.** An
+  opening question ("why is the menu not showing?", "is this spec or a bug?") is a
+  request for a *diagnosis*, not a work order. Diagnose (spec vs bug) from real
+  behaviour + the Why, then act once it's agreed.
+- **Autonomy applies to agreed work only.** Once "we're fixing X" is settled, the
+  agent may self-run through PR → manual QA → merge → prod redeploy → prod
+  measurement. The opening question is *not yet* agreed work.
+- **Soft requests get "answer → then action", in that order.** Heavy/irreversible
+  calls (design changes, destructive ops) get a one-line confirm instead of a guess.
+- **No pandering, no taking the user's hypothesis as fact** — verify against real
+  data and flag mismatches.
+- **Why is the spine of an Issue.** It's read after close to trace intent.
+- **Evidence is real, not asserted.** Green tests / "I implemented it" is a
+  necessary-but-insufficient condition; "done" requires RED→GREEN reproduced **on
+  staging**. Discord-side proof is normally a **user-provided screenshot** (the
+  server-side agent has no GUI), supplemented by tmux captures + REST-fetched text.
+
+**Why (what motivated this):**
+
+A week-long review of the maintainer's own Discord messages (~1900, excluding
+AI-authored Issue/commit text) surfaced a gap between *what was said* and *what
+got recorded*. The records (Issues/PRs/commits) tended to close on "tests green /
+done"; the maintainer repeatedly pushed the opposite: mocks-green-but-broke-on-real-hardware
+had happened, so "done" must mean reproduced-and-fixed on the real bot, with a
+screenshot of the actual Discord behaviour. A second, subtler gap: when the
+maintainer asked "why is X happening?", the agent would read code and jump
+straight to a fix/PR, skipping the diagnosis the maintainer actually wanted
+("is this the intended spec, or a bug?"). A third: some transcript "user"
+messages were polished instruction text the maintainer had an AI draft and
+pasted — not the maintainer's own intent — so they over-weighted a "stop after
+every PR / merge is the user's gate" reading that the maintainer later corrected
+(self-run through merge/deploy is fine for now).
+
+**Fix:** Codify the conduct in CLAUDE.md, enforce the artifact fields via the
+`.github` templates, and record the rationale here. See CLAUDE.md → "開発の行動規範
+(Working Conduct)" and "Definition of Done (DoD)".


### PR DESCRIPTION
## What does this PR do?

Codify the working agreements we settled in discussion into three layers:
**CLAUDE.md (commands)**, **`.github` templates (enforcement by form)**, and
**`docs/DESIGN_DECISIONS.md` (the why)**.

- **CLAUDE.md**: new "開発の行動規範 (Working Conduct)" section; Issue rules gain Why-required, screenshot evidence, and the "body = current truth + dated comment for rewrites" convention; DoD clarifies Discord-screenshot (user-provided) + tmux/REST supplement, and `Closes`/`Resolves`/`Refs` on its own line.
- **`.github/ISSUE_TEMPLATE/*` + `pull_request_template.md`**: Why, binary ACs, scope-out, Staging Evidence with screenshots, `<details>` for long logs.
- **`docs/DESIGN_DECISIONS.md`**: section 14 records the rationale (incl. the transcript-noise lesson: some "user" messages were AI-drafted text the maintainer pasted).

## Why?

A week-long review of the maintainer's own Discord messages (~1900) showed a gap between *what was said* and *what got recorded*: records close on "tests green / done", but the maintainer repeatedly demands "reproduced-and-fixed on staging, with a screenshot", and "answer the diagnosis question before jumping to a fix". This wires those into the artifacts.

Closes #244

## Acceptance Criteria (copied from the issue)

- [x] `.github/ISSUE_TEMPLATE/bug_report.md` / `feature_request.md` に Why・1 concern・証跡(スクショ)・二値 AC・スコープ外 の節がある
- [x] `.github/pull_request_template.md` に Proof(証跡)＝Discord スクショ(人間提供主)＋tmux/REST 補強、`Closes`/`Resolves`/`Refs` を独立行に書く注記、`<details>` 推奨が入っている
- [x] `CLAUDE.md` に「行動規範」節が追加され、Issue/PR ルールが上記方針に更新され、「テンプレに従う」参照がある
- [x] `docs/DESIGN_DECISIONS.md` に本ルールの Decision/Why/Fix が追記され、CLAUDE.md から相互リンクされている
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` が緑（挙動変更なし）

## Staging Evidence (証跡)

`documentation` label — docs/templates only, no runtime behaviour change. Staging verification exempted per DoD rules.

Local checks (this branch):
```
ruff check c_lord/        → All checks passed!
ruff format --check c_lord/ → 71 files already formatted
pyright c_lord/           → 0 errors, 0 warnings, 0 informations
pytest tests/             → 1264 passed, 9 skipped
```

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

> **Label exemptions** (`documentation`): TDD evidence + Staging verification waived. `Closes` discipline always enforced.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: exempt (documentation — no code change)
- [x] `uv run pytest tests/` passes (1264 passed, 9 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence: skip reason written (documentation label)
- [x] No unrelated changes in the diff; self-review done (docs/templates only)
- [x] `Closes #244` — satisfies 100% of the issue's ACs
