### PR TITLE
fix(scripts): _load_font の戻り値型注釈を FreeTypeFont|ImageFont に修正 (#331)

### DIFF
--- a/scripts/compose_screenshots.py
+++ b/scripts/compose_screenshots.py
@@ -26,7 +26,7 @@ _BG = (255, 255, 255)  # canvas background
 _FG = (0, 0, 0)  # label text color
 
 
-def _load_font() -> ImageFont.ImageFont:
+def _load_font() -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
     """Return a usable font, falling back to Pillow's bundled default."""
     try:
         return ImageFont.truetype("DejaVuSans-Bold.ttf", 18)


### PR DESCRIPTION
## What does this PR do?

`scripts/compose_screenshots.py` の `_load_font` 戻り値注釈を
`ImageFont.ImageFont` → `ImageFont.FreeTypeFont | ImageFont.ImageFont` に修正（#331）。
`ImageFont.truetype()` が `FreeTypeFont` を返す型不一致を解消（1 行）。

## Why?

pyright が `"FreeTypeFont" is not assignable to return type "ImageFont"` を出していた。CI の pyright は `c_lord/` のみ対象なので**ブロックされず #310 で main に入っていた**が、型注釈として誤り。残すと「型は通っている」という誤った前提を作る。

Closes #331

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: `no-user-visible-change`（dev スクリプトの型注釈のみ。実行結果・Discord 上の挙動は不変）

## Acceptance Criteria (copied from the issue)

- [x] `_load_font` の戻り値注釈が truetype / load_default 双方の戻り値型を含む
- [x] `uv run pyright scripts/compose_screenshots.py` が当該行でエラーを出さない（→ `0 errors, 0 warnings`）
- [x] `ruff check` + `pytest tests/test_compose_screenshots.py` green（→ `2 passed`）

## Staging Evidence (証跡)

`no-runtime-change` ラベル（dev スクリプトの型注釈のみ・実行挙動不変）。staging 検証は対象外。**skip 理由: no behavior change（型注釈のみ）。**

ローカル検証:
```
$ uv run pyright scripts/compose_screenshots.py
0 errors, 0 warnings, 0 informations
$ uv run pytest tests/test_compose_screenshots.py -q
2 passed
```

## Definition of Done checklist

> `no-runtime-change` ラベルにより DoD 完了要件は免除。`Closes` 規律は常時適用。

- [x] Every Acceptance Criterion above is checked
- [ ] TDD: RED/GREEN — N/A（型注釈のみの修正・既存 `test_compose_screenshots.py` が挙動を担保／`no-runtime-change` 免除）
- [x] `uv run pytest tests/ -v` passes（compose テスト 2 passed・他不変）
- [x] `uv run ruff check` + `ruff format --check` + `pyright`（当該ファイル）pass
- [ ] Staging Evidence — N/A（no-runtime-change 免除、上記 skip 理由）
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」も更新 — `no-user-visible-change`（挙動不変）
- [x] `Closes #331` を独立行で記載・#331 の AC を 100% 充足
