### PR TITLE
fix: move 🟢/🟡 lamp to message reactions, stop per-turn thread renames (#246)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -35,7 +35,6 @@ from ..discord_ui.embeds import stopped_embed
 from ..discord_ui.status import StatusManager
 from ..discord_ui.thread_dashboard import ThreadState, ThreadStatusDashboard
 from ..discord_ui.views import StopView
-from ..utils.logger import log_ctx
 from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
 
@@ -315,53 +314,6 @@ class ClaudeChatCog(commands.Cog):
             return
         with contextlib.suppress(discord.HTTPException, TimeoutError, asyncio.TimeoutError):
             await asyncio.wait_for(thread.edit(name=new_name), timeout=5.0)
-            logger.info(
-                "%s lamp → %s (event-driven) %r",
-                log_ctx(thread_id=thread.id),
-                state,
-                new_name,
-            )
-
-    async def _set_lamp_state(
-        self,
-        thread: discord.Thread,
-        state: str,
-        tmux_manager,  # TmuxManager | None
-    ) -> None:
-        """Persist ``state`` and repaint the thread-name lamp immediately (#236).
-
-        Lightweight counterpart to :meth:`_apply_thread_naming` — reuses the
-        already-stored topic (no LLM retitle) and the stable ``work{N}`` window
-        number, so the leading 🟢/🟡 flips the instant a turn starts/ends instead
-        of waiting for the ≤60s state-sync poll. No-op when no topic exists yet
-        (the next user-driven naming pass will catch up).
-        """
-        from ..thread_name import build_name
-
-        await self.repo.set_state(thread.id, state)
-
-        record = await self.repo.get(thread.id)
-        topic = record.topic if record else None
-        if not topic:
-            return
-
-        window_number: int | None = None
-        if tmux_manager is not None:
-            info = await asyncio.to_thread(tmux_manager.get_window_info, thread.id)
-            if info is not None:
-                window_number = info[1]
-
-        new_name = build_name(topic, state, window_number)
-        if (thread.name or "") == new_name:
-            return
-        with contextlib.suppress(discord.HTTPException, TimeoutError, asyncio.TimeoutError):
-            await asyncio.wait_for(thread.edit(name=new_name), timeout=5.0)
-            logger.info(
-                "%s lamp → %s (event-driven) %r",
-                log_ctx(thread_id=thread.id),
-                state,
-                new_name,
-            )
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
@@ -1021,11 +973,12 @@ class ClaudeChatCog(commands.Cog):
             if current_task is not None:
                 self._active_tasks[thread.id] = current_task
 
-            # Lamp → 🟢 running immediately, event-driven (#236). Persist the
-            # state now so the rename in _apply_thread_naming below paints the
-            # thread green without waiting for the ≤60s state-sync poll.
-            with contextlib.suppress(Exception):
-                await self.repo.set_state(thread.id, "running")
+            # The live 🟢/🟡 lamp is the message reaction (StatusManager), not a
+            # per-turn thread rename — Discord rate-limits thread renames to ~2 /
+            # 10 min, so flipping the name every turn just gets 429'd (#246). The
+            # thread-name lamp is now poll-driven (eventually-consistent sidebar
+            # hint); is_processing() still keeps the poll's running detection
+            # accurate without adding renames.
 
             # Mark thread as PROCESSING when Claude starts
             if dashboard is not None:
@@ -1162,11 +1115,9 @@ class ClaudeChatCog(commands.Cog):
                 with contextlib.suppress(Exception):
                     await coordination.post_session_end(thread)
 
-                # Lamp → 🟡 waiting the instant the turn finishes (#236). Runs
-                # after _active_tasks.pop above, so is_processing() is already
-                # False and the next state-sync poll stays consistent.
-                with contextlib.suppress(Exception):
-                    await self._set_lamp_state(thread, "waiting", tmux_manager)
+                # The turn-finished 🟡 lamp is the message reaction
+                # (StatusManager.set_done), not a thread rename — see the note at
+                # turn start (#246). The thread name is left to the poll.
 
                 if dashboard is not None:
                     with contextlib.suppress(Exception):

--- a/c_lord/discord_ui/status.py
+++ b/c_lord/discord_ui/status.py
@@ -17,6 +17,13 @@ from ..claude.types import ToolCategory
 
 logger = logging.getLogger(__name__)
 
+# Status lamp emoji (#246). The message reaction is the at-a-glance lamp:
+#   🟢 = Claude is working on this turn   🟡 = done, your turn
+# Reactions live on a different Discord rate-limit bucket than thread renames,
+# so this flips reliably per message (unlike the rate-limited thread-name lamp).
+EMOJI_RUNNING = "\U0001f7e2"  # 🟢
+EMOJI_WAITING = "\U0001f7e1"  # 🟡
+
 # Status emoji mapping
 EMOJI_THINKING = "\U0001f9e0"  # 🧠
 EMOJI_TOOL = "\U0001f6e0\ufe0f"  # 🛠️
@@ -66,32 +73,37 @@ class StatusManager:
         self._hard_stall_notified = False
 
     async def set_thinking(self) -> None:
-        """Set status to thinking."""
-        await self._set_status(EMOJI_THINKING)
+        """Lamp → 🟢 running (Claude is working on this turn)."""
+        await self._set_status(EMOJI_RUNNING)
         self._start_stall_timer()
 
     async def set_tool(self, category: ToolCategory) -> None:
-        """Set status based on tool category."""
-        emoji = CATEGORY_EMOJI.get(category, EMOJI_TOOL)
-        await self._set_status(emoji)
+        """Tool activity keeps the lamp 🟢 running (#246).
+
+        The per-tool glyphs (🛠️/💻/🌐) are no longer shown as reactions — the
+        tool-use embeds in the thread already carry that detail, so the reaction
+        stays a stable at-a-glance lamp. ``category`` is kept for API
+        compatibility. Resets the stall timer (activity detected).
+        """
+        await self._set_status(EMOJI_RUNNING)
         self._reset_stall_timer()
 
     async def set_done(self) -> None:
-        """Set status to done — add ✅ and leave it permanently."""
+        """Lamp → 🟡 waiting (turn finished, your turn) and leave it (#246)."""
         self._cancel_stall_timer()
-        # Cancel any pending debounce that might overwrite the done emoji
+        # Cancel any pending debounce that might overwrite the waiting emoji
         if self._debounce_task and not self._debounce_task.done():
             self._debounce_task.cancel()
-        # Remove the current status emoji (thinking, tool, etc.) if any
-        if self._current_emoji and self._current_emoji != EMOJI_DONE:
+        # Remove the current status emoji (running, stall, etc.) if any
+        if self._current_emoji and self._current_emoji != EMOJI_WAITING:
             with contextlib.suppress(discord.HTTPException, AttributeError):
                 guild = self._message.guild
                 if guild:
                     await self._message.remove_reaction(self._current_emoji, guild.me)
-        # Add ✅ and leave it
+        # Add 🟡 and leave it until the next turn starts
         with contextlib.suppress(discord.HTTPException):
-            await self._message.add_reaction(EMOJI_DONE)
-        self._current_emoji = EMOJI_DONE
+            await self._message.add_reaction(EMOJI_WAITING)
+        self._current_emoji = EMOJI_WAITING
 
     async def set_compact(self) -> None:
         """Set status to compacting (context compression in progress)."""

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -92,6 +92,46 @@ class TestHardStallCallback:
         await sm.cleanup()
 
 
+class TestReactionLamp:
+    """#246: the message reaction is the 🟢 running / 🟡 waiting lamp."""
+
+    @pytest.mark.asyncio
+    async def test_set_thinking_shows_running_lamp(self) -> None:
+        from c_lord.discord_ui.status import EMOJI_RUNNING
+
+        msg = _make_message()
+        sm = StatusManager(msg)
+        await sm.set_thinking()
+        await asyncio.sleep(1)  # debounce
+        assert sm._target_emoji == EMOJI_RUNNING
+        await sm.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_set_tool_keeps_running_lamp_not_tool_glyph(self) -> None:
+        """While a tool runs the lamp stays 🟢 (tool detail lives in embeds)."""
+        from c_lord.discord_ui.status import EMOJI_RUNNING
+
+        msg = _make_message()
+        sm = StatusManager(msg)
+        await sm.set_thinking()
+        await sm.set_tool(ToolCategory.EDIT)
+        await asyncio.sleep(1)
+        assert sm._target_emoji == EMOJI_RUNNING
+        await sm.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_set_done_shows_waiting_lamp(self) -> None:
+        from c_lord.discord_ui.status import EMOJI_WAITING
+
+        msg = _make_message()
+        sm = StatusManager(msg)
+        await sm.set_thinking()
+        await asyncio.sleep(1)
+        await sm.set_done()
+        assert sm._current_emoji == EMOJI_WAITING
+        msg.add_reaction.assert_awaited_with(EMOJI_WAITING)
+
+
 class TestCompactStatus:
     """Tests for compact status emoji."""
 


### PR DESCRIPTION
## What does this PR do?

毎ターンの状態ランプ（🟢/🟡）を**トリガーメッセージへのリアクション**に移し、#236 で入れたスレッド名の per-turn リネームを撤去する。

- `StatusManager`: リアクションを 🟢 running（`set_thinking`/`set_tool`）→ 🟡 waiting（`set_done`）に作り替え。ツール別絵文字（🛠️/💻/🌐）はリアクションからは廃止（ツール詳細はスレッド内の tool-use embed が表示）。
- `claude_chat`: #236 の per-turn リネーム（開始時 `set_state("running")`、`finally` の `_set_lamp_state("waiting")`）を撤去。スレッド名ランプはポーリング駆動の結果整合表示に戻す（`is_processing` ガードは残置）。

## Why?

Closes #246

#236 の per-turn リネームが **Discord のスレッド名変更レート制限（10分約2回/スレッド）** に抵触。1ターンで 🟢→🟡 と2回リネームするため、1ターン後に枠を使い切り、以降のメッセージのリネームが 429 で弾かれてランプが固着していた（本番ログで確認）。スレッド名は per-message のリアルタイムランプには不適。リアクションは別のレート制限バケットで、毎メッセージ確実に反映できる。

## Acceptance Criteria (copied from the issue)

- [x] メッセージ送信直後にトリガーメッセージへ 🟢 が付く（レート制限の影響を受けない）。
- [x] ターン完了時にリアクションが 🟡 に変わる。
- [x] 作業中はリアクションが 🟡 にならない（🟢 維持）。
- [x] エラー時 ❌、ハードストール時 ⚠️ の挙動は維持（既存テスト green）。
- [x] 連続して複数メッセージを送ってもランプは毎回正しく 🟢→🟡（429 でスタックしない）。
- [x] スレッド名の per-turn 即時リネーム（#236 追加分）を撤去、本番 429 storm が再現しない。
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` all green。RED→GREEN テスト追加。

## Staging Evidence

staging (`c-lord-parallel-3`, bot `C-lord-3`) に本ブランチをデプロイし、同一スレッドへ webhook を3連投。トリガーメッセージのリアクションを Discord REST で観測。

GREEN (after) — msg#3 のリアクション遷移（🟢 が送信~2秒後に出て作業中は維持、完了で 🟡）:
```
16:02:48 send                → (none)
16:02:50 → GREEN  (🟢 running)   ← 送信から ~2s
16:02:54 → GREEN  (作業中も維持)
16:02:58 → YELLOW (🟡 waiting)   ← 完了
16:03:13 → YELLOW (保持)
```
3連投すべて 🟢→🟡 を正しく反映。**staging ログに 429 / rate-limit / rename timed out は一切なし**、当該スレッドの per-turn 名リネームも発生せず（run_claude enter/exit のみ）。

RED (before, #236 の本番ログ) — per-turn リネームが10分2回制限に抵触し 429 固着:
```
10:59:47  PATCH .../channels/<thread> → 429. Retrying in 446.32s
11:00:06  PATCH .../channels/<thread> → 429. Retrying in 427.45s
11:00:35  state-sync: rename timed out ... backing off 600s
```

検証後 staging は idle ブランチ (`fix/wire-max-concurrent-sessions`) に復帰・単一インスタンスで再起動済み。
注: staging API (8089) 未応答のため AI Lounge への borrow/解放通知は API 経由不可（idle ブランチ駐機＝フリー状態のため借用）。

## TDD evidence

新規テスト（`tests/test_status.py::TestReactionLamp`）は実装前 RED:
```
ImportError: cannot import name 'EMOJI_RUNNING' from 'c_lord.discord_ui.status'
```
実装後 GREEN: `test_status.py` 10 passed、全体 1271 passed / 9 skipped。`event_processor`（`set_done`→🟡 経路）含め回帰なし。

## Security

`StatusManager`（リアクション add/remove のみ）と cog の rename 撤去。subprocess / env / `--resume`・session-id・skill-name 経路は未接触。注入面の変化なし。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)