### PR TITLE
fix(dod-gate): Closes 使用時に AC 見出し違いで素通りする穴を fail-closed (#341)

### DIFF
--- a/.github/scripts/dod_gate.js
+++ b/.github/scripts/dod_gate.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// DoD Gate のロジック本体（テスト可能にするため dod-gate.yml から切り出した純関数）。
+// 層1: PR 本文の機械パースによる Definition of Done ゲート。構造的に検出可能な漏れだけを
+// 決定論的に止める。真偽（本当に動作確認したか）は捕まえられない。詳細: yousan/c-lord#128
+//
+// evaluateDod({ body, labels }) -> { errors: string[] }  ... 純関数（I/O 無し）。
+// CLI モード（直接実行）では GITHUB_EVENT_PATH の PR 本文/ラベルを読み、errors があれば exit 1。
+
+const fs = require('fs');
+
+function evaluateDod({ body = '', labels = [] } = {}) {
+  const errors = [];
+  const lower = (labels || []).map((l) => String(l).toLowerCase());
+  // documentation / no-runtime-change ラベル付き PR は Rule 1（DoD 完了要件）を免除。
+  // Rule 2（Closes 規律）は常に適用。
+  const ruleOneExempt = lower.includes('documentation') || lower.includes('no-runtime-change');
+
+  // 指定見出し (## <heading>) のセクション本文を返す。見つからなければ空文字。
+  const section = (heading) => {
+    const re = new RegExp(`##\\s*${heading}[\\s\\S]*?(?=\\n##\\s|$)`, 'i');
+    const m = body.match(re);
+    return m ? m[0] : '';
+  };
+  const countUnchecked = (text) => (text.match(/- \[ \]/g) || []).length;
+
+  const dodSection = section('Definition of Done checklist');
+  const acSection = section('Acceptance Criteria');
+
+  // テンプレ未使用（DoD セクションが無い）も落とす。
+  if (!dodSection) {
+    errors.push('PR本文に『Definition of Done checklist』セクションが無い。PRテンプレートを使うこと。');
+  }
+
+  // Rule 1: DoD チェックリストが全部チェック済みか（免除ラベルがあればスキップ）。
+  if (!ruleOneExempt) {
+    const n = countUnchecked(dodSection);
+    if (n > 0) {
+      errors.push(`DoDチェックリストに未チェック項目が ${n} 件。全部 [x] になるまでマージ不可。`);
+    }
+  }
+
+  // Rule 2: Closes/Fixes/Resolves を使うなら AC は全達成（未チェック AC 禁止）。
+  const usesClose = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+/i.test(body);
+  if (usesClose) {
+    if (!acSection) {
+      // fail-closed (#265): '## Acceptance Criteria' セクションが見つからない。見出しが
+      // ### AC など h3 やリネームだと acSection='' で未チェック数 0 となり、AC 検証ゼロで
+      // 素通りしていた。Closes を使うなら AC セクションの存在自体を必須にする。
+      errors.push(
+        '`Closes`/`Resolves #N` を使うなら `## Acceptance Criteria` セクション（`##` 見出し）が必須。' +
+          '見出しが見つからない（`### AC` など h3 やリネームは不可）。' +
+          'Issue の AC を貼って全項目チェックするか、`Refs #N` に変えること。'
+      );
+    } else {
+      const acUnchecked = countUnchecked(acSection);
+      if (acUnchecked > 0) {
+        errors.push(
+          `Closes/Fixes を使っているが Acceptance Criteria に未達(${acUnchecked}件)がある。` +
+            '100%満たすか、満たさないなら "Refs #N" に変えて Issue を開いたままにすること。'
+        );
+      }
+    }
+  }
+
+  return { errors };
+}
+
+module.exports = { evaluateDod };
+
+// --- CLI モード: GitHub Actions の pull_request イベントから body/labels を読む ---
+if (require.main === module) {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  let body = '';
+  let labels = [];
+  if (eventPath && fs.existsSync(eventPath)) {
+    const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+    const pr = event.pull_request || {};
+    body = pr.body || '';
+    labels = (pr.labels || []).map((l) => l.name);
+  }
+  const { errors } = evaluateDod({ body, labels });
+  if (errors.length) {
+    console.error('DoD Gate 失敗:\n- ' + errors.join('\n- '));
+    process.exit(1);
+  }
+  console.log('DoD Gate 通過');
+}

--- a/.github/workflows/dod-gate.yml
+++ b/.github/workflows/dod-gate.yml
@@ -3,6 +3,8 @@ name: DoD Gate
 # 層1: PR本文の機械パースによる Definition of Done ゲート。
 # 「良心まかせ」を「構造的に検出可能な漏れ」だけ決定論的に止める。
 # 真偽（本当に動作確認したか）は捕まえられない — それは層2(レビュアーAgent)/層3(E2E)の担当。
+# ロジック本体は .github/scripts/dod_gate.js（純関数 evaluateDod + CLI）。
+# テストは tests/test_dod_gate.py（pytest が node を subprocess 起動して検証）。
 # 詳細: yousan/c-lord#128
 
 on:
@@ -17,54 +19,8 @@ jobs:
   dod-gate:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      # GITHUB_EVENT_PATH（pull_request イベント JSON）から PR 本文/ラベルを読み、
+      # DoD 規律違反があれば exit 1 でこのチェックを落とす。node は ubuntu-latest に同梱。
       - name: Check DoD checklist & Closes discipline
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const body = pr.body || "";
-            const labels = (pr.labels || []).map(l => l.name.toLowerCase());
-            const errors = [];
-
-            // documentation / no-runtime-change ラベル付き PR は Rule 1（DoD完了要件）を免除。
-            // Rule 2（Closes規律）は常に適用。
-            const ruleOneExempt = labels.includes("documentation") || labels.includes("no-runtime-change");
-
-            // --- セクション抽出ヘルパ ---
-            const section = (heading) => {
-              const re = new RegExp(`##\\s*${heading}[\\s\\S]*?(?=\\n##\\s|$)`, "i");
-              const m = body.match(re);
-              return m ? m[0] : "";
-            };
-            const countUnchecked = (text) => (text.match(/- \[ \]/g) || []).length;
-
-            const dodSection = section("Definition of Done checklist");
-            const acSection  = section("Acceptance Criteria");
-
-            // テンプレ未使用（DoDセクションが無い）も落とす
-            if (!dodSection) {
-              errors.push("PR本文に『Definition of Done checklist』セクションが無い。PRテンプレートを使うこと。");
-            }
-
-            // Rule 1: DoD チェックリストが全部チェック済みか（免除ラベルがあればスキップ）
-            if (!ruleOneExempt) {
-              const n = countUnchecked(dodSection);
-              if (n > 0) errors.push(`DoDチェックリストに未チェック項目が ${n} 件。全部 [x] になるまでマージ不可。`);
-            }
-
-            // Rule 2: Closes/Fixes/Resolves を使うなら AC は全達成（未チェックAC禁止）
-            const usesClose = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+/i.test(body);
-            if (usesClose) {
-              const acUnchecked = countUnchecked(acSection);
-              if (acUnchecked > 0) {
-                errors.push(`Closes/Fixes を使っているが Acceptance Criteria に未達(${acUnchecked}件)がある。` +
-                            `100%満たすか、満たさないなら "Refs #N" に変えて Issue を開いたままにすること。`);
-              }
-            }
-
-            if (errors.length) {
-              core.setFailed("DoD Gate 失敗:\n- " + errors.join("\n- "));
-            } else {
-              const exemptMsg = ruleOneExempt ? `（${labels.includes("no-runtime-change") ? "no-runtime-change" : "documentation"} ラベルによりRule 1免除）` : "";
-              core.info("DoD Gate 通過" + exemptMsg);
-            }
+        run: node .github/scripts/dod_gate.js

--- a/tests/test_dod_gate.py
+++ b/tests/test_dod_gate.py
@@ -1,0 +1,81 @@
+"""dod-gate のロジック (.github/scripts/dod_gate.js) を node 経由で検証する。
+
+dod-gate は GitHub Actions の必須チェックで、全 PR のマージを止める。ロジックを
+壊すと全 PR がブロック（誤検知）または穴が残る（見逃し）ため、決定論的にテストする。
+node を subprocess 起動し、GITHUB_EVENT_PATH に PR イベント JSON を渡して exit code を見る。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "dod_gate.js"
+
+# node が無い環境（ローカルのみ）では skip。CI の ubuntu-latest には node が入っている。
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+
+# 全項目チェック済みの DoD セクション（Rule 1 を満たす）。
+_DOD_OK = (
+    "## Definition of Done checklist\n\n"
+    "- [x] Every Acceptance Criterion above is checked\n"
+    "- [x] No unrelated changes\n"
+    "- [x] Closes discipline\n"
+)
+
+
+def _run_gate(body: str, labels: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    event = {"pull_request": {"body": body, "labels": [{"name": n} for n in labels]}}
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+    return subprocess.run(
+        ["node", str(SCRIPT)],
+        env={**os.environ, "GITHUB_EVENT_PATH": str(event_path)},
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_proper_ac_heading_all_checked_with_closes_passes(tmp_path: Path) -> None:
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + "\nCloses #1\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_h3_ac_heading_with_closes_is_fail_closed(tmp_path: Path) -> None:
+    # PR #265 のバイパス再現: AC が h3 見出し (### AC) だと '## Acceptance Criteria'
+    # セクションとして認識されず、AC 検証がゼロで Closes が素通りしていた。
+    # 修正後は「Closes 使用 + AC セクション不在」を fail-closed で落とすこと。
+    body = "### AC (Issue #250)\n\n- [x] AC1\n\n" + _DOD_OK + "\nCloses #250\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 1, (
+        f"expected fail-closed (rc=1) for the #265 h3-heading bypass, got rc={result.returncode}\n"
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "Acceptance Criteria" in result.stderr
+
+
+def test_unchecked_ac_with_closes_fails(tmp_path: Path) -> None:
+    body = "## Acceptance Criteria\n\n- [ ] AC1\n\n" + _DOD_OK + "\nCloses #1\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 1, result.stdout
+
+
+def test_documentation_label_exempts_dod_completion(tmp_path: Path) -> None:
+    # documentation ラベルは Rule 1（DoD 全チェック）を免除。Closes 無しなので Rule 2 も不発。
+    body = (
+        "## Acceptance Criteria\n\n- [x] AC1\n\n## Definition of Done checklist\n\n- [ ] not yet\n"
+    )
+    result = _run_gate(body, ["documentation"], tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_dod_section_fails(tmp_path: Path) -> None:
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\nbody without a DoD section\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 1, result.stdout


### PR DESCRIPTION
## What does this PR do?

dod-gate の **`Closes` 規律が見出し違いで素通りする穴**を fail-closed で塞ぐ（#341 / Refs #128, #265）。併せて、全 PR を止めるゲートを安全に変更できるよう**ロジックをテスト可能な形に切り出した**。

- `dod-gate.yml` の YAML 直書き JS を **`.github/scripts/dod_gate.js`（純関数 `evaluateDod` + CLI）** に切り出し（挙動不変の抽出）。ワークフローは `node .github/scripts/dod_gate.js` を実行（`GITHUB_EVENT_PATH` から PR 本文/ラベルを読む）。
- **fail-closed 追加**: `Closes`/`Resolves #N` を使うのに `## Acceptance Criteria` セクションが**見つからない**（`### AC` など h3 / リネーム）場合に落とす。
- `tests/test_dod_gate.py`: pytest が node を subprocess 起動して 5 ケースを検証。

## Why?

Rule 2（`Closes` を使うなら AC 100%）は `## Acceptance Criteria` 見出しを正規表現で探すが、**`### AC` だと `acSection=''` → 未チェック数 0 → AC 検証ゼロで素通り**していた。唯一の機械強制ルールが見出し一文字で無効化される。**マージ済 PR #265 で実発火**（`### AC (Issue #250)` + `Closes #250` が AC 検証ゼロで通っていた）。

Closes #341

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: `no-user-visible-change`（CI の dod-gate の挙動変更のみ。c-lord（bot）のランタイム挙動・Discord 上の見え方は不変）

## Acceptance Criteria (copied from the issue)

- [x] ゲートロジックが `.github/scripts/dod_gate.js` の純関数 `evaluateDod` に切り出され、`dod-gate.yml` がそれを実行している
- [x] `Closes`/`Resolves #N` 使用かつ `## Acceptance Criteria` セクション不在のとき Gate が落ちる
- [x] `### AC` 等 h3/リネーム見出しは AC セクションと認識されず落ちる（#265 再現ケース）
- [x] 既存挙動が不変：正しい `## Acceptance Criteria` + 全チェック → 通過 / `documentation`・`no-runtime-change` ラベル → Rule 1 免除 / DoD セクション無し → 落ちる
- [x] `tests/test_dod_gate.py` が #265 バイパスを RED で再現し、修正後 GREEN（RED 行を下記に貼付）
- [x] `pytest` + `ruff check` green

## TDD evidence

`.github/scripts/dod_gate.js` を**修正前（抽出のみ）**の状態で #265 ケースを node に直接食わせた **RED**（穴が再現）:

```
# body: "### AC (Issue #250) ... Closes #250"（h3 見出し）
$ node .github/scripts/dod_gate.js   # GITHUB_EVENT_PATH=ev_265.json
DoD Gate 通過
rc=0          ← Closes なのに AC 検証ゼロで通過 = 穴(RED)
```

fail-closed 追加後の **GREEN**（5 ケース）:

```
proper (Closes + ## AC all checked)   expect rc=0 → rc=0
#265 h3 bypass (Closes + ### AC)       expect rc=1 → rc=1  [FIXED]
unchecked AC + Closes                  expect rc=1 → rc=1
documentation label, DoD unchecked     expect rc=0 → rc=0
missing DoD section                    expect rc=1 → rc=1

$ uv run pytest tests/test_dod_gate.py -q   → 5 passed
```

## Staging Evidence (証跡)

`no-runtime-change` ラベル（CI ツール=dod-gate の変更で、c-lord bot のランタイムは不変）。bot staging の対象外。**skip 理由: CI-gate change / no bot runtime change。** 代わりに **(a) 上記 node 直 RED→GREEN + pytest 5 passed**、**(b) この PR 自身が新ゲート（本 PR の `dod-gate.yml` + `dod_gate.js`）で評価される**ことが生きた検証になる。

## Definition of Done checklist

> `no-runtime-change` ラベルにより DoD 完了要件は免除。`Closes` 規律は常時適用。

- [x] Every Acceptance Criterion above is checked
- [x] TDD: RED（#265 が rc=0 で素通り）→ GREEN（rc=1）の RED 行を上記に貼付
- [x] `uv run pytest tests/ -v` passes（dod_gate 5 passed・収集エラー無し）
- [x] `uv run ruff check` + `ruff format --check` pass
- [ ] Staging Evidence — N/A（no-runtime-change 免除、上記 skip 理由 + 本 PR 自身が新ゲートで評価される）
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」も更新 — dod-gate.yml のコメントに新ロジックの所在を明記（`no-user-visible-change`）
- [x] `Closes #341` を独立行で記載・#341 の AC を 100% 充足
