### PR TITLE
fix: /api/reply 500 when progress_file absent (UnboundLocalError on discord) (#201)

### DIFF
--- a/c_lord/ext/api_server.py
+++ b/c_lord/ext/api_server.py
@@ -686,6 +686,12 @@ class ApiServer:
         if not content:
             return web.json_response({"error": "content is required"}, status=400)
 
+        # Issue #201: import unconditionally — `discord` is referenced later for
+        # MessageReference / table images even when progress_file is absent. A
+        # conditional import made the name a function-local that was unbound on
+        # the no-attachment path, raising UnboundLocalError -> 500.
+        import discord
+
         # Optional attachment — resolve and validate before touching Discord.
         progress_file = data.get("progress_file")
         attachment = None
@@ -698,7 +704,6 @@ class ApiServer:
                     {"error": f"progress_file not found: {progress_file}"},
                     status=400,
                 )
-            import discord
 
             attachment = discord.File(str(path), filename=path.name)
 

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -781,6 +781,42 @@ class TestReplyEndpoint:
         assert resp.status == 400
         assert was_replied_since(thread_id=555666777, since=before) is False
 
+    @pytest.mark.asyncio
+    async def test_reply_to_trigger_without_progress_file(
+        self, repo: NotificationRepository, bot_with_thread: MagicMock, thread_mock: MagicMock
+    ) -> None:
+        """Issue #201: a plain reply (no progress_file) on a thread that has a
+        trigger_message_id must not raise UnboundLocalError on ``discord``.
+
+        The ``discord`` module used to be imported only inside the
+        ``if progress_file:`` block, so the later ``discord.MessageReference``
+        reference raised ``UnboundLocalError`` -> 500 when progress_file was absent.
+        """
+        session_repo = MagicMock()
+        record = MagicMock()
+        record.trigger_message_id = 111222333
+        session_repo.get = AsyncMock(return_value=record)
+
+        api = ApiServer(
+            repo=repo,
+            bot=bot_with_thread,
+            default_channel_id=12345,
+            session_repo=session_repo,
+        )
+        server = TestServer(api.app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            resp = await client.post(
+                "/api/reply",
+                json={"thread_id": 555666777, "content": "plain answer"},
+            )
+            assert resp.status == 200
+            kwargs = thread_mock.send.call_args.kwargs
+            assert "reference" in kwargs
+        finally:
+            await client.close()
+
 
 class TestPromptChoiceEndpoint:
     """Issue #63: POST /api/prompt-choice — Skill posts a choice prompt."""


### PR DESCRIPTION
## What does this PR do?

Moves `import discord` to the top of `ApiServer.reply()` so the module is
always bound, regardless of whether `progress_file` is present.

## Why?

`import discord` lived inside the `if progress_file:` block, so on the
plain-text reply path the name was an unbound function-local. The later
`discord.MessageReference(...)` (Issue #115 reply-to-trigger) then raised
`UnboundLocalError` → 500 Internal Server Error whenever a reply had no
`progress_file` and the thread had a `trigger_message_id`. Only the first
turn worked, because `trigger_message_id` is NULL until set.

Closes #201

## Acceptance Criteria (derived from the issue)

- [x] `POST /api/reply` without `progress_file` on a thread that has a
  `trigger_message_id` returns 200 (no `UnboundLocalError`)
- [x] `import discord` moved out of the conditional block to the function top

## TDD Evidence

New test `TestReplyEndpoint::test_reply_to_trigger_without_progress_file`
(real aiohttp `TestServer`, real `reply()` route).

RED (before fix):
```
c_lord/ext/api_server.py: send_kwargs["reference"] = discord.MessageReference(
UnboundLocalError: cannot access local variable 'discord' where it is not associated with a value
```
GREEN (after fix): `59 passed` in tests/test_api_server.py.

## Staging Evidence

Staging runs `CLORD_BRIDGE_MODE=jsonl`, so the skill `/api/reply` path is not
exercised by its normal flow. Verified instead by driving the **real
`ApiServer.reply` route over real HTTP on the staging host**, backed by a copy
of staging's real `sessions.db` via a real `SessionRepository` (real row with
`trigger_message_id` set), no `progress_file`.

RED (origin/main code, staging host):
```
thread_id=1508274772641972374 trigger_message_id=1509461659750760448
File ".../c_lord/ext/api_server.py", line 741, in reply
    reference = discord.MessageReference(
UnboundLocalError: cannot access local variable 'discord' where it is not associated with a value
STATUS=500
BODY=500 Internal Server Error / Server got itself in trouble
```
GREEN (this branch, same DB row, same request):
```
thread_id=1508274772641972374 trigger_message_id=1509461659750760448
STATUS=200
BODY={"status": "sent"}
```

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/` passes (1214 passed, 9 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)