### PR TITLE
fix: set git identity in auto-version-bump before tagging

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -91,9 +91,11 @@ jobs:
           print(section if section else f"Automated release {version}.")
           PY
 
+          # The runner has no git identity by default; annotated tags need one.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           git tag -a "$TAG" -m "Release $TAG (auto patch bump)"
           git push origin "$TAG"
           gh release create "$TAG" --title "$TAG" --notes-file release_notes.md
           echo "Released $TAG"
-
-# (auto-bump verified live on first post-merge push)


### PR DESCRIPTION
## What does this PR do?

Fixes `auto-version-bump.yml`, which ran on the previous merge but failed at the tag step with `fatal: empty ident name (...) not allowed` (run 26933761239). The GitHub runner has no default git identity, which annotated tags (`git tag -a`) require.

## Why?

So the auto patch-bump actually creates `vX.Y.(Z+1)` + Release on merge (the whole point of #307). Version bump + release-notes generation already worked; only the annotated-tag creation failed.

## Fix

Set `github-actions[bot]` git identity before `git tag -a`. (Also removed a stray verification comment.)

Refs #256

## Acceptance Criteria

- [x] `git config user.name/email` set before tagging
- [ ] After merge: auto-bump produces `v1.4.1` tag + Release (verified post-merge)

## Staging Evidence

Skip reason: GitHub Actions workflow-only change. Root cause is the exact runner error above; fix is the standard `git config` identity step. End-to-end effect verified by the next merge producing `v1.4.1`.

## Definition of Done checklist

- [x] Acceptance Criteria 記載
- [x] TDD: N/A（CI YAML 修正、原因＝runnerエラー明確）
- [x] `pytest`/`ruff`/`pyright` green（コード無変更）
- [x] Staging: workflow-only のためスキップ（理由を上に記載）
- [x] 関係ない変更なし
- [x] `Refs #256`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
