### PR TITLE
fix: auto-submit AskUserQuestion multi-question Review screen (#252)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -178,6 +178,29 @@ def _is_ask_question(text: str) -> bool:
     return _ASK_SIGNATURE in text and bool(_ASK_OPTION_RE.search(text))
 
 
+# A multi-question AskUserQuestion ends on a "Review your answers" screen with a
+# two-option menu — "Submit answers" / "Cancel" — and the cursor defaulting to
+# "Submit answers".  It carries NO "Chat about this" marker, so _is_ask_question
+# misses it; without explicit handling it falls through to the unknown-prompt
+# alert.  Match the two option labels (cursor optional) anchored to the bottom
+# zone, where real prompts live — the pairing is unique to this screen, so it
+# can't be confused with a normal question menu or an unrelated numbered list.
+_ASK_SUBMIT_RE = re.compile(r"^\s*❯?\s*\d+\.\s+Submit answers\s*$", re.MULTILINE)
+_ASK_CANCEL_RE = re.compile(r"^\s*❯?\s*\d+\.\s+Cancel\s*$", re.MULTILINE)
+
+
+def _is_ask_submit_screen(text: str) -> bool:
+    """True iff the pane shows the AskUserQuestion Submit/Review confirmation.
+
+    All questions were already answered via the Discord bridge; this final
+    screen only needs a bare Enter (cursor starts on "Submit answers") to
+    submit.  Only the bottom zone is scanned so a stale review screen left in
+    the scrollback can't re-trigger a submit.
+    """
+    zone = _permission_zone(text)
+    return bool(_ASK_SUBMIT_RE.search(zone)) and bool(_ASK_CANCEL_RE.search(zone))
+
+
 def _parse_ask_from_pane(text: str) -> AskQuestion | None:
     """Parse an AskUserQuestion TUI menu from the pane into an ``AskQuestion``.
 
@@ -537,6 +560,11 @@ class TmuxClaudeRunner:
         # signature of the menu we already bridged to Discord (dedup).
         ask_stable = 0.0
         last_bridged_ask: str | None = None
+        # AskUserQuestion Submit/Review screen: seconds it has been stable, and
+        # the signature of the screen we already submitted (dedup so a lingering
+        # screen isn't Enter-ed every poll).
+        submit_stable = 0.0
+        last_submitted: str | None = None
         # Raw pane activity (#166): while Claude works the pane changes every
         # poll (spinner frame, elapsed-seconds tick), even when no response text
         # is extracted yet.  We only treat the session as idle once the raw pane
@@ -593,6 +621,8 @@ class TmuxClaudeRunner:
                 last_alerted_unknown = None
                 ask_stable = 0.0
                 last_bridged_ask = None
+                submit_stable = 0.0
+                last_submitted = None
                 await self._accept_permission_prompt(current)
                 continue
 
@@ -620,6 +650,26 @@ class TmuxClaudeRunner:
             else:
                 ask_stable = 0.0
                 last_bridged_ask = None
+
+            # AskUserQuestion multi-question Submit/Review screen (post-bridge).
+            # Once every question was answered via the Discord buttons, the TUI
+            # shows a "Review your answers" confirmation with the cursor on
+            # "Submit answers".  Auto-confirm with Enter so the answered flow
+            # completes instead of stalling as an "unknown" prompt.  A short
+            # dwell guards against acting on a half-drawn frame, and the
+            # signature dedup prevents re-pressing Enter while it lingers.
+            if _is_ask_submit_screen(current):
+                submit_stable += _POLL_INTERVAL
+                if submit_stable >= _ASK_ALERT_DELAY:
+                    sig = _unknown_prompt_signature(current)
+                    if sig != last_submitted:
+                        last_submitted = sig
+                        await self._submit_ask_screen()
+                    submit_stable = 0.0
+                continue
+            else:
+                submit_stable = 0.0
+                last_submitted = None
 
             # Detect unknown TUI interactive menus (not covered by known markers).
             # Alert Discord so the session doesn't stall silently.
@@ -864,6 +914,11 @@ class TmuxClaudeRunner:
         # the real UI with a spurious warning.
         if _is_ask_question(zone):
             return False
+        # Exclude the AskUserQuestion multi-question Submit/Review screen: it is a
+        # known, auto-submitted prompt (handled in the poll loop), not an unknown
+        # one — flagging it would surface a spurious warning over an answered flow.
+        if _is_ask_submit_screen(zone):
+            return False
         # Exclude Plan approval (ExitPlanMode) and (legacy) AskUserQuestion menus (#153).
         # These are handled via Discord buttons; surfacing them as "unknown" would
         # confuse users with a duplicate warning alongside the real Discord UI.
@@ -895,6 +950,19 @@ class TmuxClaudeRunner:
             target = f"{self._tmux.session_name}:{window}"
             key = "y" if self._is_yn_prompt(pane_text) else "Enter"
             _run(["tmux", "send-keys", "-t", target, key])
+
+    async def _submit_ask_screen(self) -> None:
+        """Confirm a multi-question AskUserQuestion Submit/Review screen.
+
+        Every question was already answered via the Discord bridge, so this
+        final screen only needs confirming.  Its cursor starts on "Submit
+        answers", so a bare Enter submits the recorded answers and lets Claude
+        proceed (mirrors the auto-accept used for trust/permission prompts).
+        """
+        logger.info(
+            "AskUserQuestion Submit screen detected, submitting (thread=%d)", self._thread_id
+        )
+        await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Enter")
 
     async def _navigate_menu(self, index: int) -> None:
         """Move the menu cursor down *index* times then confirm with Enter.

--- a/docs/askuserquestion-bridge.md
+++ b/docs/askuserquestion-bridge.md
@@ -119,10 +119,27 @@ Keystrokes are spaced by `_MENU_NAV_DELAY` for the same timing reason as
 `answer_menu` (#171). Verified end-to-end: the typed text is recorded as
 `<question> → <text>` (not "User declined to answer questions").
 
+## Multi-question Submit screen
+
+A multi-question AskUserQuestion is handled one menu at a time as each renders in
+the pane (each question → its own Discord buttons). After the last question is
+answered, the TUI shows a **"Review your answers" / "Submit answers" / "Cancel"**
+confirmation. That screen carries **no `Chat about this` marker**, so
+`_parse_ask_from_pane` does not match it; without explicit handling it fell
+through to the unknown-prompt path and surfaced a spurious *"Unknown TUI prompt
+detected"* warning over an already-answered flow.
+
+c-lord now recognises it (`_is_ask_submit_screen`) and **auto-submits**: the
+cursor defaults to "Submit answers", so the poll loop presses a bare `Enter`
+(after a short stability dwell, with signature dedup so a lingering screen isn't
+Enter-ed twice) — mirroring the auto-accept used for trust/permission prompts.
+The answers are already locked in via the bridge, so no further user input is
+needed.
+
 ## Limitations
 
-- **Single question at a time.** A multi-question AskUserQuestion is handled one
-  menu at a time as each renders in the pane.
+- **Free text on the Submit screen is not re-editable from Discord.** The review
+  screen is auto-submitted as-is; to change an answer, use `/attach`.
 
 ## Source map
 

--- a/tests/fixtures/panes/ask_user_question_submit_screen.txt
+++ b/tests/fixtures/panes/ask_user_question_submit_screen.txt
@@ -1,0 +1,19 @@
+  ← ⊞ 症状 / ✓ Submit →
+
+  Review your answers
+
+   • 「スレッドが読める/読めない」とは、具体的にどの動作のこ
+     とですか？
+     → Botがスレッド内容を取得できない
+   • 本番(c-lord), staging(c-lord-parallel-3)のどちらで
+     起きていますか？
+     → 回答します。
+
+  Ready to submit your answers?
+
+  ❯ 1. Submit answers
+    2. Cancel
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  -- INSERT --   ⏵⏵ bypass permissions on /home/yousan/c-lord

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from c_lord.claude.tmux_runner import (
     TmuxClaudeRunner,
     _clean_tui_lines,
+    _is_ask_submit_screen,
     _normalize_capture,
     _parse_ask_from_pane,
 )
@@ -1879,6 +1880,84 @@ class TestKnownInteractiveMenusNotFlaggedAsUnknown:
             "-- INSERT --"
         )
         assert TmuxClaudeRunner._has_unknown_interactive(pane) is True
+
+
+class TestAskUserQuestionSubmitScreen:
+    """Multi-question AskUserQuestion ends on a 'Review your answers' /
+    'Submit answers' / 'Cancel' confirmation screen.  It carries no
+    'Chat about this' marker, so _parse_ask_from_pane misses it and it used to
+    fall through to _has_unknown_interactive — surfacing a spurious 'Unknown TUI
+    prompt' warning instead of completing the answered questions.  c-lord must
+    recognise it and auto-submit (the answers are already locked via the bridge).
+    """
+
+    def test_submit_screen_detected(self) -> None:
+        pane = _normalize_capture(_load_fixture("ask_user_question_submit_screen.txt"))
+        assert _is_ask_submit_screen(pane) is True
+
+    def test_submit_screen_not_flagged_as_unknown(self) -> None:
+        """RED: the Submit/Review screen must NOT trip the unknown-prompt alert."""
+        pane = _normalize_capture(_load_fixture("ask_user_question_submit_screen.txt"))
+        assert TmuxClaudeRunner._has_unknown_interactive(pane) is False
+
+    def test_single_question_menu_is_not_submit_screen(self) -> None:
+        """A normal question menu must not be mistaken for the Submit screen."""
+        pane = _normalize_capture(_load_fixture("ask_user_question_menu.txt"))
+        assert _is_ask_submit_screen(pane) is False
+
+    def test_unknown_menu_is_not_submit_screen(self) -> None:
+        """A truly unknown numbered menu must not be mistaken for Submit."""
+        pane = (
+            "Would you like to install the LSP plugin?\n"
+            "❯ 1. Yes\n"
+            "  2. No\n"
+            "────────────────────────────────────────\n"
+            "-- INSERT --"
+        )
+        assert _is_ask_submit_screen(pane) is False
+
+    @pytest.mark.asyncio
+    async def test_submit_ask_screen_sends_enter(self, runner, tmux_manager) -> None:
+        """Confirming the review screen presses Enter on 'Submit answers'."""
+        await runner._submit_ask_screen()
+        tmux_manager.send_keys.assert_called_once_with(12345, "Enter")
+
+    @pytest.mark.asyncio
+    async def test_run_loop_auto_submits_review_screen(self, runner, tmux_manager) -> None:
+        """End-to-end: when the Submit/Review screen renders, the poll loop
+        auto-presses Enter once (no 'unknown prompt' event is emitted)."""
+        submit_pane = _load_fixture("ask_user_question_submit_screen.txt")
+        done_pane = _make_pane(["● Done."], with_input_prompt=True)
+        call_idx = 0
+
+        def capture_fn(tid):
+            nonlocal call_idx
+            call_idx += 1
+            # Show the review screen long enough to clear the dwell, then a
+            # completed pane so run() can finalise and the loop exits.
+            return submit_pane if call_idx <= 4 else done_pane
+
+        tmux_manager.is_claude_running.return_value = True
+        tmux_manager.capture_pane.side_effect = capture_fn
+        tmux_manager._find_window_for_thread.return_value = "work1"
+
+        events = []
+        with (
+            patch("c_lord.claude.tmux_runner._POLL_INTERVAL", 0.02),
+            patch("c_lord.claude.tmux_runner._ASK_ALERT_DELAY", 0.04),
+            patch("c_lord.claude.tmux_runner._RESPONSE_STABLE_TIMEOUT", 0.06),
+            patch("c_lord.claude.tmux_runner._POST_STARTUP_DELAY", 0.01),
+        ):
+            async for event in runner.run("follow up"):
+                events.append(event)
+
+        enter_calls = [
+            c for c in tmux_manager.send_keys.call_args_list if c == call(12345, "Enter")
+        ]
+        assert len(enter_calls) >= 1, "review screen should be auto-submitted with Enter"
+        assert not any(e.unknown_tui_prompt for e in events), (
+            "Submit screen must not surface an unknown-prompt warning"
+        )
 
 
 class TestGhostTextInputNotFlagged:


### PR DESCRIPTION
## What does this PR do?

複数質問 AskUserQuestion の最終「Review your answers / Submit answers / Cancel」確認画面を c-lord が「Unknown TUI prompt detected」と誤検出する問題を修正。各質問は #166 で正しく Discord ボタン化されるが、最後の送信確認画面だけが未知扱いになりセッションが Submit 待ちで stall していた。

選択方針（自動 Submit）に基づき、Submit 画面を検出して bare Enter を自動送信する（trust/permission プロンプトの自動承認と同じパターン）。

- `_is_ask_submit_screen()` 追加 — 底部ゾーンで「Submit answers」+「Cancel」の組をマッチ（当画面固有で誤検出耐性あり）
- `_has_unknown_interactive` から除外
- poll ループで `_ASK_ALERT_DELAY` 安定待機 + signature dedup を経て `_submit_ask_screen()`（bare Enter）
- `docs/askuserquestion-bridge.md` 更新

## Why?

最終 Submit 画面には AskUserQuestion メニューのシグネチャ `"Chat about this"` が無いため `_parse_ask_from_pane` が None を返し、`❯ 1. Submit answers` が未知メニューとして `_has_unknown_interactive` に落ちていた。答えは各質問のボタンで既にロック済みなので、最終確認は自動送信でよい。

Closes #252

## Acceptance Criteria (copied from the issue)

- [x] `tests/fixtures/panes/ask_user_question_submit_screen.txt` に Submit 画面の pane snapshot を追加し、修正前は `_has_unknown_interactive` が True を返す（バグ再現）
- [x] `_is_ask_submit_screen(submit_pane)` が True を返す（新規検出関数）
- [x] `_has_unknown_interactive(submit_pane)` が False を返す（誤検出解消）
- [x] 通常の単一質問メニュー / 真に未知のメニューは `_is_ask_submit_screen` で False（誤判定なし）
- [x] poll ループが Submit 画面検出時に `Enter` を1回自動送信し、`unknown_tui_prompt` イベントを出さない（run() 統合テスト）
- [x] staging で RED→GREEN を確認し Staging Evidence を残す

## Staging Evidence

staging bot (`c-lord-parallel-3`, bot user `C-lord-3`) に各ブランチをデプロイし、**実 tmux ペインに Submit 画面を表示 → 実 `tmux capture-pane` → デプロイ済みコードの検出関数**を実行して RED/GREEN を確認した。

> 注: このバグは「複数質問 AskUserQuestion の最終 Submit 画面」が対象で、Submit 画面に到達するには各質問の Discord ボタンを実際にクリックする必要がある（bridge は pane_ask を yield した時点で poll ループを suspend しクリック待ちになる — `docs/askuserquestion-bridge.md` L98-99）。**bot API では Discord コンポーネントのクリックを合成できない**ため、完全な webhook→ボタン駆動の live 再現は自動化不能。代わりに、実 tmux キャプチャ + デプロイ済み実コードで検出挙動を決定的に検証した（mock ではなく実 tmux の capture/normalize を通す）。

実 tmux ペイン底部（`tmux capture-pane -t clordverify -p | tail`）:
```
  ❯ 1. Submit answers
    2. Cancel
────────────────────────────────────────────────────────────────────────────────
❯
────────────────────────────────────────────────────────────────────────────────
  -- INSERT --   ⏵⏵ bypass permissions on /home/yousan/c-lord
```

**RED (main / 修正前コード, branch `main` @ 59ea1e2):**
```
branch: main
parse_ask_from_pane    : None (bridge does NOT recognise it)
has_unknown_interactive: True   ← バグ: 「Unknown TUI prompt」警告 embed が出る
```

**GREEN (fix / 修正後コード, branch `fix/askuserquestion-submit-screen` @ cf51713):**
```
branch: fix/askuserquestion-submit-screen
is_ask_submit_screen   : True
has_unknown_interactive: False  ← 誤検出解消。poll ループは bare Enter で自動送信
```

GREEN は checkout 往復後も安定再現。検証後 staging は borrow 時の状態（`staging-verify`）へ原状復帰し単一インスタンスで再起動済み。

## TDD evidence

RED:
```
ImportError: cannot import name '_is_ask_submit_screen' from 'c_lord.claude.tmux_runner'
```
GREEN: 新規 6 テスト（`TestAskUserQuestionSubmitScreen`）が PASS。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes — **1270 passed, 9 skipped**
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
