### PR TITLE
fix: resolve data dir relative to --env path, not CWD (#202)

### DIFF
--- a/c_lord/cli.py
+++ b/c_lord/cli.py
@@ -345,7 +345,7 @@ async def _run_start(env_path: Path) -> None:
     # Import and run the existing main() from c_lord.main
     from c_lord.main import main as bot_main
 
-    await bot_main()
+    await bot_main(env_path)
 
 
 def cmd_start(env_path: Path = Path(".env")) -> None:

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -19,9 +19,25 @@ from .utils.logger import setup_logging
 logger = logging.getLogger(__name__)
 
 
-def load_config() -> dict[str, str]:
+def resolve_data_dir(env_path: Path | None) -> Path:
+    """Resolve the directory that holds sessions.db / notifications.db.
+
+    Issue #202: when launched via ``c-lord start --env <path>``, data files must
+    live next to the given .env — not relative to the CWD — otherwise starting
+    from a different directory silently creates an empty sessions.db and orphans
+    every existing session. Standalone ``python -m c_lord.main`` (env_path=None)
+    keeps the legacy CWD-relative ``data/``.
+    """
+    base = env_path.parent if env_path is not None else Path(".")
+    return base / "data"
+
+
+def load_config(env_path: Path | None = None) -> dict[str, str]:
     """Load and validate configuration from environment."""
-    load_dotenv()
+    if env_path is not None:
+        load_dotenv(env_path)
+    else:
+        load_dotenv()
 
     token = os.getenv("DISCORD_BOT_TOKEN", "")
     if not token:
@@ -47,15 +63,15 @@ def load_config() -> dict[str, str]:
     }
 
 
-async def main() -> None:
+async def main(env_path: Path | None = None) -> None:
     """Start the bot."""
     log_level_name = os.getenv("LOG_LEVEL", "INFO").upper()
     log_level = getattr(logging, log_level_name, logging.INFO)
     setup_logging(log_level)
-    config = load_config()
+    config = load_config(env_path)
 
-    data_dir = Path("data")
-    data_dir.mkdir(exist_ok=True)
+    data_dir = resolve_data_dir(env_path)
+    data_dir.mkdir(parents=True, exist_ok=True)
     db_path = str(data_dir / "sessions.db")
 
     runner = ClaudeConfig(

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -131,6 +131,7 @@ async def main(env_path: Path | None = None) -> None:
             runner,
             api_server=api_server,
             session_db_path=db_path,
+            task_db_path=str(data_dir / "tasks.db"),
             allowed_user_ids=allowed_user_ids,
             allowed_role_name=allowed_role_name,
             claude_channel_id=int(config["channel_id"]),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,41 @@
+"""Tests for c_lord.main path/config resolution.
+
+Issue #202: ``c-lord start --env <path>`` must resolve data files (sessions.db,
+notifications.db) and load the .env relative to the given path, not the CWD.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from c_lord.main import load_config, resolve_data_dir
+
+
+class TestResolveDataDir:
+    def test_env_path_anchors_data_dir(self, tmp_path: Path) -> None:
+        env_path = tmp_path / "cfg" / ".env"
+        assert resolve_data_dir(env_path) == tmp_path / "cfg" / "data"
+
+    def test_none_falls_back_to_cwd_relative(self) -> None:
+        # Standalone `python -m c_lord.main` keeps the legacy CWD-relative dir.
+        assert resolve_data_dir(None) == Path("data")
+
+
+class TestLoadConfigEnvPath:
+    def test_loads_env_from_given_path(self, tmp_path: Path) -> None:
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "DISCORD_BOT_TOKEN=tok-from-file\nDISCORD_CHANNEL_ID=999\n",
+            encoding="utf-8",
+        )
+        # Ensure the value isn't already in the environment.
+        os.environ.pop("DISCORD_BOT_TOKEN", None)
+        os.environ.pop("DISCORD_CHANNEL_ID", None)
+        try:
+            config = load_config(env_path)
+            assert config["token"] == "tok-from-file"
+            assert config["channel_id"] == "999"
+        finally:
+            os.environ.pop("DISCORD_BOT_TOKEN", None)
+            os.environ.pop("DISCORD_CHANNEL_ID", None)


### PR DESCRIPTION
## What does this PR do?

Makes `--env <path>` the source of truth for where the bot reads config and
data: `sessions.db` / `notifications.db` / `tasks.db` now live next to the
given `.env`, and `load_dotenv()` loads that exact file.

## Why?

`main()` hardcoded `data_dir = Path("data")` (CWD-relative) and
`cli._run_start` discarded `env_path` entirely (called `bot_main()` with no
args). So `c-lord start --env /path/to/.env` launched from a different
directory either failed to load the token at all (`load_dotenv()` searched the
CWD) or created empty DBs in the wrong place — `repo.get()` then returned
`None` for every existing thread and `on_message` silently dropped replies,
orphaning session state, topics, and tmux-window bindings.

Closes #202

## Acceptance Criteria (derived from the issue)

- [x] `c-lord start --env <path>` resolves `sessions.db` under `env_path.parent/data`, not CWD
- [x] `notifications.db` and `tasks.db` (other data files) also resolve under `env_path.parent/data`
- [x] Standalone `python -m c_lord.main` (no `--env`) keeps the legacy CWD-relative `data/` (backward compatible)
- [x] `--env` path is honored for loading the `.env` itself (`load_dotenv(env_path)`)

## TDD Evidence

New `tests/test_main.py` (`resolve_data_dir`, `load_config(env_path)`).

RED (before fix):
```
tests/test_main.py: from c_lord.main import load_config, resolve_data_dir
ImportError: cannot import name 'resolve_data_dir' from 'c_lord.main'
```
GREEN (after fix): tests/test_main.py + tests/test_cli.py — `17 passed`.

## Staging Evidence

Verified on the staging host by running the **real `c-lord start --env`
console-script entrypoint** from a CWD different from the `.env` directory
(env at `/tmp/clord202/envdir/.env`, launched from `/tmp/clord202/workdir`).

RED (origin/main code) — `--env` ignored entirely:
```
[ERROR] c_lord.main: DISCORD_BOT_TOKEN is required
# load_dotenv() searched the empty CWD; token never loaded; bot exits.
```
GREEN (this branch) — all data files resolve under the .env directory, nothing in CWD:
```
Notification DB initialized at /tmp/clord202/envdir/data/notifications.db
Database initialized at      /tmp/clord202/envdir/data/sessions.db
Task DB initialized at       /tmp/clord202/envdir/data/tasks.db
workdir/data: (none)    envdir/data: notifications.db  sessions.db  tasks.db
```
(The first GREEN run revealed `tasks.db` was still CWD-relative — fixed in the
second commit, re-verified above. This is exactly the gap staging caught.)

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/` passes (1214 passed, 9 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)