### PR TITLE
fix: resume via --continue on message reply after tmux pane death (#270)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -916,8 +916,32 @@ class ClaudeChatCog(commands.Cog):
                     with contextlib.suppress(Exception):
                         await existing_task
 
+            # #270: when the tmux pane has died (bot restart / kill -9 / tmux-server
+            # death) but a prior session's transcript is still on disk, resume it via
+            # --continue instead of starting fresh and discarding the history.
+            # Conditions:
+            #   - existing_runner is None: an interrupted-but-live session stays alive
+            #     in tmux and should just receive send_input, not --continue.
+            #   - session_id is not None: a /clear'd thread has its session_id reset,
+            #     so it stays fresh — preserving the #123 Part 1 invariant.
+            #   - the tmux pane is actually dead (is_claude_running is False).
+            # This extends the --continue fallback (previously only on the
+            # restart-resume path, #123 Part 2) to the ordinary reply path.
+            try_continue = False
+            if session_id is not None and existing_runner is None:
+                parent_channel_id = getattr(thread, "parent_id", None) or thread.id
+                tmux_manager = await self._resolve_tmux_manager(parent_channel_id)
+                if tmux_manager is not None:
+                    pane_alive = await asyncio.to_thread(tmux_manager.is_claude_running, thread.id)
+                    try_continue = not pane_alive
+
             await self._run_claude(
-                message, thread, prompt, session_id=session_id, image_paths=image_paths
+                message,
+                thread,
+                prompt,
+                session_id=session_id,
+                image_paths=image_paths,
+                try_continue=try_continue,
             )
 
     async def _build_prompt(self, message: discord.Message) -> str:

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -684,6 +684,86 @@ class TestInterruptOnNewMessage:
         assert cog.is_processing(42) is False
 
 
+class TestResumeAfterPaneDeath:
+    """#270: a normal thread reply must resume the on-disk session via --continue
+    when the tmux pane has died (bot restart / kill -9 / tmux-server death), instead
+    of starting fresh and discarding the transcript that is still on disk.
+
+    The decision surfaces as ``_run_claude(..., try_continue=...)``:
+      - pane dead + prior session exists → ``try_continue=True``  (resume via --continue)
+      - tmux pane still alive            → ``try_continue=False`` (live send_input)
+      - session cleared (/clear)         → ``try_continue=False`` (stay fresh, #123 Part 1)
+
+    Refs #123 Part 2 — the existing --continue fallback only covers the
+    restart-resume path (on_ready → pending_resumes); the ordinary
+    message-triggered reply path is uncovered.
+    """
+
+    def _make_thread_message(self, thread_id: int = 42) -> MagicMock:
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = thread_id
+        thread.parent_id = 999
+        thread.send = AsyncMock()
+        msg = MagicMock(spec=discord.Message)
+        msg.channel = thread
+        msg.content = "what is my name?"
+        msg.attachments = []
+        msg.author = MagicMock()
+        msg.author.bot = False
+        return msg
+
+    def _cog_with_pane(self, *, running: bool) -> ClaudeChatCog:
+        """Cog whose tmux pane for the thread is alive (running) or dead."""
+        cog = _make_cog()
+        tmux_mgr = MagicMock()
+        tmux_mgr.is_claude_running.return_value = running
+        cog._resolve_tmux_manager = AsyncMock(return_value=tmux_mgr)
+        cog._run_claude = AsyncMock()
+        return cog
+
+    @pytest.mark.asyncio
+    async def test_resumes_with_continue_when_pane_dead_and_prior_session(self) -> None:
+        """RED (#270): pane died but a prior session exists → must pass try_continue=True."""
+        cog = self._cog_with_pane(running=False)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        cog.repo.get = AsyncMock(return_value=record)
+
+        await cog._handle_thread_reply(self._make_thread_message())
+
+        cog._run_claude.assert_called_once()
+        _, kwargs = cog._run_claude.call_args
+        assert kwargs.get("try_continue") is True
+
+    @pytest.mark.asyncio
+    async def test_no_continue_when_session_cleared(self) -> None:
+        """/clear invariant (#123 Part 1): session was reset → stay fresh, never --continue."""
+        cog = self._cog_with_pane(running=False)
+        record = MagicMock()
+        record.session_id = ""  # /clear resets session_id to empty
+        cog.repo.get = AsyncMock(return_value=record)
+
+        await cog._handle_thread_reply(self._make_thread_message())
+
+        cog._run_claude.assert_called_once()
+        _, kwargs = cog._run_claude.call_args
+        assert not kwargs.get("try_continue")
+
+    @pytest.mark.asyncio
+    async def test_no_continue_when_pane_alive(self) -> None:
+        """Pane still alive → live send_input continues context; must not force --continue."""
+        cog = self._cog_with_pane(running=True)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        cog.repo.get = AsyncMock(return_value=record)
+
+        await cog._handle_thread_reply(self._make_thread_message())
+
+        cog._run_claude.assert_called_once()
+        _, kwargs = cog._run_claude.call_args
+        assert not kwargs.get("try_continue")
+
+
 class TestZeroConfigCoordination:
     """_get_coordination() must work without any consumer wiring (Zero-Config Principle).
 


### PR DESCRIPTION
## What does this PR do?

スレッドの tmux pane が graceful shutdown を経由しない経路(bot 再起動の restart-resume TTL 切れ後 / `kill -9` / tmux-server 死)で消えた後、通常のスレッド返信を `--continue` で復帰させる。`_handle_thread_reply` で「中断中の runner が無い × 過去 session_id あり × pane が死んでいる」ときだけ `_run_claude(try_continue=True)` を渡す。production diff は `c_lord/cogs/claude_chat.py` +24 行のみ。

## Why?

修正前は `_handle_thread_reply → _run_claude` が `try_continue=False`(デフォルト)で呼ばれ、pane が死ぬとディスクに transcript が残っているのに Claude を fresh 起動して文脈を失っていた(ユーザーは `/clear` も `/workspace-delete` もしていない)。#123 Part 2 の `--continue` フォールバックは restart-resume パス限定で、通常の返信パスが取りこぼされていた。`/clear` 済み(session_id リセット)は fresh のまま・pane 生存時は send_input のままで、#123 Part 1 の不変条件を保持する。

Closes #270
Refs #123

## Acceptance Criteria (copied from the issue)

- [x] スレッドで 2 ターン会話後、graceful shutdown を経由せず tmux pane を kill → 同スレッドへ返信 → Claude が直前の文脈を覚えている(復帰する) — staging GREEN で「ボブ。」と回答
- [x] `/clear` 直後の返信は従来どおり fresh — `test_no_continue_when_session_cleared`(session_id='' → try_continue 付かず)
- [x] restart-resume パス(graceful shutdown → `on_ready`)の挙動は従来どおり維持 — 既存パス未変更、フル suite 1315 passed で回帰なし
- [x] ユニットテスト追加(修正前 RED) — `TestResumeAfterPaneDeath::test_resumes_with_continue_when_pane_dead_and_prior_session`(※判定境界 `_handle_thread_reply → _run_claude(try_continue=True)` で検証。`--continue` が CLI に届くことは下記 staging のコマンドキャプチャで確認)
- [x] Staging で RED 再現 → GREEN 確認 — 下記 Staging Evidence

## Staging Evidence

staging bot `C-lord-3#1206`(channel `1503196656265597082`)で同一フロー(turn1「私の名前はボブ」→ `tmux kill-window`(pane death)→ turn2「私の名前は?」)を webhook で実行。

RED — main @ 81d6be5 (thread 1510979397367103499):
```
# pane kill 後も transcript はディスクに残存: 671d02ac-….jsonl (16774B, 「ボブ」含む)
# turn2 起動コマンド (tmux capture) — --continue 無し:
unalias claude 2>/dev/null; env -u CLAUDECODE claude --model sonnet --dangerously-skip-permissions '私の名前は何でしたか？一言だけ答えて。'
# Claude turn2 応答 (文脈消失):
メモリを確認します。 / メモリファイルはまだありません。ただし、git の設定から確認できます。
```
GREEN — fix/resume-continue-on-message-reply (thread 1510982499084402801):
```
# turn1: Claude「覚えました。」(work7 生存)
# turn2 起動コマンド (tmux capture) — --continue あり:
unalias claude 2>/dev/null; env -u CLAUDECODE claude --continue --model sonnet --dangerously-skip-permissions '私の名前は何でしたか？一言だけ答えて。'
# Claude turn2 応答 (文脈復帰):
ボブ。
```

TDD RED 行(修正前):
```
FAILED tests/test_claude_chat.py::TestResumeAfterPaneDeath::test_resumes_with_continue_when_pane_dead_and_prior_session
>       assert kwargs.get("try_continue") is True
E       AssertionError: assert None is True   (実際 kwargs = {'image_paths': [], 'session_id': 'abc-123'})
```

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes — 1315 passed, 9 skipped (sanitized env = CI clean env)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass — c_lord/ All checks passed, pyright c_lord/ 0 errors
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done — claude_chat.py +24 / test +80 のみ
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`) — 全 AC 達成のため Closes #270
