### PR TITLE
fix: 起動時に EXPECTED_BOT_USER_ID と照合し、誤 identity なら即終了する (#323)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Discord Bot Configuration
 DISCORD_BOT_TOKEN=your-bot-token-here
 DISCORD_CHANNEL_ID=your-channel-id-here
+# Identity guard (#323, optional but recommended when running multiple bots,
+# e.g. prod + staging on one host): the bot's own Discord user id. If the
+# process logs in as a DIFFERENT bot (e.g. a production token leaked into the
+# environment of a staging launch), it exits immediately instead of running
+# as the wrong identity.
+# EXPECTED_BOT_USER_ID=123456789012345678
 
 # Claude Code CLI Configuration
 CLAUDE_COMMAND=claude

--- a/c_lord/bot.py
+++ b/c_lord/bot.py
@@ -39,6 +39,7 @@ class ClaudeDiscordBot(commands.Bot):
         lounge_channel_id: int | None = None,
         session_dir_manager: SessionDirManager | None = None,
         tmux_manager: TmuxSessionManager | None = None,
+        expected_bot_user_id: int | None = None,
     ) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
@@ -67,6 +68,10 @@ class ClaudeDiscordBot(commands.Bot):
         self.session_dir_manager: SessionDirManager | None = session_dir_manager
         # Tmux session lifecycle manager (optional)
         self.tmux_manager: TmuxSessionManager | None = tmux_manager
+        # Issue #323: when set, on_ready verifies the logged-in identity and
+        # kills the process on mismatch (guards against booting with an
+        # inherited production token — the #322 env-contamination class).
+        self.expected_bot_user_id: int | None = expected_bot_user_id
 
     async def process_commands(self, message: discord.Message, /) -> None:
         """Override to allow webhook messages to trigger text commands.
@@ -110,9 +115,33 @@ class ClaudeDiscordBot(commands.Bot):
         """Log slash command errors that would otherwise be silently swallowed."""
         logger.error("Slash command error: %s", error, exc_info=error)
 
+    def _assert_expected_identity(self) -> None:
+        """Fail fast when the logged-in identity is not the expected one.
+
+        Issue #323: with ``load_dotenv(override=False)`` semantics and shell
+        env inheritance, a staging launch can silently boot with the
+        production token (#322). When ``expected_bot_user_id`` is configured,
+        a mismatch means the process is running as the WRONG bot — refuse to
+        run rather than whisper one log line and continue.
+        """
+        if self.expected_bot_user_id is None:
+            return
+        actual = self.user.id if self.user else None
+        if actual != self.expected_bot_user_id:
+            logger.critical(
+                "IDENTITY MISMATCH: logged in as bot user id %s but "
+                "EXPECTED_BOT_USER_ID=%s — refusing to run (wrong token in "
+                "env? see #322/#323). Exiting.",
+                actual,
+                self.expected_bot_user_id,
+            )
+            sys.exit(1)
+
     async def on_ready(self) -> None:
         logger.info("Logged in as %s (ID: %s)", self.user, self.user.id if self.user else "?")
         logger.info("Watching channel ID: %d", self.channel_id)
+        # Issue #323: verify identity BEFORE doing anything else.
+        self._assert_expected_identity()
 
         # Re-register persistent AskViews for any questions that were pending
         # when the bot last shut down.  This prevents "Interaction Failed" on

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -90,9 +90,20 @@ def load_config(env_path: Path | None = None) -> dict[str, str]:
         logger.error("DISCORD_CHANNEL_ID is required")
         sys.exit(1)
 
+    # Issue #323: optional identity guard. A garbage value must fail loudly —
+    # a guard that silently disables itself is worse than no guard.
+    expected_bot_user_id = os.getenv("EXPECTED_BOT_USER_ID", "")
+    if expected_bot_user_id and not expected_bot_user_id.isdigit():
+        logger.error(
+            "EXPECTED_BOT_USER_ID must be a numeric Discord user id, got: %r",
+            expected_bot_user_id,
+        )
+        sys.exit(1)
+
     return {
         "token": token,
         "channel_id": channel_id,
+        "expected_bot_user_id": expected_bot_user_id,
         "claude_command": os.getenv("CLAUDE_COMMAND", "claude"),
         "claude_model": os.getenv("CLAUDE_MODEL", "sonnet"),
         "claude_permission_mode": os.getenv("CLAUDE_PERMISSION_MODE", "acceptEdits"),
@@ -141,6 +152,9 @@ async def main(env_path: Path | None = None) -> None:
         channel_id=int(config["channel_id"]),
         owner_id=owner_id,
         coordination_channel_id=coordination_channel_id,
+        expected_bot_user_id=(
+            int(config["expected_bot_user_id"]) if config["expected_bot_user_id"] else None
+        ),
     )
 
     # Issue #53: REST API is the only path Claude has for reaching Discord

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -83,6 +83,86 @@ class TestOnAppCommandError:
         assert any("test failure" in record.message for record in caplog.records)
 
 
+class TestIdentityFailFast:
+    """Issue #323: refuse to run when the logged-in identity differs from the expected one.
+
+    Guards against the env-contamination incident class (#322): a "staging"
+    launch that inherited the production token must die at startup instead of
+    silently running as a second production bot.
+    """
+
+    def test_mismatch_exits_process(self) -> None:
+        """expected_bot_user_id set + different login identity -> sys.exit(1)."""
+        import sys
+        from unittest.mock import PropertyMock, patch
+
+        bot = ClaudeDiscordBot(channel_id=123, expected_bot_user_id=111)
+        user = MagicMock()
+        user.id = 222
+
+        with (
+            patch.object(ClaudeDiscordBot, "user", new_callable=PropertyMock, return_value=user),
+            patch.object(sys, "exit") as mock_exit,
+        ):
+            bot._assert_expected_identity()
+
+        mock_exit.assert_called_once_with(1)
+
+    def test_mismatch_logs_expected_and_actual(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The failure log must show BOTH the expected and the actual bot user id."""
+        import sys
+        from unittest.mock import PropertyMock, patch
+
+        bot = ClaudeDiscordBot(channel_id=123, expected_bot_user_id=111)
+        user = MagicMock()
+        user.id = 222
+
+        with (
+            caplog.at_level(logging.CRITICAL, logger="c_lord.bot"),
+            patch.object(ClaudeDiscordBot, "user", new_callable=PropertyMock, return_value=user),
+            patch.object(sys, "exit"),
+        ):
+            bot._assert_expected_identity()
+
+        joined = " ".join(r.message for r in caplog.records)
+        assert "111" in joined
+        assert "222" in joined
+
+    def test_match_does_not_exit(self) -> None:
+        """expected_bot_user_id set + matching identity -> bot keeps running."""
+        import sys
+        from unittest.mock import PropertyMock, patch
+
+        bot = ClaudeDiscordBot(channel_id=123, expected_bot_user_id=111)
+        user = MagicMock()
+        user.id = 111
+
+        with (
+            patch.object(ClaudeDiscordBot, "user", new_callable=PropertyMock, return_value=user),
+            patch.object(sys, "exit") as mock_exit,
+        ):
+            bot._assert_expected_identity()
+
+        mock_exit.assert_not_called()
+
+    def test_unset_is_backward_compatible(self) -> None:
+        """No expected_bot_user_id (default) -> never exits, any identity allowed."""
+        import sys
+        from unittest.mock import PropertyMock, patch
+
+        bot = ClaudeDiscordBot(channel_id=123)
+        user = MagicMock()
+        user.id = 222
+
+        with (
+            patch.object(ClaudeDiscordBot, "user", new_callable=PropertyMock, return_value=user),
+            patch.object(sys, "exit") as mock_exit,
+        ):
+            bot._assert_expected_identity()
+
+        mock_exit.assert_not_called()
+
+
 class TestOnError:
     """on_error zombie-detection tests (Issue #91)."""
 
@@ -119,21 +199,18 @@ class TestOnError:
         mock_exit.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_session_closed_logs_error(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_session_closed_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
         """RuntimeError('Session is closed') must log at ERROR level."""
         import sys
         from unittest.mock import patch
 
         bot = ClaudeDiscordBot(channel_id=123)
 
-        with caplog.at_level(logging.ERROR, logger="c_lord.bot"):
-            with patch.object(sys, "exit"):
-                try:
-                    raise RuntimeError("Session is closed")
-                except RuntimeError:
-                    await bot.on_error("on_message")
+        with caplog.at_level(logging.ERROR, logger="c_lord.bot"), patch.object(sys, "exit"):
+            try:
+                raise RuntimeError("Session is closed")
+            except RuntimeError:
+                await bot.on_error("on_message")
 
         assert any(r.levelno >= logging.ERROR for r in caplog.records)
         assert any("zombie" in r.message.lower() for r in caplog.records)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,3 +39,35 @@ class TestLoadConfigEnvPath:
         finally:
             os.environ.pop("DISCORD_BOT_TOKEN", None)
             os.environ.pop("DISCORD_CHANNEL_ID", None)
+
+
+class TestExpectedBotUserId:
+    """Issue #323: EXPECTED_BOT_USER_ID config key for the identity fail-fast guard."""
+
+    def _base_env(self, monkeypatch: object) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")  # type: ignore[attr-defined]
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "999")  # type: ignore[attr-defined]
+
+    def test_parsed_when_set(self, monkeypatch: object) -> None:
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("EXPECTED_BOT_USER_ID", "1503195981142032405")  # type: ignore[attr-defined]
+        config = load_config()
+        assert config["expected_bot_user_id"] == "1503195981142032405"
+
+    def test_empty_when_unset(self, monkeypatch: object) -> None:
+        self._base_env(monkeypatch)
+        monkeypatch.delenv("EXPECTED_BOT_USER_ID", raising=False)  # type: ignore[attr-defined]
+        config = load_config()
+        assert config["expected_bot_user_id"] == ""
+
+    def test_non_numeric_value_exits(self, monkeypatch: object) -> None:
+        """A garbage value must fail loudly — a guard that silently disables
+        itself is worse than no guard."""
+        import sys
+        from unittest.mock import patch
+
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("EXPECTED_BOT_USER_ID", "not-a-number")  # type: ignore[attr-defined]
+        with patch.object(sys, "exit") as mock_exit:
+            load_config()
+        mock_exit.assert_called_with(1)


### PR DESCRIPTION
## What does this PR do?

`.env` に `EXPECTED_BOT_USER_ID`(任意キー)を設定すると、`on_ready` で実際のログイン bot user id と照合し、**不一致なら期待値・実値の両方を CRITICAL ログに出して即 `exit(1)`** する。未設定なら従来動作(Zero-Config 後方互換)。不正値(非数値)は起動時に即エラー終了(黙って無効化される守りは守りではないため)。

## Why?

env 継承 + `load_dotenv(override=False)` により「staging を起動したつもりが**本番トークンでログイン**」する事故が3回以上発生(#322 根因A)。現状はログ1行で走り続けるため気づけず、本番の二重処理と偽の検証結果を生む。この PR は「間違った identity では**そもそも動かない**」という最終防壁を入れる。

Closes #323

## 利用者から見た before/after(1行・必須)

- before(この PR 前)→ after(この PR 後): いまは誤ったトークンで起動した bot が本番チャンネルで静かに動き続ける → この PR 後は誤った identity の bot は数秒で自動消滅し、Discord に現れない(正しく設定された bot の見え方は不変)

## Acceptance Criteria (copied from the issue)

- [x] `EXPECTED_BOT_USER_ID` 設定時、異なる bot user としてログインすると起動が失敗し非0で終了する(ユニットテストで RED→GREEN 確認 — 下記)
- [x] 失敗ログに期待値と実値の両方(bot user id)が含まれる(`test_mismatch_logs_expected_and_actual` + staging 実機ログ)
- [x] `EXPECTED_BOT_USER_ID` 未設定なら従来どおり起動する(`test_unset_is_backward_compatible` + 既存テスト全 green)
- [x] 本番・staging 両方の `.env` に各自の期待値を設定し、staging 実機で「誤起動 → 即終了」を再現確認(下記 Staging Evidence)
- [x] README / docs の該当箇所に新キーの説明を追記(`.env.example` — env キーの正規ドキュメント箇所)

## TDD Evidence

RED(実装前、7 failed):
```
FAILED tests/test_bot.py::TestIdentityFailFast::test_mismatch_exits_process
FAILED tests/test_bot.py::TestIdentityFailFast::test_mismatch_logs_expected_and_actual
FAILED tests/test_bot.py::TestIdentityFailFast::test_match_does_not_exit - Ty...
FAILED tests/test_bot.py::TestIdentityFailFast::test_unset_is_backward_compatible
FAILED tests/test_main.py::TestExpectedBotUserId::test_parsed_when_set - KeyE...
FAILED tests/test_main.py::TestExpectedBotUserId::test_empty_when_unset - Key...
FAILED tests/test_main.py::TestExpectedBotUserId::test_non_numeric_value_exits
```
GREEN(実装後): `tests/test_bot.py tests/test_main.py — 17 passed`

## Staging Evidence (証跡)

staging (`c-lord-parallel-3`, bot `C-lord-3#1206`) を借用して検証(2026-06-10 13:23-13:26。検証後 main に復帰・bot 再起動・単一インスタンス確認済み)。本変更は Discord 画面に現れない起動時ガードのため、主証跡はプロセスの生死とログ(`no-user-visible-change` 相当の UI 影響)。

<details>
<summary>RED (修正前コード @87c7862) — 誤った期待IDを無視して走り続ける</summary>

```
$ EXPECTED_BOT_USER_ID=1475105094071750818 timeout 40 .venv/bin/python3 -m c_lord.main
exit code: 124 (= timeout が殺すまで生存 = ガード不在)
2026-06-10 13:23:50 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
2026-06-10 13:23:50 [INFO] c_lord.bot: Watching channel ID: 1503196656265597082
(MISMATCH ログなし — 期待ID 1475…(本番) との不一致が完全に素通り)
```
</details>

<details>
<summary>GREEN 1 (修正後 @cef55dc) — 不一致なら即 exit(1)</summary>

```
$ EXPECTED_BOT_USER_ID=1475105094071750818 timeout 40 .venv/bin/python3 -m c_lord.main
exit code: 1
2026-06-10 13:24:58 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
2026-06-10 13:24:58 [CRITICAL] c_lord.bot: IDENTITY MISMATCH: logged in as bot user id 1503195981142032405 but EXPECTED_BOT_USER_ID=1475105094071750818 — refusing to run (wrong token in env? see #322/#323). Exiting.
```
</details>

<details>
<summary>GREEN 2 (修正後) — 正しい期待IDなら正常稼働</summary>

```
$ EXPECTED_BOT_USER_ID=1503195981142032405 timeout 40 .venv/bin/python3 -m c_lord.main
exit code: 124 (= 稼働継続)、MISMATCH ログ 0 件
2026-06-10 13:25:16 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
```
</details>

<details>
<summary>原状復帰 (2026-06-10 13:26)</summary>

```
2026-06-10 13:26:30 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
2026-06-10 13:26:30 [INFO] c_lord.bot: Watching channel ID: 1503196656265597082
staging instances: 1 (expect 1) / branch=main @16d1640 / 両 .env に EXPECTED_BOT_USER_ID 恒久設定済み
```
</details>

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes(scoped 17 passed。full suite の tmux 系失敗はクリーン base でも同数再現する既存・環境依存のもので本変更と無関係 — CI のクリーン環境が arbiter)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass(ローカル green、CI で最終確認)
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新した(`.env.example` に新キーの説明を追加。誤設定時以外の利用者の見え方は不変)
- [x] `Closes #323` used — Issue の AC 5項目すべて充足(独立行に記載済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
