### PR TITLE
feat: make reasoning effort configurable (default: CLI default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ DISCORD_CHANNEL_ID=your-channel-id-here
 # Claude Code CLI Configuration
 CLAUDE_COMMAND=claude
 CLAUDE_MODEL=sonnet
+# Reasoning effort passed to the CLI as --effort. One of: low, medium, high,
+# xhigh, max. Defaults to max (the deepest level the --effort flag accepts).
+CLAUDE_EFFORT=max
 CLAUDE_PERMISSION_MODE=acceptEdits
 CLAUDE_WORKING_DIR=
 

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ DISCORD_CHANNEL_ID=your-channel-id-here
 CLAUDE_COMMAND=claude
 CLAUDE_MODEL=sonnet
 # Reasoning effort passed to the CLI as --effort. One of: low, medium, high,
-# xhigh, max. Defaults to max (the deepest level the --effort flag accepts).
-CLAUDE_EFFORT=max
+# xhigh, max. Unset (default) passes no flag — the CLI's own default applies.
+# CLAUDE_EFFORT=max
 CLAUDE_PERMISSION_MODE=acceptEdits
 CLAUDE_WORKING_DIR=
 

--- a/c_lord/claude/config.py
+++ b/c_lord/claude/config.py
@@ -26,3 +26,10 @@ class ClaudeConfig:
     working_dir: str | None = None
     timeout_seconds: int = 300
     dangerously_skip_permissions: bool = False
+    # Reasoning effort for the session, passed to the CLI as ``--effort``.
+    # c-lord raises this above the CLI's own default: every session gets the
+    # deepest level the flag accepts.  Valid values: low, medium, high, xhigh,
+    # max (the ``--effort`` flag rejects anything else; ``ultracode``/``auto``
+    # are only reachable via ``CLAUDE_CODE_EFFORT_LEVEL`` / the ``/effort``
+    # command, not this flag).  Override per instance or via ``CLAUDE_EFFORT``.
+    effort: str = "max"

--- a/c_lord/claude/config.py
+++ b/c_lord/claude/config.py
@@ -27,9 +27,9 @@ class ClaudeConfig:
     timeout_seconds: int = 300
     dangerously_skip_permissions: bool = False
     # Reasoning effort for the session, passed to the CLI as ``--effort``.
-    # c-lord raises this above the CLI's own default: every session gets the
-    # deepest level the flag accepts.  Valid values: low, medium, high, xhigh,
-    # max (the ``--effort`` flag rejects anything else; ``ultracode``/``auto``
-    # are only reachable via ``CLAUDE_CODE_EFFORT_LEVEL`` / the ``/effort``
-    # command, not this flag).  Override per instance or via ``CLAUDE_EFFORT``.
-    effort: str = "max"
+    # ``None`` (default) passes no flag, leaving the CLI's own default in
+    # effect.  Valid values: low, medium, high, xhigh, max (the ``--effort``
+    # flag rejects anything else; ``ultracode``/``auto`` are only reachable
+    # via ``CLAUDE_CODE_EFFORT_LEVEL`` / the ``/effort`` command, not this
+    # flag).  Override per instance or via ``CLAUDE_EFFORT``.
+    effort: str | None = None

--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -510,6 +510,7 @@ class TmuxClaudeRunner:
         permission_mode: str = "acceptEdits",
         dangerously_skip_permissions: bool = False,
         try_continue: bool = False,
+        effort: str | None = None,
     ) -> None:
         self._tmux = tmux_manager
         self._thread_id = thread_id
@@ -518,6 +519,7 @@ class TmuxClaudeRunner:
         self.timeout_seconds = timeout_seconds
         self._permission_mode = permission_mode
         self._dangerously_skip_permissions = dangerously_skip_permissions
+        self._effort = effort
         # True only for the restart-resume path (on_ready → pending_resumes).
         # /clear and normal new threads must remain False to prevent --continue
         # from recovering cleared conversation history (issue #123 Part 2 fix).
@@ -594,6 +596,7 @@ class TmuxClaudeRunner:
                     permission_mode=self._permission_mode,
                     dangerously_skip_permissions=self._dangerously_skip_permissions,
                     try_continue=True,
+                    effort=self._effort,
                 )
                 if not ok:
                     yield StreamEvent(
@@ -623,6 +626,7 @@ class TmuxClaudeRunner:
                         permission_mode=self._permission_mode,
                         dangerously_skip_permissions=self._dangerously_skip_permissions,
                         try_continue=False,
+                        effort=self._effort,
                     )
                     if not ok:
                         yield StreamEvent(
@@ -643,6 +647,7 @@ class TmuxClaudeRunner:
                     permission_mode=self._permission_mode,
                     dangerously_skip_permissions=self._dangerously_skip_permissions,
                     try_continue=False,
+                    effort=self._effort,
                 )
                 if not ok:
                     yield StreamEvent(

--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -1187,6 +1187,7 @@ class ClaudeChatCog(commands.Cog):
                 timeout_seconds=self.runner.timeout_seconds,
                 dangerously_skip_permissions=True,
                 try_continue=try_continue,
+                effort=self.runner.effort,
             )
 
             self._active_runners[thread.id] = runner

--- a/c_lord/cogs/scheduler.py
+++ b/c_lord/cogs/scheduler.py
@@ -148,6 +148,7 @@ class SchedulerCog(commands.Cog):
                 working_dir=working_dir,
                 timeout_seconds=self.runner.timeout_seconds,
                 dangerously_skip_permissions=True,
+                effort=self.runner.effort,
             )
 
             registry = getattr(self.bot, "session_registry", None)

--- a/c_lord/cogs/skill_command.py
+++ b/c_lord/cogs/skill_command.py
@@ -198,6 +198,7 @@ class SkillCommandCog(commands.Cog):
             working_dir=self.runner.working_dir,
             timeout_seconds=self.runner.timeout_seconds,
             dangerously_skip_permissions=True,
+            effort=self.runner.effort,
         )
 
     def _is_claude_thread(self, channel: discord.abc.GuildChannel | discord.Thread) -> bool:

--- a/c_lord/cogs/webhook_trigger.py
+++ b/c_lord/cogs/webhook_trigger.py
@@ -170,6 +170,7 @@ class WebhookTriggerCog(commands.Cog):
             working_dir=trigger.working_dir or self.runner.working_dir,
             timeout_seconds=trigger.timeout,
             dangerously_skip_permissions=trigger.dangerously_skip_permissions,
+            effort=self.runner.effort,
         )
 
         self._active_count += 1

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -174,6 +174,7 @@ def load_config(env_path: Path | None = None) -> dict[str, str]:
         "expected_bot_user_id": expected_bot_user_id,
         "claude_command": os.getenv("CLAUDE_COMMAND", "claude"),
         "claude_model": os.getenv("CLAUDE_MODEL", "sonnet"),
+        "claude_effort": os.getenv("CLAUDE_EFFORT", "max"),
         "claude_permission_mode": os.getenv("CLAUDE_PERMISSION_MODE", "acceptEdits"),
         "claude_working_dir": os.getenv("CLAUDE_WORKING_DIR", ""),
         "max_concurrent": os.getenv("MAX_CONCURRENT_SESSIONS", "3"),
@@ -209,6 +210,7 @@ async def main(env_path: Path | None = None) -> None:
     runner = ClaudeConfig(
         command=config["claude_command"],
         model=config["claude_model"],
+        effort=config["claude_effort"],
         permission_mode=config["claude_permission_mode"],
         working_dir=config["claude_working_dir"] or None,
         timeout_seconds=int(config["timeout"]),

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -174,7 +174,7 @@ def load_config(env_path: Path | None = None) -> dict[str, str]:
         "expected_bot_user_id": expected_bot_user_id,
         "claude_command": os.getenv("CLAUDE_COMMAND", "claude"),
         "claude_model": os.getenv("CLAUDE_MODEL", "sonnet"),
-        "claude_effort": os.getenv("CLAUDE_EFFORT", "max"),
+        "claude_effort": os.getenv("CLAUDE_EFFORT", ""),
         "claude_permission_mode": os.getenv("CLAUDE_PERMISSION_MODE", "acceptEdits"),
         "claude_working_dir": os.getenv("CLAUDE_WORKING_DIR", ""),
         "max_concurrent": os.getenv("MAX_CONCURRENT_SESSIONS", "3"),
@@ -210,7 +210,7 @@ async def main(env_path: Path | None = None) -> None:
     runner = ClaudeConfig(
         command=config["claude_command"],
         model=config["claude_model"],
-        effort=config["claude_effort"],
+        effort=config["claude_effort"] or None,
         permission_mode=config["claude_permission_mode"],
         working_dir=config["claude_working_dir"] or None,
         timeout_seconds=int(config["timeout"]),

--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -41,6 +41,12 @@ _LEGACY_WINDOW_PREFIX = "work"
 # compacts them back from ``base-index``. Far above any realistic window count.
 _SORT_TMP_BASE = 9000
 
+# Effort levels the ``claude --effort`` flag accepts (commander-validated; it
+# hard-errors on anything else).  ``ultracode``/``auto`` are real effort levels
+# but only settable via ``CLAUDE_CODE_EFFORT_LEVEL`` or the ``/effort`` command,
+# not this flag — so they are intentionally excluded here.
+_VALID_EFFORT_LEVELS = frozenset({"low", "medium", "high", "xhigh", "max"})
+
 # #147: Claude Code runs with ``editorMode: vim``.  Its input box therefore has
 # a vim NORMAL mode in which literal characters (``send-keys -l``) are
 # interpreted as editor commands, corrupting the message.  The TUI status bar
@@ -876,6 +882,7 @@ class TmuxSessionManager:
         permission_mode: str = "acceptEdits",
         dangerously_skip_permissions: bool = False,
         try_continue: bool = False,
+        effort: str | None = None,
     ) -> bool:
         """Start Claude Code inside the tmux window for *thread_id*.
 
@@ -910,6 +917,20 @@ class TmuxSessionManager:
             cmd_parts.append("--dangerously-skip-permissions")
         else:
             cmd_parts.extend(["--permission-mode", permission_mode])
+        if effort is not None:
+            if effort in _VALID_EFFORT_LEVELS:
+                cmd_parts.extend(["--effort", effort])
+            else:
+                # The --effort flag hard-errors on unknown values, which would
+                # abort claude startup and leave the thread with no reply.  Drop
+                # the flag and fall back to the CLI default instead of crashing.
+                # (ultracode/auto are valid effort levels but only via
+                # CLAUDE_CODE_EFFORT_LEVEL / the /effort command, not this flag.)
+                logger.warning(
+                    "start_claude: ignoring unsupported effort %r (valid: %s)",
+                    effort,
+                    ", ".join(sorted(_VALID_EFFORT_LEVELS)),
+                )
 
         # Escape single quotes in the prompt for shell safety.
         safe_prompt = prompt.replace("'", "'\\''")

--- a/docs/evidence/254/staging-launch-commands.md
+++ b/docs/evidence/254/staging-launch-commands.md
@@ -1,0 +1,26 @@
+# Staging Evidence — PR #254 (configurable effort)
+
+staging: `c-lord-parallel-3` / channel `1503196656265597082` / 2026-06-11
+前提: staging `.env` に `CLAUDE_EFFORT=high` を一時設定。`!clord <prompt>` で新規スレッドを spawn し、
+tmux window の claude 起動コマンドを `capture-pane` で観測（`--effort` フラグの有無が観測点）。
+
+## RED — `main` (effort プラミングが存在しない)
+新規 window `w13` の起動コマンド:
+```
+$ env -u CLAUDECODE claude --model sonnet --dangerously-skip-permissions 'PR254-RED-main …'
+```
+→ `CLAUDE_EFFORT=high` を設定しても `--effort` は**付かない**（main には effort を渡す経路が無い）。
+
+## GREEN — `feat/configurable-effort-default-max`
+新規 window `w14` の起動コマンド:
+```
+$ env -u CLAUDECODE claude --model sonnet --dangerously-skip-permissions --effort high 'PR254-GREEN-branch …'
+```
+→ `CLAUDE_EFFORT=high` が `--effort high` として渡る（設定可能化が機能）。
+
+## 新デフォルト（CLAUDE_EFFORT 未設定）
+`effort` 未指定なら `--effort` は付かず CLI デフォルトに従う（`ClaudeConfig().effort is None`、test_config.py）。
+これは main と同じ無フラグ挙動＝ゼロコンフィグ後方互換。
+
+注: TUI バナーの "high effort" は claude CLI 自身の env/config 由来で、c-lord の `--effort` とは独立。
+本証跡は**起動コマンド文字列**を観測点としている。

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from c_lord.claude.config import ClaudeConfig
 
 
-def test_effort_defaults_to_max() -> None:
-    """c-lord raises the effort default: a fresh ClaudeConfig uses 'max'.
+def test_effort_defaults_to_none() -> None:
+    """A fresh ClaudeConfig passes no --effort flag (CLI default applies).
 
-    The Claude CLI otherwise runs at its own (lower) default; c-lord opts every
-    session into the deepest reasoning level available via the --effort flag.
+    c-lord does not override the CLI's own reasoning-effort default; the
+    effort level is opt-in via ``CLAUDE_EFFORT`` / per-instance config.
     """
-    assert ClaudeConfig().effort == "max"
+    assert ClaudeConfig().effort is None
 
 
 def test_effort_is_configurable() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+"""Tests for ClaudeConfig defaults."""
+
+from __future__ import annotations
+
+from c_lord.claude.config import ClaudeConfig
+
+
+def test_effort_defaults_to_max() -> None:
+    """c-lord raises the effort default: a fresh ClaudeConfig uses 'max'.
+
+    The Claude CLI otherwise runs at its own (lower) default; c-lord opts every
+    session into the deepest reasoning level available via the --effort flag.
+    """
+    assert ClaudeConfig().effort == "max"
+
+
+def test_effort_is_configurable() -> None:
+    """The effort level is overridable per ClaudeConfig instance."""
+    assert ClaudeConfig(effort="high").effort == "high"

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -513,6 +513,63 @@ class TestTmuxSessionManager:
         cmd_str = " ".join(args[3:])
         assert "--continue" not in cmd_str
 
+    def test_start_claude_includes_effort_flag(self) -> None:
+        """start_claude passes a valid effort level as --effort <level>."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0),  # send-keys
+            ]
+            mgr.start_claude(12345, "hello", effort="max")
+
+        cmd_call = mock_run.call_args_list[1]
+        args = cmd_call[0][0]
+        cmd_str = " ".join(args[3:])
+        assert "--effort max" in cmd_str
+
+    def test_start_claude_no_effort_flag_when_none(self) -> None:
+        """effort=None (default) omits the --effort flag entirely."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0),  # send-keys
+            ]
+            mgr.start_claude(12345, "hello")
+
+        cmd_call = mock_run.call_args_list[1]
+        args = cmd_call[0][0]
+        cmd_str = " ".join(args[3:])
+        assert "--effort" not in cmd_str
+
+    def test_start_claude_invalid_effort_is_skipped(self) -> None:
+        """An effort the --effort flag rejects (e.g. ultracode) is dropped, not
+        passed — passing it would hard-error the claude process and leave the
+        thread with no response. The command is still built without it."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        mgr._thread_to_window[12345] = "work1"
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
+                MagicMock(returncode=0),  # send-keys
+            ]
+            result = mgr.start_claude(12345, "hello", effort="ultracode")
+
+        assert result is True
+        cmd_call = mock_run.call_args_list[1]
+        args = cmd_call[0][0]
+        cmd_str = " ".join(args[3:])
+        assert "--effort" not in cmd_str
+
     def test_send_input_sends_text_and_enter(self) -> None:
         mgr = TmuxSessionManager(mapping_path="")
         mgr._available = True

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1030,6 +1030,7 @@ class TestTmuxClaudeRunnerRun:
             permission_mode="acceptEdits",
             dangerously_skip_permissions=False,
             try_continue=False,
+            effort=None,
         )
         assert any(e.message_type == MessageType.RESULT and e.is_complete for e in events)
 
@@ -1664,6 +1665,7 @@ class TestContinueFallback:
             permission_mode="acceptEdits",
             dangerously_skip_permissions=False,
             try_continue=True,
+            effort=None,
         )
 
     @pytest.mark.asyncio
@@ -1750,6 +1752,7 @@ class TestContinueFallback:
             permission_mode="acceptEdits",
             dangerously_skip_permissions=False,
             try_continue=False,
+            effort=None,
         )
         # Only one is_claude_running call (no post-continue check)
         assert tmux_manager.is_claude_running.call_count == 1


### PR DESCRIPTION
## What does this PR do?

Makes Claude's reasoning effort **configurable** (per instance / via env). The **default is unchanged**: no `--effort` flag is passed, leaving the CLI's own default in effect. (当初は default=`max` だったが、2026-06-11 のユーザー判断で「設定可能化のみ・default は CLI 任せ」に変更。)

- `ClaudeConfig.effort: str | None = None` (configurable per instance; `None` = no flag)
- `CLAUDE_EFFORT` env var (`main.py`) + documented in `.env.example`
- `TmuxClaudeRunner` threads `effort` through all three start paths
- `TmuxSessionManager.start_claude` validates against the 5 flag-valid levels (`low/medium/high/xhigh/max`) and **drops + warns** on anything else — `ultracode`/`auto` are real effort levels but only reachable via `CLAUDE_CODE_EFFORT_LEVEL` / the `/effort` command, not this flag, and passing them would hard-error claude startup
- All four cogs pass `effort=self.runner.effort`

Backward compatible: `effort` defaults to `None` at every layer (`ClaudeConfig` / runner / `start_claude`), so the out-of-the-box behavior is identical to before this PR — the flag only appears when explicitly configured.

## Why?

The CLI exposes `--effort low|medium|high|xhigh|max`; c-lord had no way to use it, so the effort level could not be tuned per deployment. This PR adds the knob (`CLAUDE_EFFORT` / `ClaudeConfig(effort=...)`) without changing the default behavior. No linked issue (direct request); not using `Closes`.

## Acceptance Criteria (copied from the issue)

- [x] AC 1: effort level is configurable (via `ClaudeConfig(effort=...)` and `CLAUDE_EFFORT` env)
- [x] AC 2: the default is unchanged — `ClaudeConfig().effort is None`, no `--effort` flag passed (2026-06-11 のユーザー判断で旧 AC「default を max に上げる」を置換)
- [x] AC 3: a configured effort is passed to the Claude CLI as `--effort <level>` at launch
- [x] AC 4: an unsupported value (e.g. `ultracode`) never hard-errors startup — it is dropped with a warning

## Staging Evidence

staging `c-lord-parallel-3` (channel `1503196656265597082`) / 2026-06-11 / 詳細は `docs/evidence/254/`。
`.env` に `CLAUDE_EFFORT=high` を一時設定し、`!clord` で新規スレッド spawn → claude 起動コマンドを観測:

| | branch | 起動コマンド | --effort |
|---|---|---|---|
| **RED** | `main` | `claude --model sonnet --dangerously-skip-permissions …` | **無し**（effort 経路が存在しない） |
| **GREEN** | `feat/configurable-effort-default-max` | `claude --model sonnet --dangerously-skip-permissions --effort high …` | **`--effort high`** |

`CLAUDE_EFFORT` 未設定なら `--effort` は付かず CLI デフォルト（新デフォルト＝後方互換）。


## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted below
- [x] `uv run pytest tests/ -v` passes (1585 passed / rework 後に再実行)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in — RED (no --effort) → GREEN (--effort high) on staging (docs/evidence/254/)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`) — N/A, no issue linked

### TDD RED evidence

- `tests/test_config.py::test_effort_defaults_to_max` — RED: `AttributeError: 'ClaudeConfig' object has no attribute 'effort'`
- (rework) `tests/test_config.py::test_effort_defaults_to_none` — RED: `AssertionError: assert 'max' is None` → GREEN after default change (commit cdb1710)
- `tests/test_tmux.py::test_start_claude_invalid_effort_is_skipped` — RED: `TypeError: TmuxSessionManager.start_claude() got an unexpected keyword argument 'effort'`

GREEN after implementation: all 5 new tests pass; full suite 1281 passed.

### Security audit

Ran `security-audit`. PASS — `effort` is operator-controlled config (`CLAUDE_EFFORT`), not Discord-user input, and is allowlist-validated against 5 fixed literals before reaching the tmux command string. No injection vector; no `shell=True`; no secret in logs.

