### PR TITLE
docs(DoD): 免除節/PRテンプレの項目番号参照をルール名に置換（番号ズレ是正）(#330)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -75,8 +75,8 @@ Discord screenshot (user-provided): <attach / link>
 
 See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.
 
-> **Label exemptions** (`no-runtime-change` or `documentation` label): items 1–2 and 5 below are waived.
-> `Closes` discipline (item 7) is **always enforced**, regardless of label.
+> **Label exemptions** (`no-runtime-change` or `documentation` label): the DoD-completion checklist below is waived (notably **TDD evidence** and **Staging Evidence**).
+> **`Closes` discipline is always enforced**, regardless of label: if you use `Closes`/`Resolves #N`, the Acceptance Criteria above must still be fully checked (else use `Refs #N`).
 
 - [ ] Every Acceptance Criterion above is checked
 - [ ] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,8 +367,10 @@ incident that motivated this.
 
 **Label-based exemptions** (enforced by `dod-gate` CI — see `.github/workflows/dod-gate.yml`):
 
-- `no-runtime-change` or `documentation` label: **exempts TDD evidence and Staging verification** (items 2 and 4 below). Use for pure-docs, CI/tooling, or provably no-behavior-change commits.
-- **Closes discipline (item 6) is always enforced**, regardless of labels.
+- `no-runtime-change` or `documentation` label: **waives the DoD-completion checklist below** (notably the **TDD evidence** and **Staging verification** requirements). Use for pure-docs, CI/tooling, or provably no-behavior-change commits.
+- **`Closes` discipline is always enforced**, regardless of labels: if a PR uses `Closes`/`Resolves #N`, that Issue's Acceptance Criteria must be 100% met (else use `Refs #N`).
+
+<!-- 参照はルール名で固定（番号で指さない）。項目を挿入すると番号がずれ免除対象がずれるため。dod-gate.yml の実挙動: ラベルあり → DoD 完了要件 (Rule 1) を免除 / `Closes` 規律 (Rule 2) は常時適用。 -->
 
 A PR may be merged only when:
 


### PR DESCRIPTION
## What does this PR do?

DoD の**免除節（CLAUDE.md）と PR テンプレ**が、項目を「番号」で参照していたのを**ルール名参照に置換**（#330）。項目挿入で番号がずれ、実際は Staging=項目5 / Closes=項目8 なのに `items 2 and 4` / `item 6` / `item 7` と**誤った項目を指していた**。併せて dod-gate.yml の実挙動と文言を一致させた。

## Why?

番号参照は項目を挿入するたびに desync する（実際に「検出フィクスチャ規律」「spec 更新規律」の挿入でずれていた）。「single source of truth」を名乗る DoD 自身が、prose の strictness は信用できないという自分の主張を証明してしまっていた。**ルール名参照なら項目を挿入しても二度とずれない。**

Closes #330

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: `no-user-visible-change`（DoD ドキュメント/テンプレの文言修正のみ。Discord 上の挙動は不変）

## Acceptance Criteria (copied from the issue)

- [x] CLAUDE.md 免除節が項目番号でなくルール名（TDD evidence / Staging verification / Closes discipline）で参照している
- [x] PR テンプレの免除注記も項目番号でなくルール名で参照している
- [x] 文言が dod-gate.yml の実挙動（label で DoD 完了要件を免除・`Closes` 規律は常時適用）と一致している
- [x] `ruff check` + `pytest` green

## Staging Evidence (証跡)

`documentation` ラベル（CLAUDE.md + PR テンプレのドキュメント文言修正のみ）。挙動不変のため staging 検証は対象外。**skip 理由: pure-docs / no behavior change。**

## Definition of Done checklist

> `documentation` ラベルにより DoD 完了要件は免除。`Closes` 規律は常時適用。

- [x] Every Acceptance Criterion above is checked
- [ ] TDD: RED/GREEN — N/A（documentation 免除：pure-docs）
- [x] `uv run pytest tests/ -v` passes（変更は md のみ・既存スイート緑）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [ ] Staging Evidence — N/A（documentation 免除、上記 skip 理由）
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」も更新 — `no-user-visible-change`（挙動不変）
- [x] `Closes #330` を独立行で記載・#330 の AC を 100% 充足
