### PR TITLE
fix: context 使用率の「100% full」誤表示を修正 (opus-4-8 登録 + used-aware フォールバック窓) (#292)

### DIFF
--- a/c_lord/claude/context_usage.py
+++ b/c_lord/claude/context_usage.py
@@ -24,10 +24,18 @@ from ..discord_ui.embeds import AUTOCOMPACT_THRESHOLD
 # models fall back to ``DEFAULT_CONTEXT_WINDOW``.
 DEFAULT_CONTEXT_WINDOW = 200_000
 MODEL_CONTEXT_WINDOW: dict[str, int] = {
+    "claude-opus-4-8": 200_000,
     "claude-opus-4-7": 200_000,
     "claude-sonnet-4-6": 200_000,
     "claude-haiku-4-5": 200_000,
 }
+
+# Standard context-window tiers, ascending.  Used by ``resolve_fallback_window``
+# to pick the smallest tier that still contains ``used`` when ``/context`` could
+# not be scraped — the 1M tier is opt-in and not revealed by the model id, so a
+# numerator that exceeds the 200k base is itself proof the session is on a larger
+# tier.  See #292.
+STANDARD_TIERS: tuple[int, ...] = (200_000, 1_000_000)
 
 # ``<used>/<total> tokens`` line emitted by ``/context`` (e.g. ``11.7k/1m tokens``).
 _CONTEXT_TOTAL_RE = re.compile(
@@ -123,6 +131,27 @@ def default_window(model: str | None) -> int:
     if model is None:
         return DEFAULT_CONTEXT_WINDOW
     return MODEL_CONTEXT_WINDOW.get(model, DEFAULT_CONTEXT_WINDOW)
+
+
+def resolve_fallback_window(model: str | None, used: int) -> int:
+    """Return a fallback window total that is never smaller than ``used``.
+
+    Used when ``/context`` could not be scraped for this turn.  Starts from the
+    per-model :func:`default_window` and, if the transcript-derived ``used`` is
+    larger than it, promotes the denominator to the smallest standard tier
+    (:data:`STANDARD_TIERS`) that still contains ``used``.  A window total below
+    its own numerator is logically impossible — the real window cannot be smaller
+    than what is already in it — so this guarantees ``result >= used`` and stops
+    the bogus "100% full" warning (#292).  If ``used`` exceeds every standard
+    tier, ``used`` itself is returned so the invariant still holds.
+    """
+    window = default_window(model)
+    if used <= window:
+        return window
+    for tier in STANDARD_TIERS:
+        if tier >= used:
+            return tier
+    return used
 
 
 def _fmt_tokens(n: int) -> str:

--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -23,9 +23,9 @@ import time
 import discord
 
 from ..claude.context_usage import (
-    default_window,
     format_context_line,
     read_latest_usage,
+    resolve_fallback_window,
 )
 from ..claude.tmux_runner import TmuxClaudeRunner
 from ..discord_ui.ask_handler import (  # noqa: F401
@@ -185,14 +185,18 @@ async def _cleanup_image_tempfiles(image_paths: list[str]) -> None:
             logger.debug("Deleted image tempfile: %s", path)
 
 
-async def _resolve_context_window(config: RunConfig, session_id: str, model: str | None) -> int:
+async def _resolve_context_window(
+    config: RunConfig, session_id: str, model: str | None, used: int
+) -> int:
     """Return the context-window total for ``session_id`` running ``model``.
 
     Learned by scraping ``/context`` (Claude is idle at the prompt after a turn
     completes), then cached.  A re-probe is forced when ``model`` differs from
     the value cached for this session, since the window size can change with the
-    model.  Falls back to a per-model default when the runner cannot probe or
-    the pane cannot be parsed.
+    model.  Falls back to a ``used``-aware per-model default when the runner
+    cannot probe or the pane cannot be parsed: the fallback denominator is never
+    smaller than ``used`` (a window total below its own contents is impossible),
+    which prevents the spurious "100% full" warning on 1M-tier sessions (#292).
     """
     cached = _context_window_cache.get(session_id)
     if cached is not None and cached[0] == model:
@@ -209,7 +213,7 @@ async def _resolve_context_window(config: RunConfig, session_id: str, model: str
         # not lock the per-model fallback in for the rest of the session.
         _context_window_cache[session_id] = (model, total)
         return total
-    return default_window(model or getattr(config.runner, "model", None))
+    return resolve_fallback_window(model or getattr(config.runner, "model", None), used)
 
 
 async def _post_context_usage(config: RunConfig, session_id: str | None) -> None:
@@ -232,7 +236,7 @@ async def _post_context_usage(config: RunConfig, session_id: str | None) -> None
     usage = read_latest_usage(jsonl)
     if usage is None:
         return
-    total = await _resolve_context_window(config, session_id, usage.model)
+    total = await _resolve_context_window(config, session_id, usage.model, usage.used)
     line = format_context_line(usage.used, total)
 
     # Prefer appending to Claude's last reply message — keeps the addendum

--- a/tests/test_context_usage.py
+++ b/tests/test_context_usage.py
@@ -17,6 +17,7 @@ from c_lord.claude.context_usage import (
     format_context_line,
     parse_context_total,
     read_latest_usage,
+    resolve_fallback_window,
 )
 
 # A trimmed but faithful capture of a real ``/context`` pane (1M context).
@@ -160,6 +161,53 @@ class TestDefaultWindow:
 
     def test_none_falls_back(self) -> None:
         assert default_window(None) == 200_000
+
+    def test_opus_4_8_is_registered(self) -> None:
+        """AC1: claude-opus-4-8 resolves via MODEL_CONTEXT_WINDOW, not fallback.
+
+        The 1M tier is opt-in and not revealed by the model id, so its registered
+        default window stays at the 200k base; what matters is that the model is
+        *known* (an explicit map entry) rather than silently hitting the unknown
+        fallback.
+        """
+        from c_lord.claude.context_usage import MODEL_CONTEXT_WINDOW
+
+        assert "claude-opus-4-8" in MODEL_CONTEXT_WINDOW
+        assert default_window("claude-opus-4-8") == MODEL_CONTEXT_WINDOW["claude-opus-4-8"]
+
+
+class TestResolveFallbackWindow:
+    def test_used_within_default_keeps_default(self) -> None:
+        # 50k used fits the 200k base window — no promotion.
+        assert resolve_fallback_window("claude-opus-4-8", used=50_000) == 200_000
+
+    def test_used_over_default_promotes_to_next_tier(self) -> None:
+        """AC2: used ≈ 314k exceeds the 200k base → promote to the 1M tier.
+
+        This is the opus-4-8 / 1M-tier regression from #292: when ``/context``
+        cannot be scraped, the denominator must rise to the smallest standard
+        tier that still contains ``used`` so that total >= used always holds.
+        """
+        assert resolve_fallback_window("claude-opus-4-8", used=313_779) == 1_000_000
+
+    def test_total_never_below_used(self) -> None:
+        # AC2: even a pathological numerator larger than every standard tier
+        # must yield total >= used (never a logically-impossible total < used).
+        used = 5_000_000
+        assert resolve_fallback_window("claude-opus-4-8", used=used) >= used
+
+    def test_unknown_model_promotes_too(self) -> None:
+        assert resolve_fallback_window("some-future-model", used=313_779) == 1_000_000
+
+    def test_no_promotion_yields_subtle_line_not_warning(self) -> None:
+        """AC3: with the promoted denominator the line is the subtle ``-#`` form,
+        not the ``⚠️ … 100% full … auto-compact`` warning."""
+        total = resolve_fallback_window("claude-opus-4-8", used=313_779)
+        line = format_context_line(used=313_779, total=total)
+        assert line.startswith("-#")
+        assert "⚠" not in line
+        assert "auto-compact" not in line
+        assert "100%" not in line
 
 
 class TestFormatContextLine:


### PR DESCRIPTION
## What

`claude-opus-4-8` の context 使用率が「⚠️ 100% full」を誤表示する精度バグ (#292) を修正。

- `MODEL_CONTEXT_WINDOW` に `claude-opus-4-8` を登録 (未登録フォールバックでなくなる)。
- `resolve_fallback_window(model, used)` を新設: `/context` スクレイプが取れないターンで、`used` が既定窓 (200k) を超える場合、分母を `used` を含む最小の標準 tier (`STANDARD_TIERS = (200k, 1M)`) に引き上げ、`total >= used` を保証する。
- `c_lord/cogs/_run_helper.py::_resolve_context_window` をこの `used`-aware フォールバックに差し替え、実コードパスでも誤警告が出ないようにした。

## Why

返答ごとの「コンテキスト使用率」は `/clear` / `/compact` 判断のための残量メーター。1M tier の opus-4-8 セッションで `/context` が取れなかったターンに、transcript の `used`(≈314k) が既定窓 200k を上回ると分母 < 分子という論理破綻が起き、`format_context_line` が pct を 100% にクランプして「もうすぐ自動圧縮」という強い警告を誤表示する。実際は `314k/1M ≒ 31%` で警告不要。誤誘導で不要な `/clear` を促すため有害。

Refs #292

(挙動変更だが決定的なロジックでありユニットで担保。staging 実機は #292 記載のとおり再現が不安定なためメンテナ確認待ち → `Closes` でなく `Refs`。)

## Acceptance Criteria

- [x] AC1: `default_window("claude-opus-4-8")` が `MODEL_CONTEXT_WINDOW` 経由で明示値を返す (未登録フォールバックでない)。
- [x] AC2: `/context` total が得られず、かつ transcript の `used` が当該モデルの default window を超える場合、解決後の分母は **`used` を含む最小の標準 tier** (例: `used=314k` → `1_000_000`) になり、`total >= used` を満たす。
- [x] AC3: 上記の状況で `format_context_line` が返すのは subtle な `-# 📊 …` 行であり、`⚠️ … 100% full … auto-compact …` 警告では**ない**。
- [x] AC4: AC2/AC3 を再現する回帰テスト (opus-4-8 / used≈314k / probe なし) を追加し、修正前 RED・修正後 GREEN を PR に貼る。
- [x] AC5: `ruff check` + `ruff format --check` + `pytest` が green。

## TDD evidence

**RED** — 修正前は `resolve_fallback_window` 自体が存在せず、新テストが collection error で失敗:

```
tests/test_context_usage.py:14: in <module>
    from c_lord.claude.context_usage import (
E   ImportError: cannot import name 'resolve_fallback_window' from 'c_lord.claude.context_usage'
```

修正前の実フォールバック (default_window=200k) の挙動を再現すると、まさに誤警告が出る (= バグ本体):

```
OLD fallback total: 200000
OLD line: ⚠️ Context 100% full (314k/200k) — auto-compact may run next turn
```

**GREEN** — 実装後:

```
tests/test_context_usage.py ........................  (69 passed: test_context_usage + test_run_helper)
全体: 1370 passed, 9 skipped, 23 deselected
```

新規テスト (`tests/test_context_usage.py`):
- `TestDefaultWindow::test_opus_4_8_is_registered` (AC1)
- `TestResolveFallbackWindow::test_used_over_default_promotes_to_next_tier` (AC2: used=313_779 → 1_000_000)
- `TestResolveFallbackWindow::test_total_never_below_used` (AC2 invariant)
- `TestResolveFallbackWindow::test_no_promotion_yields_subtle_line_not_warning` (AC3)

## Staging Evidence

未実施。挙動は決定的なロジック (純粋関数 `resolve_fallback_window` + 既存 `format_context_line`) でユニットテストにより担保。#292 にあるとおり opus-4-8 / 1M tier で `/context` 取得失敗を踏むターンの実機再現は不安定なため、staging はメンテナ確認待ち。

## Definition of Done

- [x] Every Acceptance Criterion of the linked Issue is copied into the PR body and checked.
- [x] TDD evidence: RED 行を上記に貼付 (import error + 修正前フォールバックの誤警告再現)。GREEN は新テスト pass。
- [x] `pytest` + `ruff check` + `ruff format --check` (変更ファイル) + pyright(CI) green。
- [ ] Staging behavior verified — 未実施 (上記理由によりメンテナ確認待ち)。
- [x] No unrelated changes; self-review 済 (`git diff main` は context_usage.py / _run_helper.py / test_context_usage.py のみ)。
- [x] Closes gating: 一部 AC (実機検証) が staging 待ちのため `Refs #292` を使用、Issue は open のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
