### PR TITLE
fix: rename backoff を DB 永続化し再起動連打時の Discord 429 を防止 (#281)

### DIFF
--- a/c_lord/database/models.py
+++ b/c_lord/database/models.py
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     tmux_window_id TEXT,
     auto_topic_locked INTEGER NOT NULL DEFAULT 0,
     topic_source TEXT,
+    rename_backoff_until TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')),
     last_used_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
 );
@@ -141,6 +142,10 @@ _MIGRATIONS = [
     # restart can detect & re-deliver a final answer dropped while the bot
     # was down (mirror not tailing).
     "ALTER TABLE sessions ADD COLUMN mirror_replied_uuid TEXT",
+    # Issue #281: persist the state-sync rename rate-limit deadline (wall-clock)
+    # so a bot restart honours Discord's ~10-min per-channel rename window
+    # instead of forgetting it (in-memory backoff resets on restart → 429).
+    "ALTER TABLE sessions ADD COLUMN rename_backoff_until TEXT",
 ]
 
 

--- a/c_lord/database/repository.py
+++ b/c_lord/database/repository.py
@@ -32,6 +32,9 @@ class SessionRecord:
     trigger_message_id: int | None = None
     # Issue #215: uuid of the last final answer the mirror delivered
     mirror_replied_uuid: str | None = None
+    # Issue #281: persisted state-sync rename rate-limit deadline (wall-clock
+    # "YYYY-MM-DD HH:MM:SS"); survives restarts so the rename window is honoured.
+    rename_backoff_until: str | None = None
 
 
 class SessionRepository:
@@ -190,6 +193,21 @@ class SessionRepository:
             await db.execute(
                 "UPDATE sessions SET mirror_replied_uuid = ? WHERE thread_id = ?",
                 (uuid, thread_id),
+            )
+            await db.commit()
+
+    async def set_rename_backoff_until(self, thread_id: int, deadline: str | None) -> None:
+        """Persist the state-sync rename rate-limit deadline (Issue #281).
+
+        ``deadline`` is a wall-clock "YYYY-MM-DD HH:MM:SS" string (or None to
+        clear). Persisting it lets a bot restart honour Discord's per-channel
+        rename window instead of forgetting the in-memory backoff and re-PATCHing
+        within the window (429).
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "UPDATE sessions SET rename_backoff_until = ? WHERE thread_id = ?",
+                (deadline, thread_id),
             )
             await db.commit()
 

--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import datetime
 import logging
 import re
 import subprocess
@@ -44,6 +45,16 @@ if TYPE_CHECKING:
     from .database.repository import SessionRepository
 
 logger = logging.getLogger(__name__)
+
+# Wall-clock format used to persist the rename backoff deadline (#281). Matches
+# the DB's datetime('now','localtime') text so values are directly comparable.
+_BACKOFF_TS_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def _now() -> datetime.datetime:
+    """Current local wall-clock time. Indirected for deterministic testing."""
+    return datetime.datetime.now()
+
 
 # Format: <session_name>|<window_id>|<window_index>|<@thread_id>|<window_name>
 _LIST_WINDOWS_FORMAT = "#{session_name}|#{window_id}|#{window_index}|#{@thread_id}|#{window_name}"
@@ -351,6 +362,23 @@ class ThreadStateSyncLoop:
         if (channel.name or "") == new_name:
             return
 
+        # Persisted (cross-restart) rate-limit backoff (#281): the in-memory
+        # _rename_backoff resets on restart, so honour the DB-persisted deadline
+        # too. A fresh process forgets it just renamed this channel and would
+        # re-PATCH within Discord's ~10-min window (429); the persisted wall-clock
+        # deadline survives the restart.
+        persisted = getattr(record, "rename_backoff_until", None)
+        if persisted:
+            with contextlib.suppress(ValueError, TypeError):
+                deadline = datetime.datetime.strptime(persisted, _BACKOFF_TS_FORMAT)
+                if _now() < deadline:
+                    logger.debug(
+                        "state-sync: rename skipped thread %d (persisted backoff until %s)",
+                        thread_id,
+                        persisted,
+                    )
+                    return
+
         # Per-thread rate-limit backoff: skip rename if still within back-off window.
         now = asyncio.get_event_loop().time()
         backoff_until = self._rename_backoff.get(thread_id, 0.0)
@@ -371,6 +399,7 @@ class ThreadStateSyncLoop:
                 new_state,
             )
             self._rename_backoff.pop(thread_id, None)
+            await self._persist_backoff(thread_id, None)  # clear stale deadline (#281)
         except discord.HTTPException as exc:
             if exc.status == 429:
                 retry_after = float(
@@ -378,6 +407,7 @@ class ThreadStateSyncLoop:
                     or _DEFAULT_RENAME_BACKOFF_SECONDS
                 )
                 self._rename_backoff[thread_id] = asyncio.get_event_loop().time() + retry_after
+                await self._persist_backoff(thread_id, retry_after)  # survive restart (#281)
                 logger.warning(
                     "state-sync: rename rate-limited thread %d, backing off %.0fs",
                     thread_id,
@@ -391,9 +421,28 @@ class ThreadStateSyncLoop:
             self._rename_backoff[thread_id] = (
                 asyncio.get_event_loop().time() + _DEFAULT_RENAME_BACKOFF_SECONDS
             )
+            await self._persist_backoff(thread_id, _DEFAULT_RENAME_BACKOFF_SECONDS)  # (#281)
             logger.warning(
                 "state-sync: rename timed out for thread %d"
                 " (suspected rate-limit), backing off %.0fs",
                 thread_id,
                 _DEFAULT_RENAME_BACKOFF_SECONDS,
             )
+
+    async def _persist_backoff(self, thread_id: int, retry_after_seconds: float | None) -> None:
+        """Persist (or clear) the rename backoff deadline to the DB (#281).
+
+        ``retry_after_seconds`` None clears the deadline; otherwise the deadline
+        is ``_now() + retry_after_seconds`` as a wall-clock string. Best-effort:
+        a repo without ``set_rename_backoff_until`` (older consumers) is skipped.
+        """
+        setter = getattr(self._repo, "set_rename_backoff_until", None)
+        if setter is None:
+            return
+        deadline: str | None = None
+        if retry_after_seconds is not None:
+            deadline = (_now() + datetime.timedelta(seconds=retry_after_seconds)).strftime(
+                _BACKOFF_TS_FORMAT
+            )
+        with contextlib.suppress(Exception):
+            await setter(thread_id, deadline)

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -33,6 +33,8 @@ class _Rec:
     created_at: str = ""
     last_used_at: str = ""
     topic_source: str | None = None
+    # #281: persisted rename rate-limit deadline (wall-clock "YYYY-MM-DD HH:MM:SS")
+    rename_backoff_until: str | None = None
 
 
 def test_index_by_thread_id_keeps_only_digit_tids():
@@ -702,6 +704,132 @@ async def test_second_tick_renames_normally(monkeypatch):
         # Second tick: normal behaviour — diverging name is renamed.
         await loop.tick()
         fake_thread.edit.assert_awaited_once()
+
+
+# ── #281: rename backoff persists across restarts ─────────────────────────────
+
+
+_FIXED_NOW = "2026-06-02 12:00:00"
+
+
+def _ts(offset_seconds: int) -> str:
+    """Return a wall-clock timestamp `offset_seconds` from _FIXED_NOW."""
+    import datetime as _dt
+
+    base = _dt.datetime.strptime(_FIXED_NOW, "%Y-%m-%d %H:%M:%S")
+    return (base + _dt.timedelta(seconds=offset_seconds)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+async def test_persisted_backoff_in_future_skips_rename(monkeypatch):
+    """#281: a FRESH loop (simulating a restart — _rename_backoff empty) must
+    still honour a backoff deadline persisted in the DB. Without persistence the
+    restart would forget the rate-limit window and re-PATCH within it (429)."""
+    import datetime as _dt
+
+    monkeypatch.setattr(
+        thread_state_sync,
+        "_now",
+        lambda: _dt.datetime.strptime(_FIXED_NOW, "%Y-%m-%d %H:%M:%S"),
+    )
+
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+    repo.set_rename_backoff_until = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock()
+
+    bot = MagicMock()
+    bot.get_channel.return_value = fake_thread
+    loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
+    # In-memory backoff is empty (fresh process), but DB says "still backed off".
+    rec = _Rec(thread_id=1201, state="waiting", topic="persisted backoff", tmux_window_id="@1")
+    rec.rename_backoff_until = _ts(300)  # 5 min in the future
+
+    with (
+        patch.object(thread_state_sync, "discord") as discord_mock,
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="❯\n"),
+    ):
+        discord_mock.Thread = fake_thread.__class__
+        discord_mock.HTTPException = _FakeHTTPException
+        await loop._sync_one(rec, by_tid={})
+
+    fake_thread.edit.assert_not_called()
+
+
+async def test_persisted_backoff_in_past_allows_rename(monkeypatch):
+    """#281: once the persisted deadline has passed, rename proceeds normally."""
+    import datetime as _dt
+
+    monkeypatch.setattr(
+        thread_state_sync,
+        "_now",
+        lambda: _dt.datetime.strptime(_FIXED_NOW, "%Y-%m-%d %H:%M:%S"),
+    )
+
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+    repo.set_rename_backoff_until = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock()
+
+    bot = MagicMock()
+    bot.get_channel.return_value = fake_thread
+    loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
+    rec = _Rec(thread_id=1202, state="waiting", topic="expired backoff", tmux_window_id="@1")
+    rec.rename_backoff_until = _ts(-1)  # already expired
+
+    with (
+        patch.object(thread_state_sync, "discord") as discord_mock,
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="❯\n"),
+    ):
+        discord_mock.Thread = fake_thread.__class__
+        discord_mock.HTTPException = _FakeHTTPException
+        await loop._sync_one(rec, by_tid={})
+
+    fake_thread.edit.assert_awaited_once()
+
+
+async def test_429_persists_backoff_to_db(monkeypatch):
+    """#281: a 429 must persist the backoff deadline to the DB (not just memory)
+    so a restart before the window elapses still honours it."""
+    import datetime as _dt
+
+    monkeypatch.setattr(
+        thread_state_sync,
+        "_now",
+        lambda: _dt.datetime.strptime(_FIXED_NOW, "%Y-%m-%d %H:%M:%S"),
+    )
+
+    repo = MagicMock()
+    repo.set_state = AsyncMock()
+    repo.set_tmux_window_id = AsyncMock()
+    repo.set_rename_backoff_until = AsyncMock()
+
+    fake_thread = MagicMock()
+    fake_thread.name = "old name"
+    fake_thread.edit = AsyncMock(side_effect=_FakeHTTPException(429, retry_after=300.0))
+
+    bot = MagicMock()
+    bot.get_channel.return_value = fake_thread
+    loop = ThreadStateSyncLoop(bot, repo, interval_seconds=999)
+    rec = _Rec(thread_id=1203, state="waiting", topic="429 persist")
+
+    with (
+        patch.object(thread_state_sync, "discord") as discord_mock,
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="❯\n"),
+    ):
+        discord_mock.Thread = fake_thread.__class__
+        discord_mock.HTTPException = _FakeHTTPException
+        await loop._sync_one(rec, by_tid={})
+
+    # Deadline persisted = now + retry_after (300s).
+    repo.set_rename_backoff_until.assert_awaited_once_with(1203, _ts(300))
 
 
 async def test_loop_start_is_idempotent():


### PR DESCRIPTION
## What does this PR do?

state-sync の rename rate-limit backoff を **DB に永続化** し、Bot 再起動を跨いで Discord のチャンネル名 rename 窓 (~10分/2回) を尊重するようにする。

- `sessions.rename_backoff_until` カラム (壁時計 "YYYY-MM-DD HH:MM:SS") を追加 + migration。
- 429 / timeout 時に `_now() + retry_after` を DB へ永続化、rename 成功時はクリア。
- `_sync_one` は毎 tick DB の `record` を読むため、再起動後 (in-memory backoff が空) でも persisted deadline を読んで窓内の rename をスキップ。明示的な復元処理は不要。
- `_now()` を間接化してテストを決定化。

## Why?

`_rename_backoff` は in-memory dict のため **再起動でリセット** される。あるスレッドを rename した直後に Bot を再起動すると、c-lord は「このチャンネルを今 rename したばかり = rate-limit 窓の中」という事実を忘れ、**窓を跨がず再 PATCH して 429** を踏む。CLAUDE.md が「Bot 再起動は積極的に」と推奨する運用と相性が悪かった。

#277 (PR #279) は「起動直後の初回 tick が全スレッドを一斉 rename するバースト」を解消したが、それとは**別経路**: 初回 tick 以降に走る通常 rename が、再起動で消えた backoff のせいで窓を割る問題。本 PR がそれを埋める。

Refs #281

## Acceptance Criteria (copied from #281)

- [x] rename 成功/429 時に「最終 rename 時刻 / backoff until」が **DB に永続化**されることを検証するテスト → `test_429_persists_backoff_to_db`
- [x] 新しい `ThreadStateSyncLoop` インスタンス (= 再起動相当) が DB の永続値から backoff を読み、**窓内のスレッドを rename しない** (RED→GREEN) → `test_persisted_backoff_in_future_skips_rename`
- [x] 窓を過ぎたスレッドは復元後も従来どおり rename される → `test_persisted_backoff_in_past_allows_rename`
- [x] staging で「backoff 中に再起動 → 窓内は再 rename されない / backoff 無しは rename」を確認 → 下記 Staging Evidence
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` 全グリーン (該当範囲)

## TDD (RED line)

```
tests/test_thread_state_sync.py::test_429_persists_backoff_to_db FAILED
  AttributeError: module 'c_lord.thread_state_sync' has no attribute '_now'
tests/test_thread_state_sync.py::test_persisted_backoff_in_future_skips_rename FAILED
```
修正後: `tests/test_thread_state_sync.py` **37 passed** / DB repo・models 151 passed。

## Staging Evidence

staging (`c-lord-parallel-3`, bot `C-lord-3#1206`, channel `1503196656265597082`, branch `1cae8c6`)。

「backoff 中に再起動した状態」を再現するため、検証用 2 スレッドを diverging (DB topic ≠ Discord 名) にし、**片方 (BACKOFF) だけ `rename_backoff_until` を 10 分後にセット**、もう片方 (CONTROL) は未設定。bot を再起動 (in-memory backoff は空) し、初回 tick スキップ後の次 tick を観測:

```
14:14:57 thread-state sync: initial pass complete (8 session(s) state-synced, no renames sent)
14:15:57 state-sync: renamed thread 1511167156333711400 → '🟡 W6 │ 281-CONTROL backoff無し検証' (state=waiting)
          ← CONTROL (backoff 無し) は通常どおり rename
          ← BACKOFF (1511166352277110805, 未来 deadline) は rename ログ無し = skip
```

再起動後の Discord 実名 (REST 取得):

| スレッド | DB backoff | 次 tick | Discord 名 |
|---|---|---|---|
| CONTROL `...400` | なし | **rename** | `🟡 W6 │ 281-CONTROL backoff無し検証` (新名) |
| BACKOFF `...805` | 10分後 | **skip** | `⚪ 再起動後の残作業確認` (旧名のまま) |

→ in-memory backoff が空の新プロセスでも、**DB の persisted deadline を読んで窓内 rename を抑止**しつつ、backoff 無しは過剰ブロックせず rename = #281 の核心が実機で機能。

**RED 対比**: main (`3985dc4`) は `rename_backoff_until` カラム自体が無く永続 backoff を一切読まないため、同状況で BACKOFF も次 tick で rename され窓を割る (ユニット RED: `_now` 未定義 AttributeError が同じギャップを示す)。

検証後 staging は idle ブランチ (`fix/wire-max-concurrent-sessions`) へ原状復帰・DB 復元済み。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: RED→GREEN, RED line pasted
- [x] `uv run pytest tests/test_thread_state_sync.py` passes (37) + DB repo/models (151)
- [x] `ruff check` + `ruff format --check` + `pyright` pass (該当 4 ファイル)
- [x] Staging Evidence filled in
- [x] No unrelated changes (`git diff origin/main` = models.py / repository.py / thread_state_sync.py / test の 4 ファイル)
- [x] `Refs #281` (本 PR は #281 の全 AC を満たすが、念のため Refs。マージ時に手動 close 可)

### Note: pre-existing test failures (本 PR 無関係)

実行環境固有で `test_skills.py` (`USE_SKILL_REPLY` env 依存) / `test_tmux.py` が落ちるが `git diff origin/main` に含まれず、CI クリーン環境では通る (#279 で実証済み)。本 PR の変更ファイルは全グリーン。
