### PR TITLE
feat: Discord から /compact を手動発火する (#278)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -704,6 +704,76 @@ class ClaudeChatCog(commands.Cog):
 
         await self._clear_impl(ctx.channel, respond)
 
+    async def _compact_impl(
+        self, channel: object, respond: _Responder, *, instructions: str = ""
+    ) -> None:
+        """Shared core for /compact and !compact (#278).
+
+        Fires the Claude Code TUI's built-in ``/compact`` slash command in the
+        thread's tmux window to compress (summarize) the session context,
+        freeing up the context window without losing history (unlike /clear).
+
+        Sent via ``send_literal`` (NOT ``send_input``): under
+        ``CLORD_BRIDGE_MODE=jsonl`` ``send_input`` prepends a zero-width-space
+        marker, so the line would no longer start with ``/`` and the TUI would
+        not treat it as a slash command (see docs/COMMANDS.md). This mirrors the
+        existing ``/context`` probe in ``tmux_runner.py``. Enter is sent
+        separately via ``send_keys`` since ``send_literal`` does not submit.
+        """
+        if not isinstance(channel, discord.Thread):
+            await respond("This command can only be used in a Claude chat thread.", ephemeral=True)
+            return
+
+        thread_id = channel.id
+        parent_id = getattr(channel, "parent_id", None) or thread_id
+        tmux_manager = await self._resolve_tmux_manager(parent_id)
+        if tmux_manager is None:
+            await respond("tmux is not configured for this thread.", ephemeral=True)
+            return
+
+        if not await asyncio.to_thread(tmux_manager.is_claude_running, thread_id):
+            await respond("No running Claude session in this thread to compact.", ephemeral=True)
+            return
+
+        instructions = instructions.strip()
+        command = f"/compact {instructions}" if instructions else "/compact"
+
+        # send_literal (not send_input): no ZWSP prefix so the leading "/" is
+        # preserved and the TUI recognises it as a slash command.
+        ok = await asyncio.to_thread(tmux_manager.send_literal, thread_id, command)
+        if not ok:
+            await respond("Failed to send /compact to the session.", ephemeral=True)
+            return
+        await asyncio.to_thread(tmux_manager.send_keys, thread_id, "Enter")
+
+        await respond("\U0001f5dc️ Compacting context… (`/compact` sent)")
+
+    @app_commands.command(
+        name="compact",
+        description="Compact (summarize) this thread's Claude context to free the window",
+    )
+    @app_commands.describe(
+        instructions="Optional focus for the summary (e.g. 'keep open tasks and decisions')"
+    )
+    async def compact_session(
+        self, interaction: discord.Interaction, instructions: str = ""
+    ) -> None:
+        """Trigger the TUI ``/compact`` for the current thread's session."""
+
+        async def respond(content: str | None = None, *, ephemeral: bool = False) -> None:
+            await interaction.response.send_message(content, ephemeral=ephemeral)
+
+        await self._compact_impl(interaction.channel, respond, instructions=instructions)
+
+    @commands.command(name="compact")
+    async def compact_text(self, ctx: commands.Context, *, instructions: str = "") -> None:
+        """Text/mention twin of /compact — invokable from webhooks for E2E (#278)."""
+
+        async def respond(content: str | None = None, *, ephemeral: bool = False) -> None:
+            await ctx.send(content or "")
+
+        await self._compact_impl(ctx.channel, respond, instructions=instructions)
+
     async def _handle_new_conversation(self, message: discord.Message) -> None:
         """Create a new thread and start a Claude Code session."""
         thread_name = message.content[:100] if message.content else "Claude Chat"

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -24,11 +24,14 @@ Bot → Channel (= 1 repo + 1 tmux session) → Thread (= 1 tmux window)
 | `/clord <prompt>` | Start a new Claude Code session | Channel or thread |
 | `/stop` | Stop the active session (session is preserved for resume) | Thread only |
 | `/clear` | Reset the session — next message starts fresh | Thread only |
+| `/compact [instructions]` | Compact (summarize) the session context to free the window | Thread only |
 | `/clord-attach <window>` | Attach this thread to an existing tmux window | Thread only |
 
 **`/clord`** creates a new thread and sends your prompt to Claude Code. If used inside an existing thread, it continues the same session.
 
 **`/stop`** gracefully interrupts the running process. The session is saved — just send another message in the thread to resume.
+
+**`/compact`** fires the Claude Code TUI's built-in `/compact` for this thread's session, compressing the conversation history into a summary so the context window is freed **without losing continuity** (unlike `/clear`, which discards the session). Pass optional `instructions` to focus the summary (e.g. `/compact keep the open tasks and decisions`). Note: a plain `/compact` typed as a normal message does **not** work under `CLORD_BRIDGE_MODE=jsonl` (the leading-slash note below) — this command exists precisely because it sends `/compact` via the zero-width-space-free `send_literal` path.
 
 **`/clord-attach`** links a thread to a tmux window so you can interact with the same Claude Code session from both Discord and the terminal.
 
@@ -99,6 +102,7 @@ Only available when the bot operator has enabled the upgrade slash command.
 | `!skill <name> [args]` | Run a Claude Code skill | `!skill recall` | `/skill` |
 | `!stop` | Stop the active session (preserved for resume) | `!stop` | `/stop` |
 | `!clear` | Reset the session — next message starts fresh | `!clear` | `/clear` |
+| `!compact [instructions]` | Compact (summarize) the session context | `!compact keep open tasks` | `/compact` |
 | `!model-show` | Show the current Claude model | `!model-show` | `/model show` |
 | `!resume-info` | Show the CLI command to resume this thread | `!resume-info` | `/resume-info` |
 | `!sessions` | List all known sessions | `!sessions` | `/sessions` |

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1876,6 +1876,114 @@ class TestClearCommand:
         assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
 
 
+class TestCompactCommand:
+    """Tests for /compact command — fires the TUI /compact via send_literal (#278).
+
+    The whole point of #278 is that a normal message would go through
+    ``send_input`` which (under ``CLORD_BRIDGE_MODE=jsonl``) prepends a
+    zero-width-space, breaking the leading ``/``. ``/compact`` must therefore
+    use ``send_literal`` (no ZWSP) + a separate Enter, mirroring the existing
+    ``/context`` probe in ``tmux_runner.py``.
+    """
+
+    @staticmethod
+    def _running_tmux() -> MagicMock:
+        tmux_manager = MagicMock()
+        tmux_manager.is_claude_running = MagicMock(return_value=True)
+        tmux_manager.send_literal = MagicMock(return_value=True)
+        tmux_manager.send_keys = MagicMock(return_value=True)
+        tmux_manager.send_input = MagicMock(return_value=True)
+        return tmux_manager
+
+    @pytest.mark.asyncio
+    async def test_compact_outside_thread_sends_ephemeral(self) -> None:
+        """/compact outside a thread sends an ephemeral error."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+
+        await cog.compact_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_compact_no_tmux_manager_sends_ephemeral(self) -> None:
+        """/compact with no tmux binding sends an ephemeral error."""
+        cog = _make_cog()  # channel_cog None → _resolve_tmux_manager returns None
+        interaction = _make_thread_interaction(thread_id=12345)
+        interaction.channel.parent_id = 999
+
+        await cog.compact_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_compact_not_running_sends_ephemeral(self) -> None:
+        """/compact when Claude is not running sends an ephemeral notice (no send)."""
+        tmux_manager = self._running_tmux()
+        tmux_manager.is_claude_running = MagicMock(return_value=False)
+        channel_cog = _make_channel_cog_mock(tmux_manager=tmux_manager)
+        cog = _make_cog(channel_cog=channel_cog)
+        interaction = _make_thread_interaction(thread_id=12345)
+        interaction.channel.parent_id = 999
+
+        await cog.compact_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+        tmux_manager.send_literal.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_compact_uses_send_literal_not_send_input(self) -> None:
+        """AC6: /compact must use send_literal (no ZWSP) + Enter, never send_input."""
+        tmux_manager = self._running_tmux()
+        channel_cog = _make_channel_cog_mock(tmux_manager=tmux_manager)
+        cog = _make_cog(channel_cog=channel_cog)
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id)
+        interaction.channel.parent_id = 999
+
+        await cog.compact_session.callback(cog, interaction)
+
+        tmux_manager.send_literal.assert_called_once_with(thread_id, "/compact")
+        tmux_manager.send_keys.assert_called_once_with(thread_id, "Enter")
+        tmux_manager.send_input.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_compact_passes_instructions(self) -> None:
+        """AC3: instructions are appended as '/compact <instructions>'."""
+        tmux_manager = self._running_tmux()
+        channel_cog = _make_channel_cog_mock(tmux_manager=tmux_manager)
+        cog = _make_cog(channel_cog=channel_cog)
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id)
+        interaction.channel.parent_id = 999
+
+        await cog.compact_session.callback(cog, interaction, instructions="keep open tasks")
+
+        tmux_manager.send_literal.assert_called_once_with(thread_id, "/compact keep open tasks")
+
+    @pytest.mark.asyncio
+    async def test_compact_text_twin_uses_send_literal(self) -> None:
+        """The !compact text twin fires the same send_literal path."""
+        tmux_manager = self._running_tmux()
+        channel_cog = _make_channel_cog_mock(tmux_manager=tmux_manager)
+        cog = _make_cog(channel_cog=channel_cog)
+        thread_id = 12345
+
+        ctx = MagicMock()
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = thread_id
+        thread.parent_id = 999
+        ctx.channel = thread
+        ctx.send = AsyncMock()
+
+        await cog.compact_text.callback(cog, ctx)
+
+        tmux_manager.send_literal.assert_called_once_with(thread_id, "/compact")
+
+
 class TestApplyThreadNamingRetitle:
     """Unit tests for the auto-retitle hook in _apply_thread_naming (#121)."""
 


### PR DESCRIPTION
## 概要

Discord から **`/compact` を手動発火**できるようにする。長いスレッドでコンテキストが膨らんだとき、ユーザーが任意のタイミングでコンテキスト圧縮(履歴を要約に置換して窓を空ける)を起動する手段がこれまで無かった。

`CLORD_BRIDGE_MODE=jsonl`(本番設定)では `send_input` が送信文字列の先頭に zero-width-space を前置するため(`tmux.py`)、スレッドに `/compact` と打っても行頭が `/` でなくなり TUI がスラッシュコマンドと認識しない(`docs/COMMANDS.md` の leading-slash note)。本 PR は既存の `/context` プローブ(`tmux_runner.py`)と同じ **`send_literal` 透過送信**(ZWSP を付けない)で `/compact` を投げる。

- `/compact [instructions]` — スラッシュコマンド(Thread 限定)
- `!compact [instructions]` — テキスト/メンション双子(#209 規約、webhook E2E 可)

## Why

`/compact` は TUI/人間専用コマンドで、(a) 普通のメッセージでは jsonl の ZWSP で潰れ、(b) スキル/プロンプト経由でも Claude 自身は発火できない。結果コンテキスト圧縮は自動コンパクション任せで、ユーザーが「今すぐ畳む」を表現できなかった。`/clear`(全消し)とは違い履歴を要約で温存する。

## Acceptance Criteria (#278)

- [x] **AC1**: スレッド内で compact コマンド(slash / テキスト双子)を実行すると、TUI で `/compact` が発火する(`send_literal("/compact")` + Enter、ZWSP 前置なし) — unit + staging pane で確認
- [x] **AC2**: `CLORD_BRIDGE_MODE=jsonl` でも AC1 が成立(`send_literal` は ZWSP を付けない経路。`send_input` は呼ばない) — unit `send_input.assert_not_called()` + staging(jsonl bot)で `/compact` が `/` 保持のまま認識されたことを確認
- [x] **AC3**: 引数付きで `/compact <instructions>` として TUI に渡る — unit + staging pane に `/compact keep #278 E2E notes` を確認
- [x] **AC4**: 発火後 `🗜️` インジケータが付く — staging で bot が `🗜️ Compacting context… (/compact sent)` をスレッドに投稿することを確認
- [x] **AC5**: staging で RED(コマンド無し→発火不可)/ GREEN(コマンドで発火)を確認 — 下記 Staging Evidence
- [x] **AC6**: compact コマンドが `send_input` ではなく `send_literal` を呼ぶことをアサート — unit `test_compact_uses_send_literal_not_send_input`

## TDD Evidence

**RED**（実装前、`compact_session` 未定義）:
```
AttributeError: 'ClaudeChatCog' object has no attribute 'compact_session'. Did you mean: 'clear_session'?
tests/test_claude_chat.py:1904: AttributeError
```

**GREEN**（実装後）: `TestCompactCommand` 6 件 pass（outside-thread / no-tmux / not-running の ephemeral、send_literal(not send_input)+Enter、instructions 透過、テキスト双子）。

## 検証 (CI scope = `c_lord/`)

- `ruff check c_lord/` → All checks passed
- `ruff format --check c_lord/` → already formatted
- `pyright c_lord/` → 0 errors, 0 warnings
- `pytest tests/`(clean env）→ 1360 passed。残失敗は env 漏れ起因（本番 `.env` の `CLORD_BRIDGE_MODE` 等がシェルに leak、clean env で pass）と既存の順序 flake `test_mirror`（単独 pass）のみ。本 PR の回帰なし。

## Staging Evidence

staging(`c-lord-parallel-3`, `CLORD_BRIDGE_MODE=jsonl`, bot `C-lord-3#1206`, channel `1503196656265597082`)で webhook 経由検証。

**RED**（feature ブランチ投入前 = `3985dc4`）:
- `Synced 16 slash commands (global)` — compact コマンド無し
- `!compact RED-probe-278` を webhook 投稿 → `discord.ext.commands.errors.CommandNotFound: Command "compact" is not found`

**GREEN**（feature ブランチ `354d79d` 起動後）:
- `Synced 17 slash commands (global)` — `/compact` 登録
- thread `1511167156333711400`(live セッション, jsonl)へ `!compact keep #278 E2E notes` を webhook 投稿 → tmux ペイン:
```
❯ /compact keep #278 E2E notes
* Compacting conversation…
  ▰▰▰▰▱▱▱▱▱▱▱▱… 9%
```
  → 先頭 `/` 保持のまま TUI がスラッシュコマンドと認識し圧縮開始（AC1/AC2）。instructions も透過（AC3）。
- bot がスレッドに `🗜️ Compacting context… (/compact sent)` を投稿（AC4）。
- 検証後 staging を idle（`3985dc4` / 16 commands）へ原状復帰済み。

## セルフレビュー / セキュリティ

- 差分は 3 ファイルのみ（`claude_chat.py` / `test_claude_chat.py` / `docs/COMMANDS.md`）、無関係変更なし
- security-audit 実施: 直接 subprocess を起こさず既存 `send_literal`/`send_keys`(`_run([...])`、`shell=True` なし)を使用。`instructions` は `send-keys -l`(literal)で Claude 入力欄に打鍵されるだけで通常メッセージと同等、新規注入経路なし。権限は `/clear` より弱い。指摘なし

Closes #278

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（clean env で 1360 passed、残失敗は env 漏れ/既存 flake のみ・本 PR 無関係。CI test 3.10/3.11/3.12 緑）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in（RED 16cmd/CommandNotFound → GREEN 17cmd/pane で /compact 圧縮開始）
- [x] No unrelated changes in the diff; self-review done（3 ファイルのみ）
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met — 全 AC 達成のため `Closes #278` を独立行で記載
