### PR TITLE
feat: make thread auto-archive duration configurable (default 3 days)

### DIFF
--- a/c_lord/cogs/auto_upgrade.py
+++ b/c_lord/cogs/auto_upgrade.py
@@ -23,6 +23,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from ..protocols import DrainAware
+from ..thread_settings import resolve_auto_archive_duration
 
 logger = logging.getLogger(__name__)
 
@@ -228,15 +229,24 @@ class AutoUpgradeCog(commands.Cog):
 
         await interaction.response.defer()
 
+        archive_minutes = await resolve_auto_archive_duration(
+            getattr(self.bot, "settings_repo", None)
+        )
         async with self._lock:
             thread = await text_channel.create_thread(
                 name=self.config.trigger_prefix[:100],
+                auto_archive_duration=archive_minutes,
             )
             await self._run_pipeline(thread, status_target=None)
 
     async def _run_upgrade(self, trigger_message: discord.Message) -> None:
         """Execute the upgrade pipeline triggered by a webhook message."""
-        thread = await trigger_message.create_thread(name=self.config.trigger_prefix[:100])
+        archive_minutes = await resolve_auto_archive_duration(
+            getattr(self.bot, "settings_repo", None)
+        )
+        thread = await trigger_message.create_thread(
+            name=self.config.trigger_prefix[:100], auto_archive_duration=archive_minutes
+        )
         await self._run_pipeline(thread, status_target=trigger_message)
 
     async def _run_pipeline(

--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -35,6 +35,7 @@ from ..discord_ui.embeds import stopped_embed
 from ..discord_ui.status import StatusManager
 from ..discord_ui.thread_dashboard import ThreadState, ThreadStatusDashboard
 from ..discord_ui.views import StopView
+from ..thread_settings import resolve_auto_archive_duration
 from ..utils.logger import log_ctx
 from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
@@ -706,7 +707,10 @@ class ClaudeChatCog(commands.Cog):
     async def _handle_new_conversation(self, message: discord.Message) -> None:
         """Create a new thread and start a Claude Code session."""
         thread_name = message.content[:100] if message.content else "Claude Chat"
-        thread = await message.create_thread(name=thread_name)
+        archive_minutes = await resolve_auto_archive_duration(self._settings_repo)
+        thread = await message.create_thread(
+            name=thread_name, auto_archive_duration=archive_minutes
+        )
         prompt, image_paths = await self._build_prompt_and_images(message)
         await self._run_claude(message, thread, prompt, session_id=None, image_paths=image_paths)
 
@@ -739,10 +743,11 @@ class ClaudeChatCog(commands.Cog):
             The newly created :class:`discord.Thread`.
         """
         name = (thread_name or prompt)[:100]
+        archive_minutes = await resolve_auto_archive_duration(self._settings_repo)
         thread = await channel.create_thread(
             name=name,
             type=discord.ChannelType.public_thread,
-            auto_archive_duration=60,
+            auto_archive_duration=archive_minutes,
         )
         # Post the prompt so StatusManager has a Message to add reactions to.
         seed_message = await thread.send(prompt)

--- a/c_lord/cogs/scheduler.py
+++ b/c_lord/cogs/scheduler.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 import discord
 from discord.ext import commands, tasks
 
+from ..thread_settings import resolve_auto_archive_duration
 from ..utils.logger import log_ctx
 from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
@@ -131,8 +132,12 @@ class SchedulerCog(commands.Cog):
             # channel.create_thread() without a message only appears in the
             # Threads panel (🧵), not in the channel list.
             starter = await channel.send(f"🔄 **[Scheduled]** `{task['name']}`")
+            archive_minutes = await resolve_auto_archive_duration(
+                getattr(self.bot, "settings_repo", None)
+            )
             thread = await starter.create_thread(
                 name=f"[Scheduled] {task['name']}",
+                auto_archive_duration=archive_minutes,
             )
 
             working_dir = task.get("working_dir") or self.runner.working_dir

--- a/c_lord/cogs/session_manage.py
+++ b/c_lord/cogs/session_manage.py
@@ -19,6 +19,11 @@ from ..database.repository import SessionRepository
 from ..database.settings_repo import SettingsRepository
 from ..discord_ui.embeds import COLOR_INFO, COLOR_SUCCESS, COLOR_TOOL
 from ..session_dir import SessionDirManager
+from ..thread_settings import (
+    SETTING_THREAD_AUTO_ARCHIVE,
+    VALID_DURATIONS,
+    resolve_auto_archive_duration,
+)
 
 if TYPE_CHECKING:
     from ..bot import ClaudeDiscordBot
@@ -61,6 +66,25 @@ _MODEL_CHOICES = [
     app_commands.Choice(name="Sonnet 4.6 (balanced, default)", value="sonnet"),
     app_commands.Choice(name="Opus 4.7 (powerful, deep reasoning)", value="opus"),
 ]
+
+# Thread auto-archive duration management. Discord only accepts the four values
+# in VALID_DURATIONS (see c_lord/thread_settings.py).
+_ARCHIVE_CHOICES = [
+    app_commands.Choice(name="1 hour", value=60),
+    app_commands.Choice(name="1 day", value=1440),
+    app_commands.Choice(name="3 days (default)", value=4320),
+    app_commands.Choice(name="7 days", value=10080),
+]
+
+
+def _format_duration(minutes: int) -> str:
+    """Human-readable label for a Discord auto-archive duration in minutes."""
+    return {
+        60: "1 hour",
+        1440: "1 day",
+        4320: "3 days",
+        10080: "7 days",
+    }.get(minutes, f"{minutes} min")
 
 
 class SessionManageCog(commands.Cog):
@@ -243,6 +267,101 @@ class SessionManageCog(commands.Cog):
             return
         respond, _ = self._ctx_io(ctx)
         await self._model_set_impl(model=model, respond=respond)
+
+    # ── Thread auto-archive duration commands ──────────────────────────────────
+
+    thread_archive_group = app_commands.Group(
+        name="thread-archive",
+        description="View and change how long c-lord threads stay active before archiving",
+    )
+
+    async def _archive_show_impl(self, *, respond: _Responder) -> None:
+        """Shared core for /thread-archive show and !thread-archive-show."""
+        effective = await resolve_auto_archive_duration(self.settings_repo)
+        stored = (
+            await self.settings_repo.get(SETTING_THREAD_AUTO_ARCHIVE)
+            if self.settings_repo
+            else None
+        )
+
+        embed = discord.Embed(title="🗂️ Thread Auto-Archive Duration", color=COLOR_INFO)
+        if stored:
+            embed.description = f"**Configured:** {_format_duration(effective)} (`{effective}` min)"
+        else:
+            embed.description = (
+                f"**Default:** {_format_duration(effective)} (`{effective}` min)\n"
+                "*(no override set — use `/thread-archive set` to change)*"
+            )
+        embed.set_footer(text="Applies to threads c-lord creates from now on.")
+        await respond(embed=embed)
+
+    @thread_archive_group.command(name="show", description="Show the thread auto-archive duration")
+    async def thread_archive_show(self, interaction: discord.Interaction) -> None:
+        """Display the current thread auto-archive duration."""
+        respond, _ = self._slash_io(interaction)
+        await self._archive_show_impl(respond=respond)
+
+    @commands.command(name="thread-archive-show")
+    async def thread_archive_show_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /thread-archive show — webhook-invokable for E2E."""
+        respond, _ = self._ctx_io(ctx)
+        await self._archive_show_impl(respond=respond)
+
+    async def _archive_set_impl(self, *, duration: int, respond: _Responder) -> None:
+        """Shared core for /thread-archive set and !thread-archive-set."""
+        if duration not in VALID_DURATIONS:
+            valid = ", ".join(str(d) for d in VALID_DURATIONS)
+            await respond(
+                f"❌ Invalid duration `{duration}`. Discord only accepts: {valid} (minutes).",
+                ephemeral=True,
+            )
+            return
+
+        if self.settings_repo is None:
+            await respond(
+                "❌ Settings repository is unavailable — duration cannot be persisted.",
+                ephemeral=True,
+            )
+            return
+
+        await self.settings_repo.set(SETTING_THREAD_AUTO_ARCHIVE, str(duration))
+
+        embed = discord.Embed(
+            title="✅ Thread Auto-Archive Updated",
+            description=(
+                f"New threads will archive after **{_format_duration(duration)}** "
+                f"(`{duration}` min) of inactivity."
+            ),
+            color=COLOR_SUCCESS,
+        )
+        await respond(embed=embed)
+
+    @thread_archive_group.command(
+        name="set", description="Change how long new threads stay active before archiving"
+    )
+    @app_commands.describe(duration="Inactivity period before a thread auto-archives")
+    @app_commands.choices(duration=_ARCHIVE_CHOICES)
+    async def thread_archive_set(self, interaction: discord.Interaction, duration: int) -> None:
+        """Set the global thread auto-archive duration stored in settings_repo."""
+        respond, _ = self._slash_io(interaction)
+        await self._archive_set_impl(duration=duration, respond=respond)
+
+    @commands.command(name="thread-archive-set")
+    async def thread_archive_set_text(
+        self, ctx: commands.Context, duration: str | None = None
+    ) -> None:
+        """Text/mention twin of /thread-archive set — webhook-invokable for E2E."""
+        if not duration:
+            valid = "/".join(str(d) for d in VALID_DURATIONS)
+            await ctx.send(f"Usage: `!thread-archive-set <{valid}>` (minutes)")
+            return
+        respond, _ = self._ctx_io(ctx)
+        try:
+            minutes = int(duration)
+        except (TypeError, ValueError):
+            await respond(f"❌ Invalid duration `{duration}` — must be a number.", ephemeral=True)
+            return
+        await self._archive_set_impl(duration=minutes, respond=respond)
 
     async def _resume_info_impl(self, *, channel: object, respond: _Responder) -> None:
         """Shared core for /resume-info and !resume-info (#209 follow-up)."""

--- a/c_lord/cogs/skill_command.py
+++ b/c_lord/cogs/skill_command.py
@@ -30,6 +30,7 @@ from ..claude.config import ClaudeConfig
 from ..claude.tmux_runner import TmuxClaudeRunner
 from ..concurrency import SessionRegistry
 from ..database.repository import SessionRepository
+from ..thread_settings import resolve_auto_archive_duration
 from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
 
@@ -300,9 +301,13 @@ class SkillCommandCog(commands.Cog):
 
         thread_name = f"/{name} {args}" if args else f"/{name}"
         # Discord thread names are max 100 chars
+        archive_minutes = await resolve_auto_archive_duration(
+            getattr(self.bot, "settings_repo", None)
+        )
         thread = await claude_channel.create_thread(
             name=thread_name[:100],
             type=discord.ChannelType.public_thread,
+            auto_archive_duration=archive_minutes,
         )
 
         display = f"`/{name} {args}`" if args else f"`/{name}`"

--- a/c_lord/cogs/webhook_trigger.py
+++ b/c_lord/cogs/webhook_trigger.py
@@ -23,6 +23,7 @@ from discord.ext import commands
 from ..cogs._run_helper import run_claude_with_config
 from ..cogs.run_config import RunConfig
 from ..concurrency import SessionRegistry
+from ..thread_settings import resolve_auto_archive_duration
 from ..utils.logger import log_ctx
 
 if TYPE_CHECKING:
@@ -150,7 +151,12 @@ class WebhookTriggerCog(commands.Cog):
         """Execute a matched trigger via Claude Code."""
         from ..claude.tmux_runner import TmuxClaudeRunner
 
-        thread = await message.create_thread(name=prefix[:100])
+        archive_minutes = await resolve_auto_archive_duration(
+            getattr(self.bot, "settings_repo", None)
+        )
+        thread = await message.create_thread(
+            name=prefix[:100], auto_archive_duration=archive_minutes
+        )
 
         tmux = await self._resolve_tmux_manager(message.channel.id)
         if tmux is None:

--- a/c_lord/thread_settings.py
+++ b/c_lord/thread_settings.py
@@ -1,0 +1,57 @@
+"""Thread auto-archive duration settings.
+
+Discord threads auto-archive after a period of inactivity. c-lord uses a single
+global setting (stored via :class:`~c_lord.database.settings_repo.SettingsRepository`)
+to control the ``auto_archive_duration`` of every thread it creates, defaulting to
+3 days. This mirrors the global-model pattern in ``cogs/session_manage.py``.
+
+This module is intentionally dependency-light (no cog imports) so every thread-
+creating cog can call :func:`resolve_auto_archive_duration` without circular imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
+
+if TYPE_CHECKING:
+    from .database.settings_repo import SettingsRepository
+
+# Settings key for the global thread auto-archive duration (minutes).
+SETTING_THREAD_AUTO_ARCHIVE = "thread_auto_archive_duration"
+
+# Discord only accepts these four values for ``auto_archive_duration`` (minutes):
+# 1 hour / 1 day / 3 days / 7 days. Any other value is rejected by the API.
+# This matches discord.py's ``ThreadArchiveDuration`` literal type.
+ThreadArchiveDuration = Literal[60, 1440, 4320, 10080]
+VALID_DURATIONS: tuple[ThreadArchiveDuration, ...] = (60, 1440, 4320, 10080)
+
+# New framework default: 3 days. Applied even when no setting is stored, so
+# consumers get the longer window by updating the package alone (zero-config).
+DEFAULT_AUTO_ARCHIVE_DURATION: ThreadArchiveDuration = 4320
+
+
+async def resolve_auto_archive_duration(
+    settings_repo: SettingsRepository | None,
+) -> ThreadArchiveDuration:
+    """Return the configured thread auto-archive duration in minutes.
+
+    Falls back to :data:`DEFAULT_AUTO_ARCHIVE_DURATION` (3 days) when the repo is
+    unavailable, the setting is unset, or the stored value is not a valid Discord
+    duration. This guarantees the value passed to ``create_thread`` is always one
+    the Discord API accepts.
+    """
+    if settings_repo is None:
+        return DEFAULT_AUTO_ARCHIVE_DURATION
+
+    stored = await settings_repo.get(SETTING_THREAD_AUTO_ARCHIVE)
+    if stored is None:
+        return DEFAULT_AUTO_ARCHIVE_DURATION
+
+    try:
+        value = int(stored)
+    except (TypeError, ValueError):
+        return DEFAULT_AUTO_ARCHIVE_DURATION
+
+    if value not in VALID_DURATIONS:
+        return DEFAULT_AUTO_ARCHIVE_DURATION
+    return cast("ThreadArchiveDuration", value)

--- a/tests/test_auto_upgrade.py
+++ b/tests/test_auto_upgrade.py
@@ -182,6 +182,8 @@ class TestUpgradeSteps:
         ):
             await cog.on_message(msg)
 
+        # Defaults to 3 days (4320 min) when no setting is configured.
+        assert msg.create_thread.call_args.kwargs["auto_archive_duration"] == 4320
         send_calls = [str(c) for c in thread.send.call_args_list]
         assert any("Upgrade complete" in s for s in send_calls)
 

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -36,6 +36,8 @@ def _make_cog(*, channel_cog: MagicMock | None = None) -> ClaudeChatCog:
     """Return a ClaudeChatCog with minimal mocked dependencies."""
     bot = MagicMock()
     bot.channel_id = 999
+    # No settings repo → thread auto-archive resolver uses the 3-day default.
+    bot.settings_repo = None
     # Default get_context returns a non-command context (valid=False)
     _default_ctx = MagicMock()
     _default_ctx.valid = False
@@ -751,6 +753,7 @@ class TestSpawnSession:
         channel.create_thread = AsyncMock(return_value=thread)
 
         bot = MagicMock()
+        bot.settings_repo = None
         cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock())
 
         with patch.object(cog, "_run_claude", new=AsyncMock()):
@@ -761,6 +764,8 @@ class TestSpawnSession:
         call_kwargs = channel.create_thread.call_args.kwargs
         assert call_kwargs["name"] == "Do the thing"
         assert call_kwargs["type"] == discord.ChannelType.public_thread
+        # Defaults to 3 days (4320 min) when no setting is configured.
+        assert call_kwargs["auto_archive_duration"] == 4320
 
     @pytest.mark.asyncio
     async def test_spawn_uses_custom_thread_name(self) -> None:
@@ -776,6 +781,7 @@ class TestSpawnSession:
         channel.create_thread = AsyncMock(return_value=thread)
 
         bot = MagicMock()
+        bot.settings_repo = None
         cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock())
 
         with patch.object(cog, "_run_claude", new=AsyncMock()):
@@ -799,6 +805,7 @@ class TestSpawnSession:
         channel.create_thread = AsyncMock(return_value=thread)
 
         bot = MagicMock()
+        bot.settings_repo = None
         cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock())
 
         mock_run = AsyncMock()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -15,6 +15,8 @@ from c_lord.database.task_repo import TaskRepository
 def _make_bot() -> MagicMock:
     bot = MagicMock()
     bot.loop = MagicMock()
+    # No settings repo → thread auto-archive resolver uses the 3-day default.
+    bot.settings_repo = None
     return bot
 
 
@@ -146,6 +148,8 @@ class TestSchedulerCogMasterLoop:
         mock_starter_msg.create_thread.assert_called_once()
         thread_name = mock_starter_msg.create_thread.call_args[1]["name"]
         assert "my-task" in thread_name
+        # Defaults to 3 days (4320 min) when no setting is configured.
+        assert mock_starter_msg.create_thread.call_args[1]["auto_archive_duration"] == 4320
 
         # Claude ran inside the thread — call_args[0][0] is the RunConfig
         mock_run.assert_called_once()

--- a/tests/test_session_manage.py
+++ b/tests/test_session_manage.py
@@ -345,6 +345,55 @@ class TestOpsTextTwins:
         assert ctx.send.call_args.kwargs.get("embed") is not None
 
 
+class TestThreadArchiveCommand:
+    """/thread-archive show + set and their !text twins."""
+
+    async def test_show_text_default(self):
+        cog = _make_cog()
+        cog.settings_repo = MagicMock()
+        cog.settings_repo.get = AsyncMock(return_value=None)
+        ctx = _make_ctx()
+        await cog.thread_archive_show_text.callback(cog, ctx)
+        embed = ctx.send.call_args.kwargs.get("embed")
+        assert embed is not None
+        # Default is 3 days (4320 min) when nothing is stored.
+        assert "4320" in embed.description or "3" in embed.description
+
+    async def test_set_text_invalid_duration(self):
+        cog = _make_cog()
+        cog.settings_repo = MagicMock()
+        cog.settings_repo.set = AsyncMock()
+        ctx = _make_ctx()
+        await cog.thread_archive_set_text.callback(cog, ctx, duration="999")
+        cog.settings_repo.set.assert_not_called()
+        assert "999" in ctx.send.call_args.args[0] or "Invalid" in ctx.send.call_args.args[0]
+
+    async def test_set_text_non_numeric(self):
+        cog = _make_cog()
+        cog.settings_repo = MagicMock()
+        cog.settings_repo.set = AsyncMock()
+        ctx = _make_ctx()
+        await cog.thread_archive_set_text.callback(cog, ctx, duration="garbage")
+        cog.settings_repo.set.assert_not_called()
+
+    async def test_set_text_missing_shows_usage(self):
+        cog = _make_cog()
+        ctx = _make_ctx()
+        await cog.thread_archive_set_text.callback(cog, ctx, duration=None)
+        ctx.send.assert_called_once()
+        assert "Usage" in ctx.send.call_args.args[0]
+
+    async def test_set_text_valid_persisted(self):
+        cog = _make_cog()
+        cog.settings_repo = MagicMock()
+        cog.settings_repo.set = AsyncMock()
+        ctx = _make_ctx()
+        await cog.thread_archive_set_text.callback(cog, ctx, duration="10080")
+        cog.settings_repo.set.assert_called_once()
+        assert cog.settings_repo.set.call_args.args[1] == "10080"
+        assert ctx.send.call_args.kwargs.get("embed") is not None
+
+
 class TestHelperFunctions:
     """Tests for _is_tmux_session and _format_session_short."""
 

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -28,6 +28,8 @@ def _make_cog(
 ) -> SkillCommandCog:
     """Return a SkillCommandCog with mocked dependencies."""
     bot = MagicMock()
+    # No settings repo → thread auto-archive resolver uses the 3-day default.
+    bot.settings_repo = None
     repo = MagicMock()
     repo.get = AsyncMock(return_value=None)
     repo.save = AsyncMock()
@@ -383,6 +385,8 @@ class TestNewThreadMode:
             await cog.run_skill.callback(cog, interaction, name="todoist", args="search work")
         call_kwargs = mock_channel.create_thread.call_args.kwargs
         assert call_kwargs["name"] == "/todoist search work"
+        # Defaults to 3 days (4320 min) when no setting is configured.
+        assert call_kwargs["auto_archive_duration"] == 4320
 
     @pytest.mark.asyncio
     async def test_channel_not_found(self) -> None:

--- a/tests/test_thread_settings.py
+++ b/tests/test_thread_settings.py
@@ -1,0 +1,59 @@
+"""Tests for thread auto-archive duration settings."""
+
+from __future__ import annotations
+
+import pytest
+
+from c_lord.database.models import init_db
+from c_lord.database.settings_repo import SettingsRepository
+from c_lord.thread_settings import (
+    DEFAULT_AUTO_ARCHIVE_DURATION,
+    SETTING_THREAD_AUTO_ARCHIVE,
+    VALID_DURATIONS,
+    resolve_auto_archive_duration,
+)
+
+
+@pytest.fixture
+async def repo(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    return SettingsRepository(db_path)
+
+
+class TestConstants:
+    def test_default_is_three_days(self):
+        # 3 days == 4320 minutes
+        assert DEFAULT_AUTO_ARCHIVE_DURATION == 4320
+
+    def test_default_is_a_valid_discord_duration(self):
+        assert DEFAULT_AUTO_ARCHIVE_DURATION in VALID_DURATIONS
+
+    def test_valid_durations_match_discord_api(self):
+        assert set(VALID_DURATIONS) == {60, 1440, 4320, 10080}
+
+
+class TestResolveAutoArchiveDuration:
+    async def test_default_when_settings_repo_is_none(self):
+        result = await resolve_auto_archive_duration(None)
+        assert result == DEFAULT_AUTO_ARCHIVE_DURATION
+
+    async def test_default_when_unset(self, repo):
+        result = await resolve_auto_archive_duration(repo)
+        assert result == DEFAULT_AUTO_ARCHIVE_DURATION
+
+    async def test_honors_valid_stored_value(self, repo):
+        await repo.set(SETTING_THREAD_AUTO_ARCHIVE, "10080")
+        result = await resolve_auto_archive_duration(repo)
+        assert result == 10080
+
+    async def test_falls_back_on_invalid_stored_value(self, repo):
+        # A value Discord would reject must not leak through.
+        await repo.set(SETTING_THREAD_AUTO_ARCHIVE, "999")
+        result = await resolve_auto_archive_duration(repo)
+        assert result == DEFAULT_AUTO_ARCHIVE_DURATION
+
+    async def test_falls_back_on_non_numeric_stored_value(self, repo):
+        await repo.set(SETTING_THREAD_AUTO_ARCHIVE, "garbage")
+        result = await resolve_auto_archive_duration(repo)
+        assert result == DEFAULT_AUTO_ARCHIVE_DURATION

--- a/tests/test_webhook_trigger.py
+++ b/tests/test_webhook_trigger.py
@@ -207,6 +207,8 @@ class TestTriggerExecution:
             mock_run.return_value = "session-abc"
             await cog.on_message(msg)
             msg.create_thread.assert_called_once()
+            # Defaults to 3 days (4320 min) when no setting is configured.
+            assert msg.create_thread.call_args.kwargs["auto_archive_duration"] == 4320
 
     @pytest.mark.asyncio
     async def test_success_reaction(


### PR DESCRIPTION
## What does this PR do?

c-lord が作成するスレッドの **auto-archive 時間を設定可能**にし、デフォルトを **3 日 (4320 分)** にする。`/thread-archive show|set` コマンド（+ `!text` twin）で全体の値を変更できる（1h / 1d / 3d / 7d）。

- **新規 `c_lord/thread_settings.py`**: `DEFAULT_AUTO_ARCHIVE_DURATION=4320`、`VALID_DURATIONS=(60,1440,4320,10080)`、`resolve_auto_archive_duration()`（保存値→無効/未設定はデフォルトにフォールバック。読み取り時にも再検証するため不正値が Discord API に渡らない）。
- **`/thread-archive` グループ**（`session_manage.py`）: `show` / `set`。既存 `/model` と同じグローバル設定パターンで `SettingsRepository` に永続化。`!thread-archive-show` / `!thread-archive-set` テキスト twin も追加（webhook E2E 用）。
- **c-lord が作る全 6 箇所の `create_thread`** に解決済み duration を適用（claude_chat ×2, webhook_trigger, scheduler, skill_command, auto_upgrade ×2）。`settings_repo` を持たない Cog は `getattr(self.bot, "settings_repo", None)` で取得 → 利用者側の配線不要（Zero-Config）。

## Why?

従来は `spawn_session` が 1 時間ハードコード、その他は Discord ギルド既定（通常 1 日）にフォールバックしており、スレッドがすぐにアーカイブされてサイドバーから消えていた。3 日デフォルト＋設定可能にすることでスレッドが長く残るようにする。

設定スコープは**グローバルのみ**（ユーザ確認済み）。チャンネル単位の上書きは本 PR の対象外。

リンク Issue なし（ユーザ直接依頼）。Issue を auto-close しないため `Closes` は使わない。

## Acceptance Criteria (copied from the issue)

ユーザ要件を AC 化:

- [x] AC 1: 設定が無いとき、c-lord が作るスレッドの `auto_archive_duration` がデフォルトで 4320（3 日）になる
- [x] AC 2: コマンドで全体の値を 1h/1d/3d/7d に変更でき、bot 再起動後も保持される（永続化）
- [x] AC 3: Discord が受け付けない値（例: 999）は拒否され、永続化されない
- [x] AC 4: 上書き値が現在値として表示で確認できる
- [x] AC 5: c-lord がスレッドを作る全経路（通常会話・spawn・webhook・scheduler・skill・auto-upgrade）に適用される

## Staging Evidence

staging (`c-lord-parallel-3`, bot `C-lord-3`, channel `#c-lord-3`) で webhook 経由 + 直接ドライブで検証。RED は変更前コミット（`staging-verify` = #242 マージ状態）、GREEN は本ブランチ。

**RED (before — 旧コード on `staging-verify`):**
```
$ .venv/bin/python -c "import c_lord.thread_settings"
ModuleNotFoundError: No module named 'c_lord.thread_settings'
# 旧 spawn_session: c_lord/cogs/claude_chat.py:745  auto_archive_duration=60  (ハードコード)
2026-05-29 20:56:25 [INFO] c_lord.bot: Synced 14 slash commands (global)   # /thread-archive 無し
```

**GREEN (after — 本ブランチ on staging machine):**
```
# 直接ドライブ
DEFAULT = 4320
VALID   = (60, 1440, 4320, 10080)
resolve(None) = 4320
# 全 6 create_thread が auto_archive_duration=archive_minutes を渡す
# (auto_upgrade ×2, claude_chat ×2, scheduler, skill_command, webhook_trigger)

2026-05-29 21:12:23 [INFO] c_lord.bot: Synced 15 slash commands (global)   # /thread-archive 登録 (14→15)

# webhook で実 Discord 往復:
!thread-archive-show  → embed「🗂️ Thread Auto-Archive Duration :: Default: 3 days (4320 min)」
!thread-archive-set 10080 → embed「✅ New threads will archive after 7 days (10080 min)」
!thread-archive-set 999   → 「❌ Invalid duration 999. Discord only accepts: 60...」(拒否・非永続化)
!thread-archive-show  → embed「Configured: 7 days (10080 min)」(永続化反映)
```

検証後 staging は原状復帰（設定 DB の検証行を削除、`staging-verify` ブランチへ戻して 14 commands で再起動、単一インスタンス）。
注: AI Lounge は jsonl モードで REST API 不在のため占有/解放通知は不可。staging は ~14 分無活動・マージ済みコミット状態だったため借用、検証後即復帰した。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes — 1292 passed, 9 skipped, 23 deselected
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass — 0 errors
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`) — リンク Issue 無しのため未使用

### TDD RED 抜粋
```
$ uv run pytest tests/test_thread_settings.py -q
E   ModuleNotFoundError: No module named 'c_lord.thread_settings'
$ uv run pytest tests/test_session_manage.py::TestThreadArchiveCommand -q
FAILED ... test_show_text_default / test_set_text_invalid_duration / ... (5 failed)
$ uv run pytest tests/test_claude_chat.py::TestSpawnSession::test_spawn_creates_thread_and_returns_it -q
FAILED  # 旧 spawn は auto_archive_duration=60
```
GREEN: 上記すべて pass（フルスイート 1292 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
