### PR TITLE
docs: 経路A→B 移行のスコープ明確化 — reply 経路のみ撤去、control plane は残す (#238)

### DIFF
--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -310,3 +310,52 @@ every PR / merge is the user's gate" reading that the maintainer later corrected
 **Fix:** Codify the conduct in CLAUDE.md, enforce the artifact fields via the
 `.github` templates, and record the rationale here. See CLAUDE.md → "開発の行動規範
 (Working Conduct)" and "Definition of Done (DoD)".
+
+## 15. 経路B移行で撤去するのは reply 経路だけ — API サーバ本体と control plane は残す
+
+**決定:** 「経路A→経路B」への移行（#71）で取り除くのは、Claude が Discord に
+最終回答を出すための **reply 経路だけ** です。具体的には:
+
+- `POST /api/reply` というエンドポイント
+- 各セッションに入れている `discord-reply` skill（`.claude/skills/discord-reply/SKILL.md` の注入）
+
+これだけを撤去します。**API サーバ本体（`c_lord/ext/api_server.py`）と、それ以外の
+control plane エンドポイントは残します。** 残すものの例:
+
+| エンドポイント | 役割 |
+|---|---|
+| `/api/lounge` (GET/POST) | AI Lounge。CLAUDE.md の「Staging bot の占有・解放プロトコル」が依存している |
+| `/api/tasks` (POST/GET/DELETE/PATCH) | SchedulerCog へのタスク登録（設計判断 #8 / #9） |
+| `/api/spawn` | 外部トリガからスレッドを作って Claude を起動する |
+| `/api/mark-resume` | bot 再起動後にセッションを復帰させる |
+| `/api/notify` `/api/schedule` `/api/scheduled` | 即時通知・予約通知 |
+
+**この決定は GO 済み（#71、2026-06-04 に経路A→Bへ進めると決定）です。** ただし
+「GO」が指すのは reply 経路の置き換えだけで、API サーバ撤去は含みません。
+
+**なぜ切り分けるか:**
+
+- 「経路を A→B にすれば API サーバはいらなくなる」という見立ては、**reply の部分に
+  限れば正しい**。でもそこから「API サーバ全体がいらない」へは広げられません。
+- reply 経路（A も B も）が運ぶのは **Claude→Discord の最終回答** だけです。
+  一方 API サーバは、それとは別に **Claude→c-lord の操作面（control plane）**
+  をまるごと持っています（設計判断 #7 / #8 / #9）。スケジュール登録、外部トリガ
+  からのスレッド生成、再起動後の復帰、通知、AI Lounge など、reply とは独立した
+  機能です。
+- 経路B（JSONL transcript の透明ミラー）が置き換えるのは **回答の出し方** であって、
+  操作面の代わりにはなりません。だから reply 経路を消しても control plane は残す
+  必要があります。
+- もし control plane を撤去すると巻き添えになるものが出ます。たとえば `/api/lounge`
+  を消すと、CLAUDE.md に書いてある staging bot の占有・解放プロトコル（複数
+  セッションの協調）が壊れます。
+
+**スコープの固定:**
+
+- #71 の実装で「既存の skill push を撤去する」ステップは、**撤去対象を
+  `/api/reply` 経路（エンドポイント＋skill 注入）だけに限定**します。他の
+  エンドポイントには触りません。
+- 将来どこかの control plane エンドポイントを撤去・移設したくなった場合は、
+  **エンドポイントごとに別の Issue を立てて判断**します。本決定の既定は「残す」です。
+
+参照: #71（経路B 本体）/ #238（このスコープ明確化）/ 設計判断 #7（REST API を
+control plane にする）・#8 / #9（SQLite スケジューラ）。


### PR DESCRIPTION
## What

`docs/DESIGN_DECISIONS.md` に設計判断 **#15** を追記しました。

- 経路A→経路B 移行（#71）で撤去するのは **reply 経路だけ**（`POST /api/reply` + `discord-reply` skill 注入）であることを明文化。
- **API サーバ本体（`c_lord/ext/api_server.py`）と control plane エンドポイント**（`/api/lounge`, `/api/tasks`, `/api/spawn`, `/api/mark-resume`, `/api/notify` 等）は **残す** ことを設計判断として固定。
- 経路A→B は **GO 決定済み（#71, 2026-06-04）** だが、GO が指すのは reply 経路の置き換えだけで API サーバ撤去は含まない旨を一言追記。
- #71 の「既存 skill push 撤去」ステップは撤去対象を `/api/reply` 経路に限定する旨と、将来 control plane を撤去/移設する場合はエンドポイントごとに別 Issue を立てる旨を記載。

docs のみ。コードは触っていません（挙動変更なし）。

## Why

「経路を A→B にすれば API サーバ不要」という見立ては reply の脚に限れば正しいが、API サーバ本体（control plane）には拡張できない。この切り分けを設計判断として固定し、「経路B移行 ≠ API サーバ撤去」を残す。

Closes #238

## Acceptance Criteria (copied from the issue)

- [x] 「経路B移行で撤去されるのは reply 経路 (`/api/reply` + skill 注入) のみで、API サーバ本体と上記 control-plane エンドポイントは残す」という方針が `docs/DESIGN_DECISIONS.md`（または #71）に明記されている。
- [x] #71 の実装ステップ「既存 skill push の撤去」に、**撤去対象は `/api/reply` 経路に限定**（他エンドポイントは温存）であることが追記されている。
- [x] もし将来的に一部 control-plane も撤去/移設する判断をする場合は、各エンドポイントごとに別 Issue を立てる（本 Issue では「残す」を既定とする）。

## Staging Evidence

documentation label — docs only, no runtime change. staging 免除。

## Definition of Done checklist

`documentation` ラベルにより TDD evidence（item 2）と Staging verification（item 4）は免除。それ以外は以下のとおり。

- [x] **Every Acceptance Criterion copied and checked** — 上記 3 件すべて [x]。
- [x] **TDD evidence** — documentation 免除（挙動変更なし、docs のみ）。
- [x] **Detection bug fixture rule** — 該当なし（検出関数を触っていない）。
- [x] **pytest + ruff check + ruff format --check + pyright** — docs のみのため Python コード未変更。CI が確認。
- [x] **Staging behavior verified** — documentation 免除（no runtime change）。
- [x] **No unrelated changes** — diff は `docs/DESIGN_DECISIONS.md` への追記のみ。
- [x] **Closes gating** — 全 AC を満たすため `Closes #238` を独立行で記載。

🤖 Generated with [Claude Code](https://claude.com/claude-code)