### PR TITLE
fix: コンテキスト行のパース誤判定 + キャッシュ汚染 + 別バブル表示 を修正

### DIFF
--- a/c_lord/claude/context_usage.py
+++ b/c_lord/claude/context_usage.py
@@ -100,10 +100,15 @@ def parse_context_total(pane_text: str) -> int | None:
     """Extract the context-window total from ``/context`` output.
 
     Looks for the ``<used>/<total> tokens`` line and returns ``<total>`` in
-    absolute tokens (e.g. ``1m`` → ``1_000_000``).  Returns ``None`` when no
-    such line is present.
+    absolute tokens (e.g. ``1m`` → ``1_000_000``).  Anchors on the latest
+    ``Context Usage`` header so a stray ``X/Y tokens`` string elsewhere in the
+    pane scrollback (e.g. text the bot itself echoed in earlier turns) does
+    not get picked up.  Returns ``None`` when no anchor is present.
     """
-    match = _CONTEXT_TOTAL_RE.search(pane_text)
+    anchor_idx = pane_text.rfind("Context Usage")
+    if anchor_idx == -1:
+        return None
+    match = _CONTEXT_TOTAL_RE.search(pane_text, pos=anchor_idx)
     if match is None:
         return None
     value, suffix = match.group(1), match.group(2)

--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -197,10 +197,12 @@ async def _resolve_context_window(config: RunConfig, session_id: str, model: str
         with contextlib.suppress(Exception):
             result = await probe()
             total = result if isinstance(result, int) else None
-    if total is None:
-        total = default_window(model or getattr(config.runner, "model", None))
-    _context_window_cache[session_id] = (model, total)
-    return total
+    if total is not None:
+        # Cache only successful probes — a transient pane-parse failure must
+        # not lock the per-model fallback in for the rest of the session.
+        _context_window_cache[session_id] = (model, total)
+        return total
+    return default_window(model or getattr(config.runner, "model", None))
 
 
 async def _post_context_usage(config: RunConfig, session_id: str | None) -> None:
@@ -224,8 +226,24 @@ async def _post_context_usage(config: RunConfig, session_id: str | None) -> None
     if usage is None:
         return
     total = await _resolve_context_window(config, session_id, usage.model)
+    line = format_context_line(usage.used, total)
+
+    # Prefer appending to Claude's last reply message — keeps the addendum
+    # inside the same bubble (no fresh avatar/timestamp chrome).  Falls back
+    # to a new message when no reply was tracked or the combined content
+    # would exceed Discord's 2000-char limit.
+    from ..skills.reply_tracker import get_last_reply_message
+
+    last_reply = get_last_reply_message(config.thread.id)
+    if last_reply is not None:
+        existing = last_reply.content or ""
+        combined = f"{existing}\n{line}" if existing else line
+        if len(combined) <= 2000:
+            with contextlib.suppress(discord.HTTPException):
+                await last_reply.edit(content=combined)
+            return
     with contextlib.suppress(discord.HTTPException):
-        await config.thread.send(format_context_line(usage.used, total))
+        await config.thread.send(line)
 
 
 async def run_claude_with_config(config: RunConfig) -> str | None:

--- a/c_lord/cogs/transcript_mirror.py
+++ b/c_lord/cogs/transcript_mirror.py
@@ -277,7 +277,9 @@ class TranscriptMirrorCog(commands.Cog):
             ]
             reference = await self._build_trigger_reference(thread_id)
             try:
-                await self._send_chunks(send, text, reference=reference, files=table_files or None)
+                last_msg = await self._send_chunks(
+                    send, text, reference=reference, files=table_files or None
+                )
             except discord.HTTPException as exc:
                 logger.warning(
                     "TranscriptMirror reply_sink failed: thread=%d body_len=%d status=%s — %s",
@@ -287,6 +289,11 @@ class TranscriptMirrorCog(commands.Cog):
                     exc,
                     exc_info=True,
                 )
+                return
+            if last_msg is not None:
+                from ..skills.reply_tracker import record_reply_message
+
+                record_reply_message(thread_id, last_msg)
 
         return reply_sink
 
@@ -314,8 +321,13 @@ class TranscriptMirrorCog(commands.Cog):
             ]
             files = [discord.File(file_path, filename="progress.txt")] + table_files
             reference = await self._build_trigger_reference(thread_id)
+
+            from ..skills.reply_tracker import record_reply_message
+
             try:
-                await self._send_chunks(send, text, reference=reference, files=files)
+                last_msg = await self._send_chunks(send, text, reference=reference, files=files)
+                if last_msg is not None:
+                    record_reply_message(thread_id, last_msg)
                 return
             except discord.HTTPException as exc:
                 logger.warning(
@@ -329,7 +341,9 @@ class TranscriptMirrorCog(commands.Cog):
                 )
             # Fallback: text without attachment (still chunked so it is not truncated).
             try:
-                await self._send_chunks(send, text, reference=reference)
+                last_msg = await self._send_chunks(send, text, reference=reference)
+                if last_msg is not None:
+                    record_reply_message(thread_id, last_msg)
             except discord.HTTPException as exc:
                 logger.warning(
                     "TranscriptMirror file_sink fallback also failed: "
@@ -373,16 +387,19 @@ class TranscriptMirrorCog(commands.Cog):
         silent: bool = False,
         reference: discord.MessageReference | None = None,
         files: list[discord.File] | None = None,
-    ) -> None:
+    ) -> discord.Message | None:
         """Send ``text`` split into Discord-sendable chunks (Issue #235).
 
         Long bodies are split instead of truncated. The quote-reply
         ``reference`` rides on the first chunk; ``files`` ride on the last.
+        Returns the last sent ``Message`` (so callers can track it for
+        in-place edits — e.g. the context-usage line).
         """
         from ..discord_ui.reply_chunker import chunk_discord_content
 
         chunks = chunk_discord_content(text)
         last = len(chunks) - 1
+        last_sent: discord.Message | None = None
         for idx, chunk in enumerate(chunks):
             kwargs: dict = {"content": chunk}
             if silent:
@@ -392,7 +409,8 @@ class TranscriptMirrorCog(commands.Cog):
                 kwargs["mention_author"] = False
             if idx == last and files:
                 kwargs["files"] = files
-            await send(**kwargs)
+            last_sent = await send(**kwargs)
+        return last_sent
 
     @staticmethod
     async def _resolve_channel(bot, thread_id: int):

--- a/c_lord/ext/api_server.py
+++ b/c_lord/ext/api_server.py
@@ -750,6 +750,7 @@ class ApiServer:
                 )
 
         last_idx = len(chunks) - 1
+        last_sent: discord.Message | None = None
         for idx, chunk in enumerate(chunks):
             send_kwargs: dict = {"content": chunk}
             if idx == 0 and reference is not None:
@@ -760,13 +761,18 @@ class ApiServer:
                     send_kwargs["file"] = all_files[0]
                 else:
                     send_kwargs["files"] = all_files
-            await raw.send(**send_kwargs)  # type: ignore[union-attr]
+            last_sent = await raw.send(**send_kwargs)  # type: ignore[union-attr]
 
         # Issue #67: record the successful reply so run_helper can detect
-        # turns where Claude never invoked the discord-reply skill.
-        from ..skills.reply_tracker import record_reply
+        # turns where Claude never invoked the discord-reply skill.  Also
+        # record the final message object so post-turn helpers (e.g. the
+        # context-usage line) can edit it in place instead of creating a new
+        # bubble.
+        from ..skills.reply_tracker import record_reply, record_reply_message
 
         record_reply(thread_id)
+        if last_sent is not None:
+            record_reply_message(thread_id, last_sent)
 
         return web.json_response({"status": "sent"})
 

--- a/c_lord/skills/reply_tracker.py
+++ b/c_lord/skills/reply_tracker.py
@@ -1,25 +1,44 @@
 """In-memory tracker recording when ``discord-reply`` was last invoked.
 
 Used to detect turns where the Claude session finished without calling the
-skill (issue #67). The api_server records the timestamp on every successful
-``POST /api/reply``; the run helper checks the tracker at the end of a turn
-and surfaces a fallback notification to the Discord thread if the skill was
-never called.
+skill (issue #67), and to let post-turn helpers append to the same message
+that Claude just sent (so context-usage and similar metadata stay inside the
+same bubble rather than creating fresh ones).
 
 Process-scoped state — both writer (api_server) and reader (run_helper)
-live in the same bot process, so a plain module-level dict is sufficient.
+live in the same bot process, so plain module-level dicts are sufficient.
 """
 
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import discord
 
 _last_reply_at: dict[int, float] = {}
+_last_reply_message: dict[int, discord.Message] = {}
 
 
 def record_reply(thread_id: int) -> None:
     """Record that ``discord-reply`` was just invoked for ``thread_id``."""
     _last_reply_at[thread_id] = time.monotonic()
+
+
+def record_reply_message(thread_id: int, message: discord.Message) -> None:
+    """Record the last Discord ``Message`` posted by ``/api/reply``.
+
+    When a reply is split into multiple chunks, only the *last* chunk is
+    recorded — that is where post-turn helpers (e.g. the context-usage line)
+    should append so the addendum sits at the bottom of the answer.
+    """
+    _last_reply_message[thread_id] = message
+
+
+def get_last_reply_message(thread_id: int) -> discord.Message | None:
+    """Return the last recorded reply message for ``thread_id``, or ``None``."""
+    return _last_reply_message.get(thread_id)
 
 
 def was_replied_since(thread_id: int, since: float) -> bool:
@@ -31,3 +50,4 @@ def was_replied_since(thread_id: int, since: float) -> bool:
 def reset_tracker() -> None:
     """Clear all recorded replies. For tests only."""
     _last_reply_at.clear()
+    _last_reply_message.clear()

--- a/tests/test_context_usage.py
+++ b/tests/test_context_usage.py
@@ -118,13 +118,37 @@ class TestParseContextTotal:
         assert parse_context_total(CONTEXT_PANE_200K) == 200_000
 
     def test_parses_inline_line(self) -> None:
-        assert parse_context_total("150.2k/1m tokens (15%)") == 1_000_000
+        assert parse_context_total("Context Usage\n  150.2k/1m tokens (15%)") == 1_000_000
 
     def test_decimal_k_total(self) -> None:
-        assert parse_context_total("1k/12.5k tokens (8%)") == 12_500
+        assert parse_context_total("Context Usage\n  1k/12.5k tokens (8%)") == 12_500
 
     def test_returns_none_without_match(self) -> None:
         assert parse_context_total("no token info in this pane") is None
+
+    def test_anchored_on_context_usage_header(self) -> None:
+        """An unrelated ``X/Y tokens`` line elsewhere in the pane must NOT win.
+
+        Regression: the bot pane scrollback can contain ``56.6k/200k tokens``
+        from prior conversation/PR text, while the freshly-emitted ``/context``
+        block (which is the only authoritative one) sits below a ``Context
+        Usage`` header.  Picking the first regex match in the pane caches the
+        wrong window forever.  parse_context_total must anchor on the latest
+        ``Context Usage`` header and only consider lines that follow it.
+        """
+        pane = (
+            "前の会話: PR 本文に 56.6k/200k tokens (28%) と書いた\n"
+            "...history continues with that text rendered...\n"
+            "❯ /context\n"
+            "  ⎿  Context Usage\n"
+            "     claude-opus-4-7[1m]\n"
+            "     340.5k/1m tokens (34%)\n"
+        )
+        assert parse_context_total(pane) == 1_000_000
+
+    def test_no_context_usage_header_returns_none(self) -> None:
+        """Without the anchor the parse must return None (safer than guessing)."""
+        assert parse_context_total("scrollback: 56.6k/200k tokens (28%)") is None
 
 
 class TestDefaultWindow:

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -46,9 +46,7 @@ class TestPostContextUsage:
         _run_helper._context_window_cache.clear()
         usage = None if used is None else ContextUsage(input_tokens=used)
         monkeypatch.setattr(_run_helper, "read_latest_usage", lambda _p: usage)
-        monkeypatch.setattr(
-            _run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl")
-        )
+        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
         return _run_helper
 
     def test_posts_line_with_probed_total(self, monkeypatch) -> None:
@@ -79,9 +77,7 @@ class TestPostContextUsage:
             "read_latest_usage",
             lambda _p: ContextUsage(input_tokens=10_000, model=next(models)),
         )
-        monkeypatch.setattr(
-            _run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl")
-        )
+        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
         cfg = self._config(probe_total=1_000_000)
         asyncio.run(_run_helper._post_context_usage(cfg, "sess-m"))
         asyncio.run(_run_helper._post_context_usage(cfg, "sess-m"))
@@ -96,11 +92,134 @@ class TestPostContextUsage:
         assert "10%" in msg  # 20k / 200k
         assert "200k" in msg
 
+    def test_does_not_cache_when_probe_fails(self, monkeypatch) -> None:
+        """A transient probe failure must NOT lock the fallback into the cache.
+
+        Regression: caching the fallback caused a 1M-context user to be stuck
+        on the 200k default for the rest of the session (showing "100% full"
+        when actually at 34%).  The next turn must re-probe.
+        """
+        from pathlib import Path
+
+        from c_lord.claude.context_usage import ContextUsage
+        from c_lord.cogs import _run_helper
+
+        _run_helper._context_window_cache.clear()
+        monkeypatch.setattr(
+            _run_helper,
+            "read_latest_usage",
+            lambda _p: ContextUsage(input_tokens=10_000),
+        )
+        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
+
+        # First turn: probe fails → fallback used → must NOT cache.
+        cfg = self._config(probe_total=None)
+        asyncio.run(_run_helper._post_context_usage(cfg, "sess-flaky"))
+        assert cfg.runner.probe_context_window.await_count == 1
+
+        # Second turn: probe must be called again (cache was not poisoned).
+        cfg.runner.probe_context_window.return_value = 1_000_000
+        asyncio.run(_run_helper._post_context_usage(cfg, "sess-flaky"))
+        assert cfg.runner.probe_context_window.await_count == 2
+        # And this turn's posted line must use the (now-successful) 1M total.
+        msg = cfg.thread.send.await_args.args[0]
+        assert "1.0M" in msg
+
     def test_skips_when_no_working_dir(self, monkeypatch) -> None:
         rh = self._patch_usage(monkeypatch, used=60_000)
         cfg = self._config(working_dir=None)
         asyncio.run(rh._post_context_usage(cfg, "sess-4"))
         cfg.thread.send.assert_not_called()
+
+    def test_edits_last_reply_when_available(self, monkeypatch) -> None:
+        """The context line must be appended to the last reply (no new bubble).
+
+        UX feedback: a separate bot message adds avatar/timestamp chrome that
+        feels obtrusive.  Editing the reply keeps the line inside the same
+        bubble as Claude's answer.
+        """
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        from c_lord.claude.context_usage import ContextUsage
+        from c_lord.cogs import _run_helper
+        from c_lord.skills import reply_tracker
+
+        _run_helper._context_window_cache.clear()
+        reply_tracker.reset_tracker()
+
+        # Simulate the api_server having recorded the assistant reply message.
+        last_msg = MagicMock()
+        last_msg.content = "2"
+        last_msg.edit = AsyncMock()
+        reply_tracker.record_reply_message(12345, last_msg)
+
+        monkeypatch.setattr(
+            _run_helper,
+            "read_latest_usage",
+            lambda _p: ContextUsage(input_tokens=60_000),
+        )
+        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
+
+        cfg = self._config(probe_total=1_000_000)
+        asyncio.run(_run_helper._post_context_usage(cfg, "sess-edit"))
+
+        # Edited the reply (no new send).
+        last_msg.edit.assert_awaited_once()
+        new_content = last_msg.edit.await_args.kwargs.get("content") or (
+            last_msg.edit.await_args.args[0] if last_msg.edit.await_args.args else ""
+        )
+        assert new_content.startswith("2\n")
+        assert "6%" in new_content
+        assert "1.0M" in new_content
+        cfg.thread.send.assert_not_called()
+
+    def test_falls_back_to_send_when_no_tracked_message(self, monkeypatch) -> None:
+        from pathlib import Path
+
+        from c_lord.claude.context_usage import ContextUsage
+        from c_lord.cogs import _run_helper
+        from c_lord.skills import reply_tracker
+
+        _run_helper._context_window_cache.clear()
+        reply_tracker.reset_tracker()
+        monkeypatch.setattr(
+            _run_helper,
+            "read_latest_usage",
+            lambda _p: ContextUsage(input_tokens=60_000),
+        )
+        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
+
+        cfg = self._config(probe_total=1_000_000)
+        asyncio.run(_run_helper._post_context_usage(cfg, "sess-no-track"))
+        cfg.thread.send.assert_awaited_once()
+
+    def test_falls_back_to_send_when_edit_would_exceed_2000(self, monkeypatch) -> None:
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        from c_lord.claude.context_usage import ContextUsage
+        from c_lord.cogs import _run_helper
+        from c_lord.skills import reply_tracker
+
+        _run_helper._context_window_cache.clear()
+        reply_tracker.reset_tracker()
+        last_msg = MagicMock()
+        last_msg.content = "x" * 1990  # leaves <= 10 chars; context line is longer
+        last_msg.edit = AsyncMock()
+        reply_tracker.record_reply_message(12345, last_msg)
+
+        monkeypatch.setattr(
+            _run_helper,
+            "read_latest_usage",
+            lambda _p: ContextUsage(input_tokens=60_000),
+        )
+        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
+
+        cfg = self._config(probe_total=1_000_000)
+        asyncio.run(_run_helper._post_context_usage(cfg, "sess-toobig"))
+        last_msg.edit.assert_not_called()
+        cfg.thread.send.assert_awaited_once()
 
     def test_skips_when_no_usage_in_transcript(self, monkeypatch) -> None:
         rh = self._patch_usage(monkeypatch, used=None)


### PR DESCRIPTION
## What does this PR do?

#250 本番反映後に判明した3つの問題を一括修正(コンテキスト行表示の信頼性と UX)。

## Why?

#250 で本番(Opus 4.7 / 1M context)に投入した結果、ユーザフィードバックとログから以下が判明:

1. **パーサが会話履歴の文字列を誤判定**: 本番で `⚠️ Context 100% full (340k/200k)` と誤表示。bot ペインのスクロールバックに以前の会話で引用された `56.6k/200k tokens` 等の文字列が残り、新しい /context 出力より先にマッチしていた。
2. **probe 失敗時のフォールバックがキャッシュに固着**: 一時的なパース失敗で 200k フォールバックが永続化、1M セッションでも全ターン 200k 基準の % が出続けていた。
3. **コンテキスト行が独立 Discord バブルで目立つ**: `-#` で文字は小さいが、avatar/timestamp の chrome が付き視覚的に重い。

Refs #250

## Acceptance Criteria (copied from the issue)

#250 の AC は #265 で完了済み。本 PR は #250 のフォローアップ(本番表面化バグの修正)で新規 AC はなし。

- [x] パーサが会話履歴の混入文字列に騙されない (test_anchored_on_context_usage_header)
- [x] 失敗 probe はキャッシュされない (test_does_not_cache_when_probe_fails)
- [x] 編集 in-place が動作 (test_edits_last_reply_when_available)
- [x] 2000字超過時は send にフォールバック (test_falls_back_to_send_when_edit_would_exceed_2000)
- [x] tracker 未登録時は send にフォールバック (test_falls_back_to_send_when_no_tracked_message)
- [x] jsonl bridge モード(transcript_mirror)でも edit-in-place が動作

## Staging Evidence (証跡)

**環境**: `c-lord-parallel-3` (jsonl bridge mode、`CLORD_BRIDGE_MODE=jsonl`、本番と同じ) / bot `C-lord-3` / staging channel `1503196656265597082` / test thread `1509537191649611818` (W5 チャンクテスト、Sonnet 4.6 / 200k window)。検証後 idle ブランチ `fix/wire-max-concurrent-sessions` へ復帰済み。

**Before** (本番 #265 マージ後、ユーザのプロダクション環境スクショ): 
- 31% コンテキスト表示は独立バブルで chrome 付き
- 別ターンでは `⚠️ Context 100% full (340k/200k)` と誤表示(実値 1M / 34%)

**After** (本 PR / commit `270fc34`): 同じ W5 スレッドで webhook 経由でターン実行。Discord REST API で確認:

```
[14:33:39] Spidey Bot: final hotfix verify: 短く挨拶 (3+4 は何?と聞きたい)
[14:34:18] C-lord-3 [EDITED]: こんにちは！
  ⏎
  ... Claude の本文 ...
  -# 📊 32% context (65k/200k)
```

ポイント:
- `[EDITED]` マーカーが付いている = 新規送信ではなく **Claude 自身の返答メッセージを編集して追記**
- `-# 📊 32% context (65k/200k)` が**同一バブル内**(avatar/timestamp chrome なし)
- staging ログ: `probe_context_window: total=200000` (Sonnet なので 200k が正しい)
- スクロールバックには `57k/200k` `340.5k/1m` 等の混入文字列もあるが、`Context Usage` アンカーで**正しい行のみ拾えた** (#1 修正の効果)

**1M 検証**: staging は Sonnet なので 200k のみ実機確認。1M 側はパーサ単体テスト (`test_anchored_on_context_usage_header`) で「`340.5k/1m tokens (34%)` 入りスクロールバックから 1_000_000 を取得」を確認済み。本番(Opus 4.7 / 1M)でのマージ後実機確認はユーザに依頼。

**Discord 側スクリーンショット**: ユーザから提供予定。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN). 例: `test_anchored_on_context_usage_header` を追加 → RED 確認 (元コードは 200k を返す) → パーサ修正 → GREEN
- [x] `uv run pytest tests/ -v` passes (新規・既存 63件 GREEN、main 由来の既存失敗14件は本 PR と無関係で検証済み)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass (全 0 errors)
- [x] Staging Evidence above is filled in (上記)
- [x] No unrelated changes in the diff; self-review done (1 ファイル新規 / 4 ファイル変更、全て同 fix 関連)
- [x] `Refs #250` を使用(AC は #265 で完了済、本 PR は表面化バグの hotfix なので `Closes` は使わない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)