### PR TITLE
feat: /close-workspace — non-destructive workspace close (#271)

### DIFF
--- a/c_lord/cogs/session_manage.py
+++ b/c_lord/cogs/session_manage.py
@@ -7,6 +7,7 @@ Provides slash commands for viewing and managing Claude Code sessions:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
@@ -882,3 +883,71 @@ class SessionManageCog(commands.Cog):
         """Text/mention twin of /workspace-delete — webhook-invokable for E2E (#209)."""
         respond, ack = self._ctx_io(ctx)
         await self._workspace_delete_impl(channel=ctx.channel, respond=respond, ack=ack)
+
+    async def _close_workspace_impl(
+        self, *, channel: object, respond: _Responder, ack: _Acknowledger
+    ) -> None:
+        """Shared core for /close-workspace and !close-workspace (#271).
+
+        Non-destructive counterpart to ``/workspace-delete``: kills the tmux
+        window and archives the thread to declutter, but **keeps** the session
+        directory, transcript, and DB session record.  The next message resumes
+        the conversation via ``--continue`` (#270) — that is the whole point of
+        "close" vs "delete".  Note this never resolves the session-dir manager,
+        so the directory-removal path is structurally unreachable here.
+        """
+        if not isinstance(channel, discord.Thread):
+            await respond(
+                "This command can only be used in a Claude chat thread.",
+                ephemeral=True,
+            )
+            return
+
+        thread_id = channel.id
+        parent_channel_id = channel.parent_id or thread_id
+        await ack()
+
+        import asyncio
+
+        results: list[str] = []
+
+        # Kill the tmux window to free the work<N> slot.
+        tmux_mgr = await self._resolve_tmux_manager(parent_channel_id)
+        if tmux_mgr is not None:
+            killed = await asyncio.to_thread(tmux_mgr.kill_session, thread_id)
+            if killed:
+                results.append("✅ Tmux window closed")
+            else:
+                results.append("ℹ️ No tmux window found")
+            results.append("📂 Session directory kept — send a message to resume.")
+        else:
+            results.append(
+                "ℹ️ このチャンネルにはリポジトリが紐づけられていません。"
+                " `/clord-init` で設定してください。"
+            )
+
+        embed = discord.Embed(
+            title="🧹 Workspace Closed",
+            description="\n".join(results),
+            color=COLOR_SUCCESS,
+        )
+        await respond(embed=embed)
+
+        # Archive the thread to declutter the sidebar (best-effort).
+        with contextlib.suppress(discord.HTTPException):
+            await channel.edit(archived=True)
+
+    @app_commands.command(
+        name="close-workspace",
+        description="Close the tmux window but keep the session (resumes on next message)",
+    )
+    async def close_workspace(self, interaction: discord.Interaction) -> None:
+        """Close the tmux window + archive the thread, keeping the session dir (#271)."""
+        respond, ack = self._slash_io(interaction)
+        await self._close_workspace_impl(channel=interaction.channel, respond=respond, ack=ack)
+
+    @commands.command(name="close-workspace")
+    async def close_workspace_text(self, ctx: commands.Context) -> None:
+        """Text/mention twin of /close-workspace — webhook-invokable for E2E (#271)."""
+        respond, ack = self._ctx_io(ctx)
+        await self._close_workspace_impl(channel=ctx.channel, respond=respond, ack=ack)

--- a/tests/test_session_manage.py
+++ b/tests/test_session_manage.py
@@ -345,6 +345,60 @@ class TestOpsTextTwins:
         assert ctx.send.call_args.kwargs.get("embed") is not None
 
 
+class TestCloseWorkspace:
+    """#271: /close-workspace — non-destructive twin of /workspace-delete.
+
+    Kills the tmux window and archives the thread to declutter, but KEEPS the
+    session directory + transcript + DB record so the next message resumes the
+    conversation via --continue (#270).
+    """
+
+    async def test_close_text_outside_thread(self):
+        cog = _make_cog()
+        ctx = _make_ctx()  # not a thread
+        await cog.close_workspace_text.callback(cog, ctx)
+        ctx.send.assert_called_once()
+        assert "thread" in ctx.send.call_args.args[0].lower()
+
+    async def test_close_kills_window_but_keeps_session_dir(self):
+        """Core (#271): kill_session IS called, cleanup_for_thread is NOT (dir kept)."""
+        cog = _make_cog()
+        tmux_mgr = MagicMock()
+        tmux_mgr.kill_session = MagicMock(return_value=True)
+        sdm = MagicMock()
+        sdm.cleanup_for_thread = MagicMock()
+        cog._resolve_tmux_manager = AsyncMock(return_value=tmux_mgr)
+        cog._resolve_session_dir_manager = AsyncMock(return_value=sdm)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 555
+        thread.parent_id = 999
+        thread.edit = AsyncMock()
+        ctx = _make_ctx(channel=thread)
+
+        await cog.close_workspace_text.callback(cog, ctx)
+
+        tmux_mgr.kill_session.assert_called_once_with(555)
+        sdm.cleanup_for_thread.assert_not_called()  # ← dir/transcript MUST survive
+
+    async def test_close_archives_thread(self):
+        """#271: the thread is archived to declutter the sidebar (the 'tidy up' goal)."""
+        cog = _make_cog()
+        tmux_mgr = MagicMock()
+        tmux_mgr.kill_session = MagicMock(return_value=True)
+        cog._resolve_tmux_manager = AsyncMock(return_value=tmux_mgr)
+        cog._resolve_session_dir_manager = AsyncMock(return_value=None)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 555
+        thread.parent_id = 999
+        thread.edit = AsyncMock()
+        ctx = _make_ctx(channel=thread)
+
+        await cog.close_workspace_text.callback(cog, ctx)
+
+        thread.edit.assert_called_once()
+        assert thread.edit.call_args.kwargs.get("archived") is True
+
+
 class TestThreadArchiveCommand:
     """/thread-archive show + set and their !text twins."""
 


### PR DESCRIPTION
## What does this PR do?

`/close-workspace`(と `!close-workspace` text twin)を追加。`/workspace-delete` の**非破壊版**で、tmux window を kill(work<N> スロット解放)+ スレッドを archive(サイドバー片付け)するが、**session dir / transcript / DB record は残す**。`_close_workspace_impl` は session-dir マネージャを解決すらしないので、dir 削除パスは構造的に到達不能。production diff は `session_manage.py` +69 行のみ。

## Why?

「タスクが一段落したので Claude/pane/スレッド一式を閉じて片付けたい」が、現状の手段は session dir ごと消す破壊的な `/workspace-delete` しか無く、名前に引きずられて履歴ごと消すのが常態化していた(window 番号が 50 番台まで伸び、サイドバーのバッファも追いつかない)。非破壊で「閉じる=後で戻れる」手段を提供する。閉じた後の次メッセージは #270 の `--continue` で文脈復帰するため、「close = 片付けて後で再開」が成立する。`/workspace-delete`(破壊)は残す。

Closes #271
Refs #270

## Acceptance Criteria (copied from the issue)

- [x] `/close-workspace`(slash)と `!close-workspace`(text)が存在し、Claude chat thread 内でのみ動作する — `test_close_text_outside_thread` でスレッド外ガード確認、staging で `!close-workspace` 動作
- [x] 実行で tmux window が kill される — staging: close 後 `tmux list-windows` から消失
- [x] session dir が**残る** — staging: close 後も `/home/yousan/c-lord-sessions-staging/.../<thread>` が EXISTS
- [x] DB の session record(session_id)が**残る** — staging: `(thread_id, 'tmux-...', 'dead')` が残存
- [x] 実行でスレッドが archive される — staging: `thread_metadata.archived=True`、`test_close_archives_thread`
- [x] ユニットテスト: `_close_workspace_impl` が `kill_session` を呼び、`cleanup_for_thread` を呼ばないこと — `test_close_kills_window_but_keeps_session_dir`
- [x] (要 #270)Staging で close → 同スレッドへ再メッセージ → 直前の文脈を覚えて復帰すること — staging: `--continue` 起動 → 「ボブ。」復帰

## Staging Evidence

staging bot `C-lord-3#1206`(ch 1503196656265597082)で、!clord でセッション+文脈(「私の名前はボブ」→「覚えました」)を作り、`!close-workspace` → 再メッセージを webhook 実行。

実装前は `!close-workspace` というコマンドは存在しない(no-op)。実装後(feat/close-workspace):

close 実行後の状態(thread 1510999915629908101):
```
[1] tmux window: ✅ NONE (killed)
[2] session dir : ✅ EXISTS (/home/yousan/c-lord-sessions-staging/1503196656265597082/1510999915629908101)
[3] transcript  : 1 jsonl (残存)
[4] DB record   : (1510999915629908101, 'tmux-1510999915629908101', 'dead')  ← 残存
[5] thread      : archived=True
[6] embed       : 🧹 Workspace Closed / ✅ Tmux window closed / 📂 Session directory kept — send a message to resume.
```
close 後に再メッセージ(archived → 自動 unarchive → #270 で復帰):
```
launch: unalias claude 2>/dev/null; env -u CLAUDECODE claude --continue --model sonnet --dangerously-skip-permissions '私の名前は何でしたか？一言だけ答えて。'
Claude 応答: ボブ。   ← 文脈復帰 ✅
```

TDD RED(実装前、`close_workspace_text` 未実装):
```
FAILED tests/test_session_manage.py::TestCloseWorkspace::test_close_kills_window_but_keeps_session_dir
E   AttributeError: 'SessionManageCog' object has no attribute 'close_workspace_text'
```

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes — 1318 passed, 9 skipped (sanitized env = CI clean env)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass — c_lord/ All checks passed, pyright c_lord/ 0 errors
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done — session_manage.py +69 / test +54 のみ
- [x] `Closes #N` used only if 100% of the issue's ACs are met (else `Refs #N`) — 全 AC 達成のため Closes #271
