### PR TITLE
feat: refuse to start a second bot with the same data dir (Closes #212)

### DIFF
--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import fcntl
 import logging
 import os
 import signal
 import sys
 from pathlib import Path
+from typing import IO
 
 from dotenv import load_dotenv
 
@@ -17,6 +19,45 @@ from .setup import setup_bridge
 from .utils.logger import setup_logging
 
 logger = logging.getLogger(__name__)
+
+
+def acquire_single_instance_lock(data_dir: Path) -> IO[bytes] | None:
+    """Acquire an exclusive non-blocking flock on ``data_dir/.bot.lock``.
+
+    Issue #212: prevents two bot processes with the same data dir from
+    double-connecting to the Discord gateway and double-processing events
+    (the staging incident on 2026-05-27).
+
+    The returned file handle must be retained for the lifetime of the process;
+    closing it releases the lock. flock auto-releases on process exit, so a
+    crash does not leave a stale lock.
+
+    Returns ``None`` when ``CLORD_ALLOW_MULTI_INSTANCE=1`` is set (advanced
+    users who understand the risk). Calls ``sys.exit(1)`` if another instance
+    already holds the lock.
+    """
+    if os.getenv("CLORD_ALLOW_MULTI_INSTANCE") == "1":
+        logger.warning("CLORD_ALLOW_MULTI_INSTANCE=1 set; skipping single-instance guard")
+        return None
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = data_dir / ".bot.lock"
+    # Intentionally not a context manager: the handle must outlive this function
+    # so flock stays held for the process lifetime (released on process exit).
+    lock_fp = open(lock_path, "wb")  # noqa: SIM115
+    try:
+        fcntl.flock(lock_fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError) as e:
+        lock_fp.close()
+        logger.error(
+            "Another bot instance is already running with the same data dir "
+            "(%s). Refusing to start to avoid Discord double-connect. "
+            "Set CLORD_ALLOW_MULTI_INSTANCE=1 to bypass. (flock error: %s)",
+            data_dir,
+            e,
+        )
+        sys.exit(1)
+    return lock_fp
 
 
 def resolve_data_dir(env_path: Path | None) -> Path:
@@ -72,6 +113,13 @@ async def main(env_path: Path | None = None) -> None:
 
     data_dir = resolve_data_dir(env_path)
     data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Issue #212: refuse to start if another bot with the same data dir is
+    # already running. The handle must be retained for the process lifetime —
+    # flock auto-releases on close/exit. Assigning to a local that lives until
+    # main() returns is sufficient; we don't need to reference it again.
+    _instance_lock = acquire_single_instance_lock(data_dir)  # noqa: F841
+
     db_path = str(data_dir / "sessions.db")
 
     runner = ClaudeConfig(

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,0 +1,72 @@
+"""Tests for the single-instance flock guard (#212).
+
+Prevents the staging incident (2026-05-27) where two bots ran on the same
+token and double-processed Discord events. ``acquire_single_instance_lock``
+takes an exclusive non-blocking flock on a lockfile under the data dir.
+A second call against the same data dir while the first lock is held must
+refuse to start (sys.exit(1)). ``CLORD_ALLOW_MULTI_INSTANCE=1`` bypasses
+the guard for advanced users.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from c_lord.main import acquire_single_instance_lock
+
+
+class TestSingleInstanceLock:
+    def test_first_acquire_returns_handle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CLORD_ALLOW_MULTI_INSTANCE", raising=False)
+        handle = acquire_single_instance_lock(tmp_path)
+        assert handle is not None
+        handle.close()
+
+    def test_second_acquire_exits_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CLORD_ALLOW_MULTI_INSTANCE", raising=False)
+        first = acquire_single_instance_lock(tmp_path)
+        assert first is not None
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                acquire_single_instance_lock(tmp_path)
+            assert exc_info.value.code != 0
+        finally:
+            first.close()
+
+    def test_release_allows_reacquire(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Closing the handle releases the lock — no stale-lock blocking."""
+        monkeypatch.delenv("CLORD_ALLOW_MULTI_INSTANCE", raising=False)
+        first = acquire_single_instance_lock(tmp_path)
+        assert first is not None
+        first.close()
+        second = acquire_single_instance_lock(tmp_path)
+        assert second is not None
+        second.close()
+
+    def test_bypass_env_skips_guard(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLORD_ALLOW_MULTI_INSTANCE", "1")
+        first = acquire_single_instance_lock(tmp_path)
+        second = acquire_single_instance_lock(tmp_path)
+        for h in (first, second):
+            if h is not None:
+                h.close()
+
+    def test_lockfile_lives_under_data_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CLORD_ALLOW_MULTI_INSTANCE", raising=False)
+        handle = acquire_single_instance_lock(tmp_path)
+        assert handle is not None
+        try:
+            lock_files = list(tmp_path.glob(".bot.lock"))
+            assert lock_files, "expected .bot.lock to exist under data dir"
+        finally:
+            handle.close()


### PR DESCRIPTION
## What does this PR do?

Adds `acquire_single_instance_lock()` in `c_lord/main.py` (#212). Takes an exclusive non-blocking `fcntl.flock` on `<data_dir>/.bot.lock` **before** the Discord gateway connect. A second process with the same data dir refuses to start with a clear error and exits 1.

- `flock` auto-releases on process exit → no stale-lock blocking after a crash
- `CLORD_ALLOW_MULTI_INSTANCE=1` bypasses the guard (escape hatch for advanced users)
- Lockfile lives under the data dir, so prod (`/home/yousan/c-lord/data`) and staging (`/home/yousan/c-lord-parallel-3/data`) each get their own lock — they don't block each other

## Why?

2026-05-27 staging incident: two bots ran on the same `DISCORD_BOT_TOKEN` and double-processed Discord events. #207 added a "borrow" protocol via AI Lounge, but adoption is 0 (verified 2026-05-29: `lounge_messages` table empty on both staging and prod). This PR is the structural fix that doesn't rely on convention. The advisory doc was trimmed in #261; this PR replaces the missing teeth.

Closes #212

## Acceptance Criteria (copied from the issue)

- [x] `c_lord/main.py` で、Discord gateway へ接続する**前**に data dir 配下の lockfile を `fcntl.flock(LOCK_EX|LOCK_NB)` で取得する。 (`c_lord/main.py:121` — call placed right after `data_dir.mkdir` and before `bot.start`)
- [x] 既に同一 data dir の bot が稼働中のとき、2 つ目の `python -m c_lord.main` は flock 取得に失敗し、明示的なエラーログ（既存インスタンス検出の旨）を出して **gateway へ接続せず** 非ゼロ exit する。 (Staging Evidence — instance 2 never logs "Logged in as", exits with code 1 and the error in the log)
- [x] 環境変数 `CLORD_ALLOW_MULTI_INSTANCE=1` を設定したときはガードを skip して従来どおり起動できる。 (`test_bypass_env_skips_guard`)
- [x] 1 つ目のプロセスを終了させると lock が解放され、その後の起動が阻害されない（stale lock で起動不能にならない）。 (`test_release_allows_reacquire`)
- [x] TDD: 同一 lockfile に対する 2 回目の flock 取得が失敗することを検証するユニットテストがある（RED → GREEN）。 (`tests/test_single_instance.py::test_second_acquire_exits_nonzero` — RED before this PR: `ImportError: cannot import name 'acquire_single_instance_lock'`; GREEN after: passes)

## Staging Evidence

Run on `/home/yousan/c-lord-parallel-3` (staging bot `C-lord-3` paused; verification used the prod-token-sharing bot `C-lord#8255` temporarily — same shape, separate data dir from prod). Compared current `main` (no flock) vs this branch.

### RED (main, no flock) — both instances log in simultaneously

```
# /tmp/red-1.log (instance 1, PID 2496735)
2026-06-01 23:12:30 [INFO] c_lord.bot: Logged in as C-lord#8255 (ID: 1475105094071750818)

# /tmp/red-2.log (instance 2, PID 2497389) — started 4s later
2026-06-01 23:12:34 [INFO] c_lord.bot: Logged in as C-lord#8255 (ID: 1475105094071750818)

# both processes alive (SNl state) — this is the bug we're fixing
```

### GREEN (this branch) — second instance refused

```
# /tmp/green-1.log (instance 1, PID 2501662)
2026-06-01 23:13:09 [INFO] c_lord.bot: Logged in as C-lord#8255 (ID: 1475105094071750818)

# /tmp/green-2.log (instance 2, PID 2502406)
2026-06-01 23:13:10 [ERROR] __main__: Another bot instance is already running with the same data dir (data). Refusing to start to avoid Discord double-connect. Set CLORD_ALLOW_MULTI_INSTANCE=1 to bypass. (flock error: [Errno 11] Resource temporarily unavailable)

# instance 2 exited; only instance 1 remained alive
```

Staging restored to idle branch (`fix/wire-max-concurrent-sessions`) with exactly 1 instance running.

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED was `ImportError: cannot import name 'acquire_single_instance_lock' from 'c_lord.main'`
- [x] `uv run pytest tests/test_single_instance.py tests/test_main.py -v` → 8 passed
- [x] `uv run ruff check c_lord/main.py tests/test_single_instance.py` + `ruff format --check` pass
- [x] Staging Evidence above is filled in (RED + GREEN excerpts pasted)
- [x] No unrelated changes in the diff; self-review done (2 files: `c_lord/main.py` +48 / `tests/test_single_instance.py` +72)
- [x] `Closes #212` — this PR satisfies 100% of #212's ACs

🤖 Generated with [Claude Code](https://claude.com/claude-code)