### PR TITLE
docs: 読み取りは MCP でなく curl にフォールバックする旨を明文化 (Refs #259, #234)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ c-lord のクローン (parallel worktree, 別ディレクトリの clone 等) �
 **前提と制約**:
 - `c_lord/cogs/_run_helper.py` は **bot が spawn する子 Claude の env から `DISCORD_BOT_TOKEN` を strip する** (security audit に記載)。bot 経由で立った Claude は環境変数からは token を読めない
 - 手動で `claude` コマンドを叩いて立ち上げた tmux window 内 Claude には strip が掛からないので、**bot の `.env` ファイル**を直接読めばよい
-- Discord MCP plugin (`plugin:discord:discord`) は別チャンネルへ `Missing Access` で失敗することが多いので、デバッグ時は **Discord REST API を curl で叩く方が確実**
+- Discord MCP plugin (`plugin:discord:discord`) は別チャンネルへ `Missing Access` で失敗することが多い。**メッセージの読み取りは MCP に頼らず、`.env` の bot token を読んで Discord REST API を `curl` で叩く**のが確実 — MCP が `Missing Access` を返しても**そこで諦めず curl にフォールバックすること**。MCP は c-lord のスタック外（利用者環境にある保証もない）なので読み取りの基盤にしない。読み取り経路を skill + API として c-lord 内に正式実装する作業は #259、設計方針は #234 を参照
 
 **Token 取得**: 各 clone の作業ディレクトリ直下の `.env` を見るのが基本。本体 (bot を起動している c-lord clone) 以外の並行作業 clone (`c-lord-parallel`, `c-lord-parallel-2`, ...) には **`.env` を本体に symlink する規約** にしている:
 


### PR DESCRIPTION
## What does this PR do?

Discord メッセージの**読み取り**は MCP (`plugin:discord:discord`) ではなく、`.env` の bot token を使った `curl`（Discord REST）にフォールバックすべき、という運用を CLAUDE.md の「Debugging Discord from a Claude session」に明文化する（1 行修正）。

## Why?

MCP は別チャンネルで `Missing Access` になりやすく、かつ **c-lord のスタック外**（利用者環境にある保証なし）なので読み取りの基盤にはしない。実際に「MCP で失敗 → curl にフォールバックせず諦める」事例が Discord 上で観測されたため、フォールバックを**命令形で明示**する。これは #259（読み取り経路の skill + API 正式実装）の軽量先行修正。

Refs #259
Refs #234

## Acceptance Criteria (copied from the issue)

本 PR は #259 の AC を満たすものではなく、その**軽量先行（docs のみ）**修正のため、対応する AC は無い（#259 は開いたまま）。

- [x] N/A — docs-only 先行修正。#259 の AC は実装 PR 側で対応する

## Staging Evidence (証跡)

Skip 理由: **純粋な docs 修正**（CLAUDE.md 1 行）でランタイム挙動は変わらないため、Staging 検証は対象外（DoD のスキップ例外に該当）。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

> **Label exemptions** (`no-runtime-change` or `documentation` label): items 1–2 and 5 below are waived.
> `Closes` discipline (item 7) is **always enforced**, regardless of label.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted （`documentation` ラベルにより免除）
- [x] `uv run pytest tests/ -v` passes （docs のみ変更／CI で確認）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass （docs のみ／CI で確認）
- [x] Staging Evidence above is filled in (or a skip reason is written) （skip 理由を記載）
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met (else `Refs #N`), and written on its own line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
