### PR TITLE
feat: auto patch-bump + GitHub Release on every main merge

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,88 +1,82 @@
 ---
 name: release
-description: c-lord のマイナー/メジャーリリース手順。「v1.4.0としてリリースして」等と言われたときに使う。
+description: c-lord のバージョン/リリース手順。「v1.5.0としてリリースして」等と言われたときに使う。
 allowed-tools: Bash, Read, Edit
 ---
 
 # c-lord リリース手順
 
-## バージョン体系
+## 仕組みの要点
+
+- **バージョンの真実源は git タグ `vX.Y.Z`**。`pyproject.toml` に version は書かない（`hatch-vcs` がタグから導出）。**手書きで version を書き換えてはいけない。**
+- **patch は全自動**: main へ PR をマージするたび `.github/workflows/auto-version-bump.yml` が patch を +1 してタグ + GitHub Release を作る（`v1.4.0`→`v1.4.1`→…）。操作不要。
+- **minor / major は手動**: 節目を付けたいときだけ `scripts/release.sh` でタグを打つ（このスキル）。
+- 実行中ボットの版は `c-lord version` / `/version` で `v1.4.0-b<commit7>-<YYYYMMDD>` 形式（記事準拠）で確認できる。
+- リリースノートは `CHANGELOG.md` の該当セクションから自動抽出される。
 
 ```
-v1.3.0  ← 手動マイナーリリース（このスキルの対象）
-v1.3.1  ← PR マージごとに自動インクリメント（普段は何もしない）
-v1.3.2  ← 同上
-...
-v1.4.0  ← 手動マイナーリリース（このスキルの対象）
+v1.4.0 ──(PR merge: 自動 patch)──> v1.4.1 ──(自動)──> v1.4.2 ──(手動 minor)──> v1.5.0
 ```
 
-- **自動パッチバンプ**: 普通の PR をマージするたびに `.1` ずつ自動インクリメント。操作不要
-- **手動リリース**: マイナー/メジャーの区切りを付けたいときに使う（このスキル）
+### 自動 patch bump が走らないケース
+
+`auto-version-bump.yml` は head コミットの subject が次のときスキップ（release→docs-sync→release ループ防止）:
+
+- `docs:` で始まる（翻訳・ドキュメント更新）
+- `[skip-release]` または `[skip ci]` を含む
+
+bump させたくない PR は、squash コミット subject を `docs:` にするか `[skip-release]` を付ける。
 
 ---
 
-## 手動リリース手順（「v1.4.0としてリリースして」）
+## 手動リリース（minor / major、「v1.5.0としてリリースして」）
 
-### Step 1: リポジトリに入る
+### Step 1: main を最新化
 
 ```bash
 cd /home/yousan/c-lord
 git checkout main && git pull
 ```
 
-### Step 2: ブランチを作る
+### Step 2: CHANGELOG.md を更新（PR で）
+
+1. `## [Unreleased]` を `## [1.5.0] - YYYY-MM-DD`（今日）に変更
+2. その上に新しい空の `## [Unreleased]` を追加
+3. 末尾のリンク定義（`[1.5.0]: .../compare/v1.4.0...v1.5.0` 等）も追記
 
 ```bash
-git checkout -b release/v1.4.0   # バージョンは指定されたものに変える
+git checkout -b docs/changelog-v1.5.0
+# CHANGELOG.md を編集
+git add CHANGELOG.md
+git commit -m "docs: changelog for v1.5.0"   # docs: なので自動 patch bump は走らない
+git push -u origin docs/changelog-v1.5.0
+gh pr create --base main --title "docs: changelog for v1.5.0" \
+  --body "Changelog for the v1.5.0 release."
 ```
 
-### Step 3: pyproject.toml のバージョンを更新
+PR をマージ（CHANGELOG をタグより先に main へ入れることで、リリースノートが正しく拾われる）。
 
-`pyproject.toml` の `version = "1.3.x"` を指定バージョンに書き換える:
+### Step 3: タグを打つ（= リリース実行）
 
-```toml
-version = "1.4.0"
-```
-
-### Step 4: CHANGELOG.md を更新
-
-1. `## [Unreleased]` セクションを `## [1.4.0] - YYYY-MM-DD` に変更（今日の日付）
-2. その上に新しい空の `## [Unreleased]` セクションを追加
-
-```markdown
-## [Unreleased]
-
-## [1.4.0] - 2026-02-22   ← 今日の日付
-
-### Added
-...（既存の Unreleased 内容がここに来る）
-```
-
-### Step 5: PR を作成（タイトルに **必ず** `[release]` を含める）
+`scripts/release.sh` を使う。まず dry-run:
 
 ```bash
-PATH="/home/yousan/.local/bin:$PATH" git add pyproject.toml CHANGELOG.md
-PATH="/home/yousan/.local/bin:$PATH" git commit -m "release: v1.4.0 [release]"
-git push -u origin release/v1.4.0
-
-gh pr create \
-  --repo yousan/c-lord \
-  --base main \
-  --title "release: v1.4.0 [release]" \
-  --body "Release v1.4.0
-
-## Changes
-See CHANGELOG.md for details."
+git checkout main && git pull
+./scripts/release.sh --version 1.5.0          # dry-run（打たれるタグを表示）
+./scripts/release.sh --version 1.5.0 --apply  # タグ作成 + push → release.yml が Release 作成
 ```
 
-**⚠️ 重要**: PR タイトルに `[release]` を含めること。これがないと自動パッチバンプが走って v1.4.1 になってしまう。
-
-### Step 6: 確認（数分後）
-
-auto-approve により PR が自動マージされ、タグ `v1.4.0` と GitHub Release が作成される:
+バージョンを明示せず、直近コミットの `[minor]`/`[major]`/`[release]` から自動算出も可能（指定なしは patch）:
 
 ```bash
-gh release view v1.4.0 --repo yousan/c-lord
+./scripts/release.sh --level minor            # dry-run
+./scripts/release.sh --level minor --apply
+```
+
+### Step 4: 確認
+
+```bash
+gh release view v1.5.0 --repo yousan/c-lord
 ```
 
 ---
@@ -90,14 +84,17 @@ gh release view v1.4.0 --repo yousan/c-lord
 ## 仕組み（裏側）
 
 ```
-PR マージ（auto-approve.yml）
-  └── repository_dispatch: pr-merged
-        └── auto-version-bump.yml
-              ├── PR タイトルに [release] あり → 現在バージョンでタグ & Release（バンプなし）
-              └── [release] なし → patch++ してコミット → タグ & Release
+普通の PR を main にマージ
+  └── push: main → auto-version-bump.yml
+        ├── subject が docs: / [skip-release] → 何もしない
+        └── それ以外 → 最新タグ + patch でタグ作成 + GitHub Release
+
+手動 minor/major
+  └── scripts/release.sh --apply → vX.Y.Z タグ push
+        └── push: tags v* → release.yml → GitHub Release（CHANGELOG 抽出）
 ```
 
-docs-sync PR（翻訳・ドキュメント更新）はバンプも Release も発生しない。
+> 注: `GITHUB_TOKEN` で打ったタグは別ワークフローを起動しない（GitHub の再帰防止）。そのため auto-version-bump.yml はタグと Release を同一ジョブで作る。release.sh が打つタグ（個人の認証）は release.yml を起動する。
 
 ---
 
@@ -105,5 +102,7 @@ docs-sync PR（翻訳・ドキュメント更新）はバンプも Release も�
 
 | 状況 | 原因 | 対処 |
 |------|------|------|
-| v1.4.1 になってしまった | PR タイトルに `[release]` がなかった | タグを削除して再度 release PR を作る |
-| タグが既に存在するエラー | 同じバージョンでタグを作ろうとした | タグを削除: `gh api repos/yousan/c-lord/git/refs/tags/v1.4.0 --method DELETE` |
+| Release のノートが空/簡素 | タグより先に CHANGELOG が main に入っていない | CHANGELOG を main へ入れてからタグを打ち直す |
+| タグが既に存在するエラー | 同じバージョンで再実行 | `git push --delete origin v1.5.0` してから再実行 |
+| docs PR なのに patch が上がった | subject が `docs:` 始まりでなかった | subject を `docs:` にするか `[skip-release]` を付ける |
+| 版が `0.0.0` に見える | タグが1つも無い（ブートストラップ前） | 最初の `v1.4.0` タグを打つ（`release.sh` が seed する） |

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,97 @@
+name: Auto Version Bump
+
+# Every push to main (i.e. a merged PR) auto-bumps the PATCH version: it cuts
+# the next vX.Y.(Z+1) tag from the latest tag and publishes a GitHub Release
+# whose notes are the matching CHANGELOG.md section (falling back to the commit
+# subject). minor/major boundaries stay MANUAL via scripts/release.sh.
+#
+# Skipped when the head commit is docs/bot churn or opts out explicitly:
+#   - subject starts with "docs:"  (docs-sync / translation churn)
+#   - subject contains "[skip-release]" or "[skip ci]"
+# This prevents a release -> docs-sync -> release loop.
+#
+# Note: a tag pushed with GITHUB_TOKEN does NOT trigger other workflows
+# (GitHub anti-recursion), so this job creates BOTH the tag and the Release
+# itself rather than relying on release.yml.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need all tags + history
+
+      - name: Decide whether to release
+        id: gate
+        run: |
+          SUBJECT="$(git log -1 --format=%s)"
+          echo "subject: $SUBJECT"
+          skip=0
+          case "$SUBJECT" in
+            docs:*) skip=1 ;;
+          esac
+          case "$SUBJECT" in
+            *"[skip-release]"*|*"[skip ci]"*) skip=1 ;;
+          esac
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next patch version
+        id: ver
+        if: steps.gate.outputs.skip == '0'
+        run: |
+          LATEST="$(git tag --list 'v*' --sort=-v:refname | head -1)"
+          if [ -z "$LATEST" ]; then
+            NEXT="1.4.0"   # seed when no tag exists yet
+          else
+            NEXT="$(python3 -c "
+          import importlib.util
+          spec = importlib.util.spec_from_file_location('v', 'c_lord/version.py')
+          m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+          print(m.bump_version('${LATEST}'.lstrip('v'), 'patch'))
+          ")"
+          fi
+          TAG="v${NEXT}"
+          echo "latest=${LATEST:-<none>}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag + GitHub Release
+        if: steps.gate.outputs.skip == '0' && steps.ver.outputs.exists == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+          VERSION="${{ steps.ver.outputs.version }}"
+
+          # Release notes: CHANGELOG section if present, else the commit subject.
+          python3 - "$VERSION" <<'PY' > release_notes.md
+          import importlib.util, pathlib, sys
+          spec = importlib.util.spec_from_file_location("_clord_version", "c_lord/version.py")
+          mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+          version = sys.argv[1]
+          text = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          section = mod.extract_changelog_section(text, version)
+          print(section if section else f"Automated release {version}.")
+          PY
+
+          git tag -a "$TAG" -m "Release $TAG (auto patch bump)"
+          git push origin "$TAG"
+          gh release create "$TAG" --title "$TAG" --notes-file release_notes.md
+          echo "Released $TAG"


### PR DESCRIPTION
## What does this PR do?

Makes **every merge to main auto-bump the PATCH version** and publish a GitHub Release. minor/major boundaries stay manual via `scripts/release.sh`.

## Why?

Requested: バージョン番号を main マージ時に自動で進めたい。Previously releases only fired on a manually-pushed tag.

## How

New `.github/workflows/auto-version-bump.yml` (`push: main`):
- computes next `vX.Y.(Z+1)` from the latest tag (seeds `v1.4.0` if none) using `c_lord/version.py::bump_version`
- creates the tag **and** the Release in one job — a `GITHUB_TOKEN`-pushed tag does not trigger `release.yml` (GitHub anti-recursion), so we can't defer to it
- release notes = matching `CHANGELOG.md` section (loaded standalone, no discord import), fallback "Automated release X"
- **SKIPS** when the head commit subject starts with `docs:` or contains `[skip-release]`/`[skip ci]` → prevents a release→docs-sync→release loop

Also rewrites the `release` skill doc to match reality (hatch-vcs tags + auto patch + manual minor/major). The on-disk skill had drifted back to the pre-hatch-vcs "edit pyproject version" flow.

## Acceptance Criteria

- [x] Merging a non-docs PR to main creates `vX.Y.(Z+1)` tag + GitHub Release automatically
- [x] `docs:` / `[skip-release]` commits do NOT bump
- [x] minor/major remain manual via `scripts/release.sh`
- [x] Release notes come from the CHANGELOG section
- [x] Workflow YAML validated; bump + gate logic verified locally

## Staging Evidence

Skip reason: **GitHub Actions workflow + skill-doc change only** (no c_lord runtime/package behavior change). Verified locally: YAML parses (4 steps), `bump_version('1.4.0','patch')→1.4.1`, gate logic skips `docs:`/`[skip-release]` and releases `feat:`/`fix:`. The end-to-end effect will be observable on the very next non-docs merge (this PR itself, if merged with a non-`docs:` squash subject, should produce `v1.4.1`).

## Definition of Done checklist

- [x] Acceptance Criteria を全て満たした
- [x] TDD: bump/gate ロジックは `c_lord/version.py` の既存ユニットテスト + ローカル再現で確認
- [x] `pytest` + `ruff` + `pyright` green（既存コードに変更なし）
- [x] Staging: workflow/doc-only のためスキップ（理由を上に記載）
- [x] 関係ない変更なし / セルフレビュー済み
- [x] `Refs #256`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
