### PR TITLE
fix: derive_project_dir matches Claude Code slug for relative/dotted cwd (#320)

### DIFF
--- a/c_lord/transcript/resolver.py
+++ b/c_lord/transcript/resolver.py
@@ -8,6 +8,7 @@ with every ``/`` replaced by ``-`` (the leading slash too — so
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 
@@ -16,9 +17,21 @@ def derive_project_dir(cwd: str, *, projects_root: Path | None = None) -> Path:
 
     The directory may not exist yet — Claude Code creates it lazily on first
     write — so callers should not assume ``.is_dir()`` is true here.
+
+    The slug must match Claude Code's own algorithm, which (#320):
+
+    * is computed from the **absolute** cwd — Claude Code always records its
+      working directory as an absolute path. ``working_dir`` may be stored
+      relative (the default session base is ``data/sessions``), so a relative
+      input is resolved against the current process CWD first.
+    * replaces **both** ``/`` and ``.`` with ``-`` — e.g. ``/home/u/.config``
+      becomes ``-home-u--config`` (the leading ``/`` plus the converted dot
+      yields a double dash).
     """
+    if not os.path.isabs(cwd):
+        cwd = os.path.realpath(cwd)
     root = projects_root if projects_root is not None else Path.home() / ".claude" / "projects"
-    return root / cwd.replace("/", "-")
+    return root / cwd.replace("/", "-").replace(".", "-")
 
 
 def latest_session_jsonl(project_dir: Path) -> Path | None:

--- a/tests/transcript/test_resolver.py
+++ b/tests/transcript/test_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 
@@ -24,6 +25,32 @@ def test_derive_project_dir_handles_trailing_slash(tmp_path: Path) -> None:
     got = derive_project_dir("/home/yousan/c-lord/", projects_root=tmp_path)
     # Trailing slash produces a trailing dash; Claude Code uses naive replace.
     assert got == tmp_path / "-home-yousan-c-lord-"
+
+
+def test_derive_project_dir_replaces_dots_with_dashes(tmp_path: Path) -> None:
+    # Claude Code's slug replaces BOTH '/' and '.' with '-' (#320). A dotted
+    # component like '.config' must become '-config', so the '/' before it
+    # plus the converted dot yields a double dash.
+    got = derive_project_dir("/home/kaiono/.config/c-lord", projects_root=tmp_path)
+    assert got == tmp_path / "-home-kaiono--config-c-lord"
+
+
+def test_derive_project_dir_resolves_relative_to_absolute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # working_dir is stored relative to c-lord's CWD (default base 'data/sessions'),
+    # but Claude Code records its cwd as an ABSOLUTE path, so a relative input must
+    # be resolved before slugifying (#320).
+    monkeypatch.chdir(tmp_path)
+    rel = "data/sessions/123/456"
+
+    got = derive_project_dir(rel, projects_root=tmp_path)
+
+    abs_real = os.path.realpath(rel)
+    expected = tmp_path / abs_real.replace("/", "-").replace(".", "-")
+    assert got == expected
+    # The naive relative slug (the bug) must NOT be produced.
+    assert got != tmp_path / "data-sessions-123-456"
 
 
 def test_latest_session_jsonl_returns_most_recently_modified(tmp_path: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

`derive_project_dir` (`c_lord/transcript/resolver.py`) の slug 生成を Claude Code の規則に一致させる:
1. 相対 `working_dir` を `os.path.realpath` で絶対化してから slug 化
2. `/` だけでなく `.` も `-` に置換

## Why?

`CLORD_BRIDGE_MODE=jsonl` で `TranscriptMirrorCog` が存在しないディレクトリを tail し、Claude の応答が**一切 Discord に出ない**ケースがあった (#320, 外部報告 hudsoncliff)。原因は slug が Claude Code と2点ズレること:

- 既定の session base は相対 `data/sessions`。Claude Code は cwd を常に**絶対パス**で記録するため、相対のまま slug 化すると別ディレクトリを指す。
- Claude Code は `/` と `.` の**両方**を `-` にするが、コードは `/` だけ。`.config` が `.config` のまま残り slug 不一致。

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: session dir が相対パス or 絶対パスにドット入り要素 (`.config`/`.local` 等) を含む `jsonl` 運用環境で、**Claude の返信が無言で消える → スレッドに正しく届く**(本番/staging のように `SESSION_DIR_BASE` が絶対・ドット無しの環境は `no-user-visible-change`)

Closes #320

## Acceptance Criteria (copied from the issue)

<!-- #320 に明示的 AC 節は無いため、本文の「Root causes (two separate bugs)」を binary AC 化 -->

- [x] AC 1: 相対 `working_dir` が絶対パスに解決されてから slug 化される (`os.path.realpath`)
- [x] AC 2: slug 生成で `/` と `.` の両方が `-` に置換される（例 `/home/kaiono/.config/c-lord` → `-home-kaiono--config-c-lord`）
- [x] AC 3: 絶対・ドット無しパス（本番/staging の `SESSION_DIR_BASE`）は従来と同一 slug（回帰なし）
- [x] AC 4: 修正は `resolver.py` 1点で両呼び出し元 (`_run_helper.py`, `transcript_mirror.py`) をカバー

## Staging Evidence (証跡)

> 本修正は決定的な純関数 (slug 派生) のバグ。staging/prod と**同一ホスト・同一 `~/.claude/projects`** 上の**実在 Claude Code トランスクリプト**で、本番コードパス (`derive_project_dir` → `latest_session_jsonl`) の RED→GREEN を実証した（モックではない on-disk データ）。Discord 実画面スクショは server 側 agent に GUI が無いため省略（#243 待ち）。

対象 cwd: `/home/yousan/games/.claude-rooms/factorio-server-1`（ドット入り・実在ディレクトリ）。
`.claude` → `--claude`（二重ダッシュ）が**実際に Claude Code が作ったディレクトリ名**であり、報告の「`.`→`-`」主張の直接の裏取り。

<details>
<summary>RED (before) — 旧 slug ロジックは実在トランスクリプトを見失う</summary>

```
修正前 slug : -home-yousan-games-.claude-rooms-factorio-server-1
  → 実在? False / latest_session_jsonl: None      ← #320 の症状（見失い→無応答）
```
</details>

<details>
<summary>GREEN (after) — 修正後は実 jsonl を発見</summary>

```
修正後 slug : -home-yousan-games--claude-rooms-factorio-server-1
  → 実在? True  / latest_session_jsonl: d9948575-f423-409a-aba8-5cd4643984b6.jsonl
```
</details>

<details>
<summary>ユニット TDD RED 行（修正前の失敗）</summary>

```
FAILED tests/transcript/test_resolver.py::test_derive_project_dir_replaces_dots_with_dashes
FAILED tests/transcript/test_resolver.py::test_derive_project_dir_resolves_relative_to_absolute
E  AssertionError: assert PosixPath('.../data-sessions-123-456')
                       == PosixPath('.../-tmp-...-data-sessions-123-456')
```
GREEN: `tests/transcript/test_resolver.py 10 passed` / 全体 `1487 passed, 3 skipped`（クリーン env）
</details>

Discord screenshot (user-provided): N/A（server 側 agent に GUI 無し。slug は純関数で Discord 描画に依存しないため上記 on-disk 実データで代替）

> Discord webhook 往復の完全 E2E は、共有 staging の `SESSION_DIR_BASE` をドット/相対へ変更し2回再起動する侵襲が必要で、かつ本修正で**未変更**の下流（jsonl→Discord 投稿）を再検証するだけになるため上記を主証跡とした。要望あれば実施可能。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメント（仕様 / README / docs）も更新した。変えないなら本文に `no-user-visible-change` と明記した（slug 規則は resolver.py docstring に記述。spec/README に派生記述なし）
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met (else `Refs #N`), and written on its own line
