### PR TITLE
fix: reply_chunker drops code body on oversized single-line code blocks (#266)

### DIFF
--- a/c_lord/discord_ui/reply_chunker.py
+++ b/c_lord/discord_ui/reply_chunker.py
@@ -37,6 +37,13 @@ def chunk_discord_content(content: str, limit: int = DISCORD_MAX) -> list[str]:
     chunk re-opens it (preserving the language hint) so each chunk is
     self-contained valid Markdown. Lines longer than ``limit`` are hard-split.
 
+    Fence accounting (#266): a continuation chunk carries **both** the re-opened
+    opening fence at its start *and* a closing fence at its end, so its room for
+    body content is ``limit - len(open_fence) - 1 - _FENCE_RESERVE``. The earlier
+    implementation only reserved for the closing fence, so a single code line
+    longer than ~1996 chars produced a chunk of ``limit + 4`` (rejected by
+    Discord) plus a degenerate empty code block — the code body never arrived.
+
     Args:
         content: The full reply body (may contain newlines / code fences).
         limit: Maximum length of each returned chunk. Defaults to Discord's
@@ -54,20 +61,24 @@ def chunk_discord_content(content: str, limit: int = DISCORD_MAX) -> list[str]:
     if len(content) <= limit:
         return [content]
 
-    # Reserve room so closing/continuation fences never push a chunk over the
-    # hard limit. We reserve unconditionally to keep the accounting simple and
-    # always safe.
-    usable = max(1, limit - _FENCE_RESERVE)
-
     chunks: list[str] = []
     current: list[str] = []
-    cur_len = 0
+    cur_len = 0  # length of "\n".join(current)
     open_fence: str | None = None  # opening fence line text while inside a block
 
-    def finalize() -> None:
+    def flush() -> None:
+        """Emit the in-progress chunk, then re-open the fence for the next one."""
         nonlocal current, cur_len
-        text = "\n".join(current)
-        if open_fence is not None:
+        if not current:
+            return
+        lines = current
+        # If the only thing trailing is the just-opened fence (no body yet),
+        # move it to the next chunk instead of emitting an empty "```\n```".
+        dangling_open = open_fence is not None and lines[-1] == open_fence
+        if dangling_open:
+            lines = lines[:-1]
+        text = "\n".join(lines)
+        if open_fence is not None and not dangling_open:
             text = f"{text}\n{_FENCE}"  # close the fence for this chunk
         if text != "":
             chunks.append(text)
@@ -75,29 +86,51 @@ def chunk_discord_content(content: str, limit: int = DISCORD_MAX) -> list[str]:
         cur_len = 0
         if open_fence is not None:
             # Re-open the fence at the start of the next chunk.
-            current.append(open_fence)
+            current = [open_fence]
             cur_len = len(open_fence)
+
+    def add_line(line: str, reserve: int) -> None:
+        """Append ``line`` to the current chunk, flushing first if it won't fit.
+
+        ``reserve`` is the room to keep free for a trailing close fence so the
+        finished chunk (content + close) never exceeds ``limit``.
+        """
+        nonlocal cur_len
+        sep = 1 if current else 0
+        if current and cur_len + sep + len(line) + reserve > limit:
+            flush()
+            sep = 1 if current else 0
+        current.append(line)
+        cur_len += sep + len(line)
 
     for raw_line in content.split("\n"):
         is_fence = raw_line.lstrip().startswith(_FENCE)
+        # A chunk holding this line needs a trailing close fence iff we're inside
+        # a block (already open, or this line opens one).
+        opening = is_fence and open_fence is None
+        reserve = _FENCE_RESERVE if (open_fence is not None or opening) else 0
 
-        segments = [raw_line] if len(raw_line) <= usable else _hard_split(raw_line, usable)
+        if open_fence is not None and not is_fence:
+            # Body line inside a fence: every continuation chunk also carries the
+            # re-opened fence line + its newline, so shrink the per-piece budget.
+            max_piece = max(1, limit - _FENCE_RESERVE - len(open_fence) - 1)
+        else:
+            max_piece = limit
+
+        segments = [raw_line] if len(raw_line) <= max_piece else _hard_split(raw_line, max_piece)
         for seg in segments:
-            added = (1 if current else 0) + len(seg)
-            if current and cur_len + added > usable:
-                finalize()
-                added = (1 if current else 0) + len(seg)
-            if current:
-                cur_len += 1
-            current.append(seg)
-            cur_len += len(seg)
+            add_line(seg, reserve)
 
         if is_fence:
             open_fence = raw_line if open_fence is None else None
 
     if current:
-        text = "\n".join(current)
-        if open_fence is not None:
+        lines = current
+        dangling_open = open_fence is not None and lines[-1] == open_fence
+        if dangling_open:
+            lines = lines[:-1]
+        text = "\n".join(lines)
+        if open_fence is not None and not dangling_open:
             text = f"{text}\n{_FENCE}"
         if text != "":
             chunks.append(text)

--- a/tests/test_reply_chunker.py
+++ b/tests/test_reply_chunker.py
@@ -64,3 +64,60 @@ class TestChunkDiscordContent:
     def test_invalid_limit_raises(self) -> None:
         with pytest.raises(ValueError):
             chunk_discord_content("x", limit=0)
+
+
+class TestCodeBlockOverflowRegression:
+    """Regression for #266 — a single long line inside a code block.
+
+    Real trigger: pasting a Factorio Blueprint string (one 2081-char line) in a
+    fenced block produced (a) a 69-char chunk that was just an *empty* code
+    block and (b) a 2004-char chunk that exceeded Discord's 2000 limit and was
+    rejected, so the code body never arrived and a duplicate empty block was
+    posted. The existing fence test only used short lines, so ``_hard_split``
+    never ran and the bug slipped through.
+    """
+
+    def _bp_reply(self, code_len: int = 2081) -> str:
+        prose = (
+            "了解です、ゲーム内撮影が一番確実です。手順をまとめます。\n\n"
+            "**1. コードをコピー**（修正版・これを使ってください）\n\n"
+        )
+        return prose + "```\n" + ("A" * code_len) + "\n```"
+
+    def test_every_chunk_within_limit(self) -> None:
+        content = self._bp_reply()
+        assert len(content) > DISCORD_MAX
+        chunks = chunk_discord_content(content)
+        for c in chunks:
+            assert len(c) <= DISCORD_MAX, f"chunk over limit: {len(c)}"
+
+    def test_no_empty_code_block_chunk(self) -> None:
+        chunks = chunk_discord_content(self._bp_reply())
+        for c in chunks:
+            # An "open-then-immediately-close" fence renders as broken empty
+            # block. No chunk should be (or end with) just that.
+            assert c.strip() != "```\n```"
+            assert not c.rstrip().endswith("```\n```")
+
+    def test_code_body_is_not_lost(self) -> None:
+        code = "A" * 2081
+        chunks = chunk_discord_content(self._bp_reply(2081))
+        # Strip fences and rejoin: the full code body must survive.
+        recovered = "".join(c.replace("```", "") for c in chunks)
+        assert code in recovered.replace("\n", "")
+
+    def test_every_chunk_has_balanced_fences(self) -> None:
+        chunks = chunk_discord_content(self._bp_reply())
+        for c in chunks:
+            assert c.count("```") % 2 == 0
+
+    def test_long_single_line_code_block_at_various_sizes(self) -> None:
+        # Sweep sizes around the chunk boundary to catch off-by-one regressions.
+        for code_len in (1996, 1997, 2000, 2001, 4100, 6005):
+            content = "```\n" + ("Z" * code_len) + "\n```"
+            chunks = chunk_discord_content(content)
+            for c in chunks:
+                assert len(c) <= DISCORD_MAX, f"size={code_len} chunk={len(c)}"
+                assert c.count("```") % 2 == 0
+            recovered = "".join(c.replace("```", "") for c in chunks).replace("\n", "")
+            assert "Z" * code_len in recovered


### PR DESCRIPTION
## What does this PR do?

`reply_chunker.chunk_discord_content` が **2000字を超える返信内の単一の長いコードブロック**（Factorio の Blueprint コード等、改行なしの長い1行）を壊し、コード本体がユーザーに永久に届かず、空のコードブロックだけが（しかも重複して）投稿される #266 を修正。

**Root cause** (`reply_chunker.py`):
1. 継続チャンクは先頭に再オープンした開きフェンス・末尾に閉じフェンスの **両方**を持つのに、`usable = limit - _FENCE_RESERVE` は閉じフェンス分（4字）しか予約していなかった → 継続チャンクが `limit + 4 = 2004` 字に膨らみ Discord が 400 で拒否。
2. `finalize()` 後に seg を limit 再チェックせず無条件 append。
3. 開きフェンスがチャンク末尾に来ると `"```\n```"`（空ブロック）を吐く。

送信側 (`api_server.py:753-763`) は chunk を順次 `raw.send` するため、2004字チャンクの `HTTPException` でループ中断 → コード本体も末尾も届かず、Skill リトライで空ブロックが二重投稿される。

**Fix**: body の hard-split サイズを `limit - len(open_fence) - 1 - close_reserve` に縮小／`add_line` で毎回 budget 再チェック／チャンク末尾にぶら下がった開きフェンスは閉じず次チャンクへ移し空ブロックを抑止。

両投稿経路（`/api/reply` の `api_server.py:736` と jsonl bridge の `transcript_mirror.py:384`）が同じ `chunk_discord_content` を通るため両方が直る。

## Why?

ユーザーが Claude に長いコード（BP コード等）を貼ってもらおうとすると、コードが届かず空コードブロックだけが出る。「コード来てないですね」という、貼り付け作業が完了できない壊れた状態だった。実機破損 (channel 1509030455754625154, `msg 1509747473089036492`/`...476616319006`): 同一 69字メッセージ 2通、2081字 BP コードが丸ごと欠落。

Closes #266

## Acceptance Criteria (copied from the issue)

- [x] AC1: 全チャンクが `len <= 2000`（2081字コードブロック入力の新規テスト GREEN）
- [x] AC2: 空コードブロックのみ／末尾が空フェンスのチャンクを生成しない
- [x] AC3: 連結復元でコード本文が欠落しない（`A`×2081 が全チャンクに含まれる）
- [x] AC4: 既存 `reply_chunker` テスト全 GREEN（リグレッションなし）
- [x] AC5: staging の deployed チェックアウトで 2081字コードブロックの分割を RED→GREEN 確認（下記 Staging Evidence）

## Staging Evidence (証跡)

純粋関数（チャンク分割）の変更のため、gotcha の規約通り **staging の deployed チェックアウトを直接駆動**して RED→GREEN を確認（`/home/yousan/c-lord-parallel-3`, `.venv/bin/python`）。元の破損メッセージと同じ「散文 + 2081字 BP コードブロック」入力。staging bot プロセスは再起動せず、検証後アイドルブランチ `fix/wire-max-concurrent-sessions` へ復帰済み。

<details>
<summary>RED (before) — staging @ main d3bd513 (pre-fix), 2026-05-30T08:26:28Z</summary>

```
num_chunks: 3 | lens: [69, 2004, 93]
OVER-2000: [(1, 2004)] | EMPTY-block: [0]
RESULT: RED (bug present)
```
chunk[1]=2004字（Discord 2000制限超 → 送信時 400 拒否）、chunk[0]=空コードブロック。実機破損と一致。
</details>

<details>
<summary>GREEN (after) — staging @ fix b4f810b, 2026-05-30T08:26:37Z</summary>

```
num_chunks: 3 | lens: [61, 2000, 97]
OVER-2000: [] | EMPTY-block: []
code_preserved (A*2081): True
RESULT: GREEN (fixed)
```
全チャンク `<= 2000`、空ブロックなし、コード本文 2081字 完全保存。
</details>

**Discord ネットワーク往復は本 PR では駆動していない**（staging は webhook 起点の Claude ターン spawn を構造的に無視 — gotcha 記載）。投稿レイヤは `test_transcript_mirror_cog` + 本 PR のユニットテストでカバー。検証対象は両投稿経路が共有する `chunk_discord_content`（deployed コード）の入出力。Discord screenshot (user-provided): 元破損のスクショは Issue #266 / 本 thread に添付済み。

<details>
<summary>TDD RED line (unit)</summary>

```
FAILED tests/test_reply_chunker.py::TestCodeBlockOverflowRegression::test_every_chunk_within_limit
FAILED tests/test_reply_chunker.py::TestCodeBlockOverflowRegression::test_no_empty_code_block_chunk
FAILED tests/test_reply_chunker.py::TestCodeBlockOverflowRegression::test_long_single_line_code_block_at_various_sizes
  AssertionError: size=1996 chunk=2004  /  assert 2004 <= 2000
```
修正後: `12 passed (tests/test_reply_chunker.py)`
</details>

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes (**1312 passed, 9 skipped**)
- [x] `uv run ruff check c_lord/` + `ruff format --check` pass（pyright は CI）
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] `Closes #266` used — 100% of the issue's ACs are met, on its own line
