### PR TITLE
chore: verify auto version bump fires on merge

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -95,3 +95,5 @@ jobs:
           git push origin "$TAG"
           gh release create "$TAG" --title "$TAG" --notes-file release_notes.md
           echo "Released $TAG"
+
+# (auto-bump verified live on first post-merge push)


### PR DESCRIPTION
## What does this PR do?

Trivial chore (a comment line) whose purpose is to **verify the auto patch-bump live**: merging this non-`docs:` PR to main should make `auto-version-bump.yml` fire and produce `v1.4.1` + a GitHub Release. (The workflow couldn't run on its own introducing merge — GitHub doesn't run a push-workflow added within that same push.)

## Acceptance Criteria

- [x] Trivial, behavior-neutral change
- [ ] After merge: `v1.4.1` tag + GitHub Release auto-created (verified post-merge)

## Staging Evidence

Skip reason: workflow comment-only change; the actual verification is the post-merge auto-bump observation (a CI/release-pipeline check, not a bot-runtime behavior). No c_lord runtime change.

## Definition of Done checklist

- [x] Acceptance Criteria 記載
- [x] TDD: N/A（コメント1行 + パイプライン実地検証）
- [x] `pytest`/`ruff`/`pyright` green（コード無変更）
- [x] Staging: workflow-only のためスキップ（理由を上に記載）
- [x] 関係ない変更なし
- [x] `Refs #256`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
