### PR TITLE
fix: load_dotenv に override=True を指定し .env を identity の単一情報源にする (#324)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ c-lord start    # start the bot (reads .env in current dir)
 c-lord start --env /path/to/.env   # custom .env location
 ```
 
+> **Config precedence (#324):** keys defined in the `.env` file always win over
+> inherited process environment variables — the directory you start from
+> determines the bot's identity. Keys *absent* from the file still fall back to
+> the process env, so env-var-only setups keep working.
+
 Send a message in the configured channel — Claude will reply in a new thread.
 
 ---

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import IO
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from .bot import ClaudeDiscordBot
 from .claude.config import ClaudeConfig
@@ -74,11 +74,27 @@ def resolve_data_dir(env_path: Path | None) -> Path:
 
 
 def load_config(env_path: Path | None = None) -> dict[str, str]:
-    """Load and validate configuration from environment."""
+    """Load and validate configuration from environment.
+
+    Issue #324: ``override=True`` — keys defined in the .env file always beat
+    inherited process env. Claude sessions spawned by a bot inherit that bot's
+    DISCORD_* vars; with the python-dotenv default (override=False) those
+    silently won over the local .env and a "staging" launch booted as the
+    production identity (#322). Directory == identity: the .env file is the
+    single source of truth for every key it defines. Keys absent from the
+    file still fall back to the process env (env-var-only setups keep working).
+    """
     if env_path is not None:
-        load_dotenv(env_path)
+        load_dotenv(env_path, override=True)
     else:
-        load_dotenv()
+        # find_dotenv(usecwd=True): search from the CURRENT DIRECTORY upward,
+        # not from this package's location. README documents the bare launch as
+        # "reads .env in current dir" — the package-location walk only matched
+        # that contract by accident (repo-clone deployments) and diverges for
+        # any CWD outside the package tree.
+        found = find_dotenv(usecwd=True)
+        if found:
+            load_dotenv(found, override=True)
 
     token = os.getenv("DISCORD_BOT_TOKEN", "")
     if not token:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from c_lord.main import load_config, resolve_data_dir
 
 
@@ -71,3 +73,56 @@ class TestExpectedBotUserId:
         with patch.object(sys, "exit") as mock_exit:
             load_config()
         mock_exit.assert_called_with(1)
+
+
+class TestDotenvOverride:
+    """Issue #324: keys present in the .env file must beat inherited process env.
+
+    A Claude session spawned by the prod bot inherits prod's DISCORD_* vars;
+    with the python-dotenv default (override=False) those silently win over
+    the staging .env and the "staging" bot boots as production (#322 根因A).
+    Directory == identity: what the .env file says is what the bot is.
+    """
+
+    def test_env_file_beats_inherited_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "inherited-prod-tok")
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "111")
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "DISCORD_BOT_TOKEN=file-tok\nDISCORD_CHANNEL_ID=222\n", encoding="utf-8"
+        )
+        config = load_config(env_path)
+        assert config["token"] == "file-tok"
+        assert config["channel_id"] == "222"
+
+    def test_keys_absent_from_file_fall_back_to_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Env-var-only setups (no key in .env) keep working — override only
+        applies to keys the file actually defines."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "x")
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "1")
+        monkeypatch.setenv("CLAUDE_MODEL", "model-from-env")
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "DISCORD_BOT_TOKEN=file-tok\nDISCORD_CHANNEL_ID=222\n", encoding="utf-8"
+        )
+        config = load_config(env_path)
+        assert config["claude_model"] == "model-from-env"
+
+    def test_override_applies_to_cwd_dotenv_without_explicit_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bare `python -m c_lord.main` launch (env_path=None) is the exact
+        path the staging incidents used — it must also prefer the CWD .env."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "inherited-prod-tok")
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "111")
+        (tmp_path / ".env").write_text(
+            "DISCORD_BOT_TOKEN=cwd-file-tok\nDISCORD_CHANNEL_ID=333\n", encoding="utf-8"
+        )
+        monkeypatch.chdir(tmp_path)
+        config = load_config()
+        assert config["token"] == "cwd-file-tok"
+        assert config["channel_id"] == "333"


### PR DESCRIPTION
## What does this PR do?

`load_config()` の `load_dotenv()` を `override=True` に変更し、**`.env` ファイルに書かれたキーは継承プロセス env に常に勝つ**ようにする。あわせて素起動(`env_path=None`)の `.env` 探索を `find_dotenv(usecwd=True)`(**CWD 基準**)に修正 — README の「reads .env in current dir」という記述と実装(パッケージ位置基準の探索)が食い違っていたのを解消。`.env` に無いキーは従来どおり process env にフォールバック(env-var-only 構成は無影響)。

## Why?

bot が spawn した Claude セッションは spawn 元(本番)の `DISCORD_BOT_TOKEN` 等を継承する。python-dotenv の既定(override=False)では**継承値が `.env` に勝つ**ため、staging ディレクトリで正しく起動しても本番トークンでログインする事故が3回以上再発(#322 根因A)。現在の回避策は 17 個の `env -u` を毎回手で並べることで、忘れると即事故。この PR で「**そのディレクトリの .env = その bot の identity**」が決定的になる。

Closes #324

## 利用者から見た before/after(1行・必須)

- before(この PR 前)→ after(この PR 後): いまは起動シェルの環境変数次第で bot が「別人」として起動し得る(staging のつもりが本番) → この PR 後はどのシェルから起動しても、起動ディレクトリの .env どおりの bot になる(正常構成での見え方は不変)

## Acceptance Criteria (copied from the issue)

- [x] プロセス env に `DISCORD_CHANNEL_ID=AAA` がある状態で `.env` に `DISCORD_CHANNEL_ID=BBB` と書いてあれば、BBB が採用される(`test_env_file_beats_inherited_env` RED→GREEN)
- [x] `.env` に存在しないキーはプロセス env の値がそのまま使われる(`test_keys_absent_from_file_fall_back_to_env`)
- [x] staging 実機で「本番 env を継承したシェルから `env -u` なしで起動 → staging identity(C-lord-3)でログイン」を確認(下記 — 偽の継承トークンで安全に実証)
- [x] README / docs に設定の優先順位(.env > 継承 env)を明記(README「Start / Stop」節に追記)

## TDD Evidence

RED(実装前、2 failed):
```
FAILED tests/test_main.py::TestDotenvOverride::test_env_file_beats_inherited_env
FAILED tests/test_main.py::TestDotenvOverride::test_override_applies_to_cwd_dotenv_without_explicit_path
```
GREEN(実装後): `tests/test_main.py — 6 passed / 0 failed`

実装中の追加発見: 素の `load_dotenv()` は CWD ではなく**呼び出し元パッケージの位置**から `.env` を探索しており、README の記述(reads .env in current dir)と乖離していた(repo-clone 構成ではたまたま一致するため潜伏)。`find_dotenv(usecwd=True)` で文書どおりの挙動に修正(3本目のテストが回帰を担保)。

## Staging Evidence (証跡)

staging (`c-lord-parallel-3`) を借用して検証(2026-06-10 13:34-13:36。検証後 main に復帰・単一インスタンス確認・lease 解放済み)。**本物の本番トークンは一切使わず**、偽の継承トークンで「継承 env が .env に勝つ」メカニズムを安全に実証。起動時ガードのため Discord 画面の見え方は不変(主証跡はログとプロセス挙動)。

<details>
<summary>RED (修正前 main @16d1640) — 継承トークンが .env の正トークンに勝つ</summary>

```
$ DISCORD_BOT_TOKEN="bogus-inherited-token-simulating-env-leak" timeout 30 .venv/bin/python3 -m c_lord.main
exit code: 1
discord.errors.LoginFailure: Improper token has been passed.
(.env には正しい staging トークンがあるのに、継承した偽値でログインを試みた
 = 本番トークンを継承していれば本番 bot になっていた経路)
```
</details>

<details>
<summary>GREEN (修正後 @7aeb122) — .env が継承 env に勝つ</summary>

```
$ DISCORD_BOT_TOKEN="bogus-inherited-token-simulating-env-leak" timeout 30 .venv/bin/python3 -m c_lord.main
exit code: 124 (= 稼働継続)
2026-06-10 13:35:53 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
2026-06-10 13:35:53 [INFO] c_lord.bot: Watching channel ID: 1503196656265597082
```
</details>

<details>
<summary>原状復帰 (2026-06-10 13:36)</summary>

```
2026-06-10 13:36:39 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
staging instances: 1 (expect 1) / branch=main / lease released
```
</details>

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes(full suite green をローカル確認済み — tmux 系のホスト依存失敗を除く。CI が最終確認)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新した(README に設定優先順位を明記)
- [x] `Closes #324` — Issue の AC 4項目すべて充足(独立行に記載済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
