### PR TITLE
feat: staging 運用を guarded launcher + docs/STAGING.md に単一ソース化 (#327)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,12 +91,9 @@ uv run python -m c_lord.main
 Bot 再起動は積極的に行ってよい。新しいコードで Bot を再起動し、Discord 上で動作確認する。
 
 ```bash
-# 1. Bot 再起動
-# 注意: 同一ホストで staging clone (c-lord-parallel-3 等) も動かしている場合、
-# 素の pgrep だと staging も巻き添えで kill される。本番だけ狙うなら venv パスで絞る:
-#   pgrep -f "/home/yousan/c-lord/.venv/bin/python3 -m c_lord.main" | xargs -r kill
-pgrep -f "c_lord.main" | xargs kill 2>/dev/null; sleep 2
-nohup uv run python -m c_lord.main > /tmp/clord-bot.log 2>&1 &
+# 1. Bot 再起動 — 必ず scripts/staging.sh を使う (#327)。
+#    pgrep パターン kill / nohup uv run は事故パターンとして禁止 (docs/STAGING.md 参照)
+bash scripts/staging.sh restart
 
 # 2. E2E テスト実行（要 .env: DISCORD_BOT_TOKEN / DISCORD_CHANNEL_ID / E2E_TEST_WEBHOOK_URL）
 uv run pytest -m e2e tests/e2e/ -v
@@ -159,7 +156,7 @@ api_server をオプトインで有効化してある環境では `POST /api/thr
 
 ## Debugging & Troubleshooting
 
-Bot の挙動が怪しいとき、最初に見るべき情報源は **bot ログ** と **Discord 上のメッセージ** の 2 つ。前者は `nohup` 経由で `/tmp/clord-bot.log` に出ているのが運用上の標準 (上の "Running (standalone)" 参照)。後者は `.env` を読んで Discord REST API を curl で叩く ("Debugging Discord from a Claude session" 参照 — Claude Code から実行可)。
+Bot の挙動が怪しいとき、最初に見るべき情報源は **bot ログ** と **Discord 上のメッセージ** の 2 つ。前者のパスは `bash scripts/staging.sh status` が表示する (per-run ログ + 最新への symlink `/tmp/clord-bot-<clone名>.log`。旧運用の固定パス `/tmp/clord-bot.log` / `/tmp/clord-bot-staging.log` は名残り)。後者は `.env` を読んで Discord REST API を curl で叩く ("Debugging Discord from a Claude session" 参照 — Claude Code から実行可)。
 
 ### ログの読み方
 
@@ -414,44 +411,27 @@ Issue → branch → PR → **動作確認 + セルフレビュー** → merge �
 4. **動作確認 (E2E on staging)** ← **必須** — 下記のスキーム
 5. **セルフレビュー** — diff を読み返す / 不要な変更がないか / セキュリティ監査 (`security-audit` skill)
 6. **Merge** (squash + delete branch) — **only after every [Definition of Done](#definition-of-done-dod--single-source-of-truth) box is checked.** A green CI is necessary but not sufficient.
-7. **Prod redeploy** — `cd /home/yousan/c-lord && git pull && pgrep -f "/home/yousan/c-lord/.venv/bin/python3 -m c_lord.main" | xargs -r kill && sleep 3 && nohup uv run python -m c_lord.main > /tmp/clord-bot.log 2>&1 &`
-   - ⚠️ **本番 venv のパスで絞ること。** 素の `pgrep -f c_lord.main` は staging clone (`c-lord-parallel-3` 等) のプロセスにもマッチするため、本番再起動のつもりで staging を巻き添えで kill してしまう。`/home/yousan/c-lord/.venv` を含むパスで絞れば本番プロセスだけに当たる (staging は `c-lord-parallel-3/.venv` なので除外される)。staging 側の再起動コマンド (下記 [動作確認スキーム](#動作確認スキーム-必須)) が `pgrep -f "c-lord-parallel-3.*c_lord.main"` で絞っているのと同じ要領。
+7. **Prod redeploy** — `cd /home/yousan/c-lord && git pull && bash scripts/staging.sh restart`
+   - スクリプトは実行ディレクトリの bot **だけ**を `/proc/<pid>/cwd` で同定して PID 直 kill する(staging を巻き添えにしない)。pgrep パターン kill は禁止 — 事故パターン一覧は `docs/STAGING.md` 参照。
+   - ⚠️ 本番が supervisor (systemd --user / start-clord.sh --guard) 配下で動いている場合は supervisor 経由で再起動すること(手動 kill+起動は #195 の二重 bot 事故の元)。
 
 ### 動作確認スキーム (必須)
 
 **ルール**: バグ修正 / 機能追加の PR は必ず staging 環境で「**修正前 = 再現できる**」「**修正後 = 再現しない (グリーン)**」を webhook 経由で確認する。これを通らないものはマージしない。
 
-**前提**: staging 環境 (本番と独立した bot / channel) が `/home/yousan/c-lord-parallel-3` で常時稼働している。詳細は memory `project_staging_env.md` 参照。本番 (`/home/yousan/c-lord`) は kill しない。staging bot は共有リソースで、再起動・ブランチ切替の調整漏れは他セッションの検証を中断させるため、下記レシピ末尾の **原状復帰** を必ず実行する。
+**前提**: staging 環境 (本番と独立した bot / channel) が `/home/yousan/c-lord-parallel-3` で常時稼働している。本番 (`/home/yousan/c-lord`) は kill しない。staging bot は共有リソース — 借用前の占有確認と検証後の**原状復帰**を必ず行う。
 
-**手順** (バグ修正の例):
+**手順の詳細は [docs/STAGING.md](docs/STAGING.md) が唯一の正**(レイアウト・占有プロトコル・禁止事項・増設手順を含む)。骨子:
+
 ```bash
-# 1. RED 再現 — staging 上で問題が発生することを webhook 経由で確認
-curl -X POST -H "Content-Type: application/json" \
-  -d '{"content":"<bug を再現する入力>"}' \
-  "$E2E_TEST_WEBHOOK_URL?wait=true&thread_id=$E2E_TEST_THREAD_ID"
-# → /tmp/clord-bot-staging.log で問題発生をログ確認
-# → Discord 上で症状を確認 (REST API で fetch_messages)
-
-# 2. 修正実装 + ユニットテスト
-
-# 3. staging bot を新コードで再起動 (単一インスタンスで起動)
-#    ⚠️ パターン kill は実行中の自分のシェル (eval 中の `c_lord.main` 文字列) にも当たって自滅することがある。
-#       残存 count が 0 にならないときは PID 直指定 (kill <PID>) が安全。
-pgrep -f "c-lord-parallel-3.*c_lord.main" | xargs -r kill; sleep 3
-echo "remaining: $(pgrep -f 'c-lord-parallel-3.*c_lord.main' | wc -l)"   # ← 0 を確認
-nohup uv run python -m c_lord.main > /tmp/clord-bot-staging.log 2>&1 &
-sleep 2; echo "running: $(pgrep -f 'c-lord-parallel-3.*c_lord.main' | wc -l)"  # ← 1 を確認 (二重起動防止)
-
-# 4. GREEN 確認 — 同じ webhook 入力で問題が再現しないこと
-curl -X POST ... (上と同じ)
-# → ログ + Discord 上の応答が期待通りであることを確認
-
-# 5. PR 本文の "Test plan" にこの再現→修正のログ抜粋を貼る
-
-# 6. 原状復帰 — 検証で切り替えていたなら idle ブランチに戻して上記 (#3) を再実行
-#    idle ブランチは memory project_staging_env.md の "Default branch when idle" 参照
-git checkout fix/wire-max-concurrent-sessions   # 例
+cd /home/yousan/c-lord-parallel-3
+bash scripts/staging.sh status        # 占有・状態確認 (.staging-lease も見る)
+bash scripts/staging.sh restart main  # 1. RED — 修正前コードで再現 (webhook 経由)
+bash scripts/staging.sh restart <fix-branch>  # 3. GREEN — 修正後コードで再現しない
+bash scripts/staging.sh restart main  # 6. 原状復帰 (idle ブランチ = main)
 ```
+
+webhook での再現入力・前提条件 (`E2E_TEST_THREAD_ID` のスレッドに sessions レコードが必要、等) は STAGING.md の「検証レシピ」を参照。PR 本文の "Staging Evidence" に RED→GREEN のログ抜粋を貼る。
 
 **機能追加の場合**: RED の代わりに「実装前は存在しない挙動」「実装後は期待挙動」を webhook + ログで観測する。例: 構造化ログ追加 PR では `grep "thread=<id>" /tmp/clord-bot-staging.log` で **before = ヒットしない / after = enter/exit ペアが出る** を比較。
 

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,0 +1,124 @@
+# STAGING.md — staging 運用の単一ソース (#327)
+
+**staging の起動・停止・検証・原状復帰の手順はこのファイルと `scripts/staging.sh` が唯一の正**。
+CLAUDE.md・メモリ・他ドキュメントに別レシピが書いてあったら、それは drift — このファイルを正として直すこと。
+背景(なぜこの形になったか)は Issue #322(調査まとめ)と `docs/DESIGN_DECISIONS.md` §13 を参照。
+
+## 環境レイアウト
+
+| | 本番 (prod) | staging |
+|---|---|---|
+| clone | `/home/yousan/c-lord` | `/home/yousan/c-lord-parallel-3` |
+| bot | `C-lord#8255` (`1475105094071750818`) | `C-lord-3#1206` (`1503195981142032405`) |
+| channel | `.env` の `DISCORD_CHANNEL_ID` | `#c-lord-3` (`1503196656265597082`) |
+| API port | 8087 | 8089 |
+| tmux session | `c-lord` | `c-lord-parallel-3` |
+| session dir | `c-lord-sessions/` | `c-lord-sessions-staging/` |
+| ログ (最新) | `/tmp/clord-bot-c-lord.log`* | `/tmp/clord-bot-c-lord-parallel-3.log`* |
+| ライフサイクル | **supervised**(手動 kill+nohup 禁止 — #195) | `scripts/staging.sh` で手動管理 |
+| idle ブランチ | `main` | **`main`** |
+
+\* `scripts/staging.sh` 導入後は per-run ログ `/tmp/clord-bot-<name>-<timestamp>.log` + 最新への symlink。
+旧固定パス (`/tmp/clord-bot.log` / `/tmp/clord-bot-staging.log`) は旧手順の名残り。
+
+> **idle ブランチについて**: かつて CLAUDE.md は `fix/wire-max-concurrent-sessions` を idle ブランチとしていたが、
+> このブランチは staging DB のスキーマ前進 (`mirror_replied_uuid`, #232/#242) と不整合で**起動クラッシュする**。
+> idle = `main` が現在の正(2026-06-10 改訂)。
+
+## 安全原理(コードで強制されているもの)
+
+1. **directory == identity** (#324): `.env` に書かれたキーは継承 env に常に勝つ。正しいディレクトリで起動すれば正しい bot になる。
+2. **identity fail-fast** (#323): `.env` の `EXPECTED_BOT_USER_ID` と実ログイン identity が違えば bot は即 exit(1)。**新しい環境の .env には必ず設定すること。**
+3. **センチネル .env** (#326): `c-lord-parallel` / `-2` / `c-lord-issue63` の `.env` は無効値。そこから bot は起動できない(本番 token の読み取りは `/home/yousan/c-lord/.env` を絶対パスで)。
+4. **単一インスタンス flock** (#212): 同一 data dir の二重起動は拒否される。トークン基準のロックは #325 で予定。
+
+## 操作 — `scripts/staging.sh`(clone のルートで実行)
+
+```bash
+cd /home/yousan/c-lord-parallel-3
+
+bash scripts/staging.sh status             # identity / branch / pid / instances / log
+bash scripts/staging.sh stop               # この clone の bot を安全停止
+bash scripts/staging.sh restart            # 現在のブランチで安全再起動
+bash scripts/staging.sh restart <branch>   # branch に切り替えて再起動 (PR 検証用)
+```
+
+`restart` は: /proc/cwd で自分の bot だけを同定 → PID 直 kill → setsid + venv python で起動 →
+per-run ログ → `Logged in as` を待って identity を検証(mismatch なら非0で失敗)→ 単一インスタンス確認、まで自動で行う。
+
+**禁止事項(全て実害のあった事故パターン — #322 根因D)**:
+- `pgrep -f "c_lord.main" | xargs kill` 系の**パターン kill**(本番・自分のシェルに当たる/相対パス起動を取り逃す)
+- kill を**並列ツールバッチに入れる**(キャンセルしても発射済みの kill は戻らない)
+- `nohup uv run ...` での起動(Bash ツール teardown で exit 144 死する)
+- 本番 (`/home/yousan/c-lord`) への手動 kill+nohup(supervised — #195 の二重 bot 事故になる)
+
+## 占有(借用)プロトコル — 暫定版
+
+staging は**共有リソース**。複数セッションが同時に使うと kill / checkout の踏み合いになる(2026-05-29 実害)。
+CLI 化(borrow/release/TTL)は #328 で実装予定。それまでの暫定規約:
+
+1. **借りる前に確認**: `bash scripts/staging.sh status` + `.staging-lease` ファイルの有無。
+   lease があり、自分のものでなく、`acquired_at + ttl` が未失効なら**触らない**。
+2. **借りる**: clone 直下に `.staging-lease` を書く:
+   ```json
+   {"owner": "<セッション識別子>", "purpose": "PR #NNN 検証", "branch_before": "main",
+    "acquired_at": "<ISO8601>", "ttl_hours": 2}
+   ```
+3. **返す(原状復帰)**: `bash scripts/staging.sh restart main` → `status` で単一インスタンス確認 → `.staging-lease` を削除。
+
+> 旧ドキュメントの「Lounge API (`/api/lounge`) で占有を宣言」は**使えない**:
+> `CLORD_BRIDGE_MODE=jsonl` の本デプロイでは ApiServer 自体が起動しない(#322 根因B)。
+
+## 検証レシピ(RED→GREEN on staging)
+
+**前提**(これを満たさないと curl が静かに no-op して偽 GREEN になる — #322 根因C):
+- staging の `.env` に `E2E_TEST_WEBHOOK_URL` と **`E2E_TEST_THREAD_ID`** が設定されていること
+- `E2E_TEST_THREAD_ID` のスレッドが staging の `sessions.db` に**セッションレコードを持つ**こと
+  (持たないスレッドへの投稿は `on_message` が無視する。チャンネル直投稿も Claude を起動しない)
+- 確認/再導出: `python3 -c "import sqlite3; print(sqlite3.connect('data/sessions.db').execute('select thread_id from sessions order by last_used_at desc limit 3').fetchall())"`
+
+```bash
+cd /home/yousan/c-lord-parallel-3
+set -a; . ./.env; set +a   # E2E_* を読み込む
+
+# 1. RED — 修正前のコード (通常 main) で問題を再現
+bash scripts/staging.sh restart main
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"content":"<bug を再現する入力>"}' \
+  "$E2E_TEST_WEBHOOK_URL?wait=true&thread_id=$E2E_TEST_THREAD_ID"
+# → ログ (staging.sh status が示す per-run ログ) と Discord で症状を確認
+
+# 2. GREEN — 修正ブランチで再現しないことを確認
+bash scripts/staging.sh restart <fix-branch>
+curl -X POST ...(同じ入力)
+
+# 3. 原状復帰(必須)
+bash scripts/staging.sh restart main && rm -f .staging-lease
+```
+
+証跡の規約(スクショ主・ログ従)は CLAUDE.md の DoD を参照。
+
+## staging を増設するとき(チェックリスト)
+
+環境が増えても `staging.sh` はそのまま使える(全値をディレクトリから導出)。増設手順:
+
+1. Discord Developer Portal で新 bot application を作成 → token 取得(1 token = 1 接続なので既存と共用不可)
+2. サーバに専用チャンネルを作成し、bot を招待(送信・スレッド権限)。チャンネルに Webhook を作成
+3. `git clone` で新ディレクトリ(例 `/home/yousan/c-lord-parallel-4`)を作成、`uv sync --dev`
+4. `.env` を**実ファイル**で作成(symlink 禁止 — #326)。必須: `DISCORD_BOT_TOKEN` / `DISCORD_CHANNEL_ID` /
+   **`EXPECTED_BOT_USER_ID`(新 bot の user id)** / `CLORD_API_PORT`(未使用ポート、#258 で自動化予定) /
+   `SESSION_DIR_BASE`(専用ディレクトリ) / `E2E_TEST_WEBHOOK_URL`
+5. `bash scripts/staging.sh restart` → `status` で identity を確認
+6. チャンネルで `/clord-init` を実行して repo を bind
+7. E2E 用スレッドを 1 つ作って `E2E_TEST_THREAD_ID` を `.env` に追記
+8. この表(環境レイアウト)に行を追加する
+
+## トラブルシュート
+
+| 症状 | 見る場所 | 典型原因 |
+|---|---|---|
+| `IDENTITY MISMATCH` で起動失敗 | per-run ログ | 意図と違う token(.env の token と EXPECTED_BOT_USER_ID の組を確認)。**ガードが正しく働いている** |
+| webhook を投げても無反応 | `E2E_TEST_THREAD_ID` の sessions レコード有無 | スレッドにセッションが無い / thread_id 空(前提節を参照) |
+| `instances: 2+` | `staging.sh status` | 二重起動 — `stop` → `restart`。手動 kill 禁止事項を守ったか確認 |
+| 起動直後に死ぬ | per-run ログ末尾 | LoginFailure(token 不正)/ DB スキーマ不整合(古いブランチ — idle は main) |
+| `API server not listening` | 仕様 | `CLORD_BRIDGE_MODE=jsonl` では ApiServer は起動しない(バグではない) |

--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# =============================================================================
+# staging.sh — guarded bot lifecycle for a c-lord clone (#327, parent #322)
+# =============================================================================
+# 使い方 (clone のルートで実行):
+#   bash scripts/staging.sh status             # identity / branch / pid / log
+#   bash scripts/staging.sh stop               # この clone の bot を安全停止
+#   bash scripts/staging.sh restart [<branch>] # (branch 切替+)安全再起動
+#
+# 環境非依存: すべての値 (bot 名・ログ名・venv・期待 identity) は「実行した
+# ディレクトリ」から導出する。staging 専用にハードコードしない — 環境が
+# 増えても (C-lord-4 等) このスクリプト 1 本で足りる。
+#
+# このスクリプトが置き換える事故パターン (#322 根因D, docs/STAGING.md 参照):
+#   - `pgrep -f "c_lord.main" | xargs kill` は本番/staging/自分のシェルの
+#     全部に当たる (自滅 exit 144 / 本番巻き添え / 相対パス起動の取り逃し)。
+#     → プロセス同定は /proc/<pid>/cwd、kill は PID 直指定のみ。
+#   - `nohup uv run ...` は Bash ツールの teardown で死ぬ (exit 144)。
+#     → setsid + venv python 直叩き。
+#   - ログ固定パス truncate で前回の検証証跡が消える。
+#     → per-run ログ + 最新への symlink。
+#   - 誤った identity (本番トークン等) のまま静かに走り続ける。
+#     → 起動後に "Logged in as" を待ち、IDENTITY MISMATCH (#323) や
+#       ログイン失敗を検出したら非 0 で終了する。
+# =============================================================================
+set -u
+
+CLONE_DIR="$(pwd)"
+NAME="$(basename "$CLONE_DIR")"
+ENV_FILE="$CLONE_DIR/.env"
+VENV_PY="$CLONE_DIR/.venv/bin/python3"
+LOG_LINK="/tmp/clord-bot-$NAME.log"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+usage() {
+  echo "usage: bash scripts/staging.sh {status|stop|restart [<branch>]}" >&2
+  exit 1
+}
+
+env_get() {
+  # .env から key の値を取る (最後の定義が勝ち)。secrets は呼び出し側で
+  # 出力しないこと。
+  /usr/bin/grep "^$1=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+find_pids() {
+  # この clone を cwd とする c_lord.main プロセスだけを列挙する。
+  # cmdline パターンマッチ (pgrep -f) は使わない: 自分のシェルへの自己
+  # マッチ・相対パス起動の取り逃し・他環境への誤爆があるため。
+  local pid cwd
+  for pid in $(ps -eo pid --no-headers); do
+    cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null)" || continue
+    [ "$cwd" = "$CLONE_DIR" ] || continue
+    if tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null | /usr/bin/grep -q "c_lord\.main"; then
+      echo "$pid"
+    fi
+  done
+}
+
+cmd_status() {
+  local pids count branch expected channel
+  pids="$(find_pids)"
+  count=$(echo "$pids" | /usr/bin/grep -c . || true)
+  branch="$(git -C "$CLONE_DIR" branch --show-current 2>/dev/null || echo '(not a git repo)')"
+  expected="$(env_get EXPECTED_BOT_USER_ID)"
+  channel="$(env_get DISCORD_CHANNEL_ID)"
+  echo "clone:     $CLONE_DIR"
+  echo "branch:    $branch"
+  echo "channel:   ${channel:-(unset)}"
+  echo "expected:  ${expected:-(unset — #323 ガード無効。.env に EXPECTED_BOT_USER_ID を設定推奨)}"
+  echo "log:       $LOG_LINK"
+  echo "instances: $count"
+  if [ "$count" -gt 0 ]; then
+    local p
+    for p in $pids; do
+      echo "  pid $p (started $(ps -o lstart= -p "$p" 2>/dev/null | sed 's/^ *//'))"
+    done
+    if [ -e "$LOG_LINK" ]; then
+      /usr/bin/grep -E "Logged in as|IDENTITY MISMATCH" "$LOG_LINK" 2>/dev/null | tail -2 | sed 's/^/  /'
+    fi
+  fi
+  if [ "$count" -gt 1 ]; then
+    echo "WARNING: 二重起動の疑い。stop してから restart してください。"
+    return 2
+  fi
+}
+
+cmd_stop() {
+  local pids p waited
+  pids="$(find_pids)"
+  if [ -z "$pids" ]; then
+    echo "no running instance for $CLONE_DIR"
+    return 0
+  fi
+  # kill は PID 直指定のみ。パターン kill 禁止・並列バッチに入れるの禁止
+  # (キャンセルしても発射済みの kill は戻らない — 2026-05-29 の実害)。
+  for p in $pids; do
+    echo "stopping pid $p"
+    kill "$p" 2>/dev/null || true
+  done
+  waited=0
+  while [ $waited -lt 15 ]; do
+    sleep 1
+    waited=$((waited + 1))
+    pids="$(find_pids)"
+    [ -z "$pids" ] && {
+      echo "stopped."
+      return 0
+    }
+  done
+  die "プロセスが 15 秒で終了しない (残: $pids)。手動確認してください。"
+}
+
+check_log_identity() {
+  # ログの "Logged in as ... (ID: <id>)" を .env の EXPECTED_BOT_USER_ID と
+  # スクリプト側で照合する。bot 側ガード (#323) に依存しない: 対象 clone が
+  # 古いコード (#323/#324 以前) でも誤 identity を検出できる必要がある —
+  # 2026-06-10 の検証中、この照合が無い初版スクリプトは「継承した本番 env +
+  # override=False の旧コード」の組み合わせで本番 identity を再現させた
+  # (即 kill、実害なし。#327 の PR の Staging Evidence 参照)。
+  local log="$1" expected actual
+  expected="$(env_get EXPECTED_BOT_USER_ID)"
+  actual="$(/usr/bin/grep -o "Logged in as .* (ID: [0-9]*)" "$log" 2>/dev/null | tail -1 | /usr/bin/grep -o "[0-9]*" | tail -1)"
+  if [ -z "$expected" ]; then
+    echo "WARNING: EXPECTED_BOT_USER_ID が .env に無い — identity 照合をスキップ (設定を強く推奨)"
+    return 0
+  fi
+  [ -n "$actual" ] || {
+    echo "ERROR: ログから identity を読めない ($log)"
+    return 1
+  }
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: IDENTITY MISMATCH (script-side): logged in as $actual, expected $expected"
+    return 1
+  fi
+  echo "identity verified: $actual"
+}
+
+cmd_restart() {
+  local branch_arg="${1:-}"
+  [ -x "$VENV_PY" ] || die "no .venv in $CLONE_DIR ($VENV_PY がない)。uv sync --dev を先に実行。"
+
+  if [ -n "$branch_arg" ]; then
+    git -C "$CLONE_DIR" fetch origin "$branch_arg" -q 2>/dev/null || true
+    git -C "$CLONE_DIR" checkout "$branch_arg" -q || die "branch '$branch_arg' に checkout できない"
+    echo "checked out: $(git -C "$CLONE_DIR" log --oneline -1)"
+  fi
+
+  cmd_stop
+
+  local ts log
+  ts="$(date +%Y%m%d-%H%M%S)"
+  log="/tmp/clord-bot-$NAME-$ts.log"
+  # per-run ログ: 前回の検証証跡を truncate で消さない。最新は symlink で参照。
+  # setsid + venv python 直叩き: Bash ツール teardown (exit 144) と
+  # `uv run` ラッパーの cmdline 不定形を両方回避する。
+  #
+  # env -u による消毒は #324 (override=True) が入った現行コードでは冗長だが、
+  # **対象 clone が古いコードのときの最後の砦**なので外さない (2026-06-10 の
+  # 検証で実証: 消毒なし + 旧コード = 本番 identity 再現)。
+  (cd "$CLONE_DIR" && setsid env \
+    -u DISCORD_BOT_TOKEN -u DISCORD_CHANNEL_ID -u DISCORD_OWNER_ID \
+    -u CLAUDE_COMMAND -u CLAUDE_MODEL -u CLAUDE_PERMISSION_MODE -u CLAUDE_WORKING_DIR \
+    -u SESSION_DIR_BASE -u SESSION_SOURCE_REPO -u SESSION_TIMEOUT_SECONDS \
+    -u MAX_CONCURRENT_SESSIONS -u CLORD_TMUX_ENABLED -u CLORD_API_PORT -u CLORD_API_URL \
+    -u CLORD_API_HOST -u CLORD_API_SECRET -u CLORD_BRIDGE_MODE -u CLORD_RENDER_TABLE_IMAGES \
+    -u CLORD_MIRROR_VERBOSITY -u CLORD_TRUSTED_BOT_IDS -u CLORD_ALLOWED_ROLE \
+    -u COORDINATION_CHANNEL_ID -u EXPECTED_BOT_USER_ID \
+    -u E2E_TEST_THREAD_ID -u E2E_TEST_WEBHOOK_URL -u VIRTUAL_ENV \
+    nohup "$VENV_PY" -m c_lord.main >"$log" 2>&1 </dev/null &)
+  ln -sf "$log" "$LOG_LINK"
+  echo "launched -> $log"
+
+  # 起動検証: "Logged in as" を待つ。identity mismatch / 早期死亡は失敗。
+  local waited=0
+  while [ $waited -lt 40 ]; do
+    sleep 2
+    waited=$((waited + 2))
+    if /usr/bin/grep -q "IDENTITY MISMATCH" "$log" 2>/dev/null; then
+      /usr/bin/grep -E "Logged in as|IDENTITY MISMATCH" "$log" | tail -2
+      die "identity mismatch — 誤った bot として起動しようとした (#323 ガード作動)"
+    fi
+    if /usr/bin/grep -q "Logged in as" "$log" 2>/dev/null; then
+      /usr/bin/grep -E "Logged in as|Watching channel" "$log" | head -2
+      # スクリプト側照合: 古いコードの clone でも誤 identity を逃さない。
+      if ! check_log_identity "$log"; then
+        local p
+        for p in $(find_pids); do
+          echo "killing wrong-identity pid $p"
+          kill "$p" 2>/dev/null || true
+        done
+        die "誤った identity で起動したため停止した (ログ: $log)"
+      fi
+      local count
+      count="$(find_pids | /usr/bin/grep -c . || true)"
+      echo "instances: $count"
+      [ "$count" = "1" ] || die "単一インスタンスでない (count=$count)"
+      echo "OK"
+      return 0
+    fi
+    # プロセスが既に死んでいる (ログイン失敗等) なら早期失敗
+    if [ -z "$(find_pids)" ]; then
+      tail -5 "$log"
+      die "bot が起動直後に終了した (ログ: $log)"
+    fi
+  done
+  tail -5 "$log"
+  die "40 秒以内に 'Logged in as' が出ない (ログ: $log)"
+}
+
+# ---- entry -----------------------------------------------------------------
+[ -f "$ENV_FILE" ] || die "no .env in $CLONE_DIR — clone のルートで実行してください"
+
+case "${1:-}" in
+status) cmd_status ;;
+stop) cmd_stop ;;
+restart)
+  shift
+  cmd_restart "${1:-}"
+  ;;
+check-log)
+  # テスト用の隠しサブコマンド: ログファイルの identity を .env と照合
+  shift
+  check_log_identity "${1:?usage: check-log <logfile>}"
+  ;;
+*) usage ;;
+esac

--- a/tests/test_staging_script.py
+++ b/tests/test_staging_script.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/staging.sh — the guarded bot lifecycle launcher (#327).
+
+The script is environment-agnostic: it derives every value (identity, log
+name, venv path) from the clone directory it is invoked in. These tests
+exercise the guard rails that do not require a live Discord connection;
+the login/identity path is verified on staging (see the PR's Staging
+Evidence).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "staging.sh"
+
+
+def run_script(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestScriptGuards:
+    def test_script_exists_and_is_executable(self) -> None:
+        assert SCRIPT.is_file()
+
+    def test_refuses_dir_without_env_file(self, tmp_path: Path) -> None:
+        """Any command outside a clone (no .env) must fail with a clear message."""
+        result = run_script(["status"], cwd=tmp_path)
+        assert result.returncode != 0
+        assert ".env" in result.stdout + result.stderr
+
+    def test_status_reports_zero_instances(self, tmp_path: Path) -> None:
+        """status in a clone-shaped dir with no running bot -> instances: 0."""
+        (tmp_path / ".env").write_text(
+            "DISCORD_BOT_TOKEN=dummy\nDISCORD_CHANNEL_ID=1\nEXPECTED_BOT_USER_ID=42\n",
+            encoding="utf-8",
+        )
+        result = run_script(["status"], cwd=tmp_path)
+        assert result.returncode == 0
+        assert "instances: 0" in result.stdout
+
+    def test_restart_refuses_without_venv(self, tmp_path: Path) -> None:
+        """restart must not attempt a launch when the clone has no .venv."""
+        (tmp_path / ".env").write_text(
+            "DISCORD_BOT_TOKEN=dummy\nDISCORD_CHANNEL_ID=1\n", encoding="utf-8"
+        )
+        result = run_script(["restart"], cwd=tmp_path)
+        assert result.returncode != 0
+        assert ".venv" in result.stdout + result.stderr
+
+    def test_unknown_command_fails_with_usage(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text(
+            "DISCORD_BOT_TOKEN=dummy\nDISCORD_CHANNEL_ID=1\n", encoding="utf-8"
+        )
+        result = run_script(["frobnicate"], cwd=tmp_path)
+        assert result.returncode != 0
+        assert "usage" in (result.stdout + result.stderr).lower()
+
+
+class TestScriptSideIdentityCheck:
+    """check-log: スクリプト側の identity 照合 (#327).
+
+    Bot 側ガード (#323) に依存しない: 対象 clone が古いコード (#323/#324
+    以前) のときの最後の砦。2026-06-10 の検証中、この照合の無い初版が
+    継承 env + 旧コードの組み合わせで prod-identity boot を再現させた。
+    """
+
+    def _clone(self, tmp_path: Path, expected: str) -> Path:
+        (tmp_path / ".env").write_text(
+            f"DISCORD_BOT_TOKEN=dummy\nDISCORD_CHANNEL_ID=1\nEXPECTED_BOT_USER_ID={expected}\n",
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_matching_identity_passes(self, tmp_path: Path) -> None:
+        clone = self._clone(tmp_path, "111")
+        log = tmp_path / "bot.log"
+        log.write_text("[INFO] c_lord.bot: Logged in as Good#1 (ID: 111)\n", encoding="utf-8")
+        result = run_script(["check-log", str(log)], cwd=clone)
+        assert result.returncode == 0
+        assert "identity verified: 111" in result.stdout
+
+    def test_wrong_identity_fails(self, tmp_path: Path) -> None:
+        clone = self._clone(tmp_path, "111")
+        log = tmp_path / "bot.log"
+        log.write_text("[INFO] c_lord.bot: Logged in as Evil#2 (ID: 222)\n", encoding="utf-8")
+        result = run_script(["check-log", str(log)], cwd=clone)
+        assert result.returncode != 0
+        assert "222" in result.stdout
+        assert "111" in result.stdout
+
+    def test_unreadable_identity_fails(self, tmp_path: Path) -> None:
+        clone = self._clone(tmp_path, "111")
+        log = tmp_path / "bot.log"
+        log.write_text("no login line here\n", encoding="utf-8")
+        result = run_script(["check-log", str(log)], cwd=clone)
+        assert result.returncode != 0
+
+    def test_missing_expected_warns_but_passes(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text(
+            "DISCORD_BOT_TOKEN=dummy\nDISCORD_CHANNEL_ID=1\n", encoding="utf-8"
+        )
+        log = tmp_path / "bot.log"
+        log.write_text("[INFO] c_lord.bot: Logged in as Any#1 (ID: 999)\n", encoding="utf-8")
+        result = run_script(["check-log", str(log)], cwd=tmp_path)
+        assert result.returncode == 0
+        assert "WARNING" in result.stdout


### PR DESCRIPTION
## What does this PR do?

1. **`scripts/staging.sh`** — 環境非依存の guarded bot ライフサイクル。`status` / `stop` / `restart [<branch>]`。プロセス同定は `/proc/<pid>/cwd` + PID 直 kill(パターン kill 全廃)、起動は `setsid` + venv python 直叩き(exit 144 回避)、**per-run ログ**(+最新 symlink)、env 消毒、起動後に **bot 側 (#323) とスクリプト側の二重 identity 照合**。誤 identity なら起動したプロセスを kill して非0終了。
2. **`docs/STAGING.md`** — staging 運用の唯一の正(レイアウト・安全原理・占有プロトコル暫定版・検証レシピ・増設チェックリスト・トラブルシュート)。
3. **CLAUDE.md** — 危険レシピ(`pgrep … xargs kill` 系)を全廃しポインタ化。idle ブランチ記述を `main` に修正(旧記述 `fix/wire-max-concurrent-sessions` はローカルに存在せず、checkout すると DB 不整合で起動クラッシュする)。
4. **ホスト ops**: staging `.env` に `E2E_TEST_THREAD_ID` を追加(従来は未定義のまま検証レシピが参照しており、空展開でチャンネル直下に投稿 → Claude 不起動 → 偽 GREEN だった)。

## Why?

staging の手順が CLAUDE.md / DESIGN_DECISIONS / 32+ のセッションメモリに分散し、互いに矛盾したまま drift していた(#322 根因C・D)。手順が暗記頼みなため、1ステップ忘れるたびに「自滅 kill」「二重起動」「偽 GREEN」が再発。手順をスクリプトにコード化し、文書を1箇所に集約する。

Closes #327

## 利用者から見た before/after(1行・必須)

- before(この PR 前)→ after(この PR 後): `no-user-visible-change`(Discord 上の見え方は不変。変わるのは開発・検証の信頼性 — staging 検証の curl が実際に Claude を起動するようになり、再起動事故が構造的に起きなくなる)

## Acceptance Criteria (copied from the issue)

- [x] `staging.sh restart` が全ステップ(env一掃 / cwd同定PID kill / setsid / identity検証 / per-runログ)を行い、誤 identity 時は非0で終了する(実機 RED→GREEN — 下記)
- [x] `staging.sh status` が identity / branch / pid / ログパスを表示する(下記 Evidence)
- [x] `docs/STAGING.md` が新設され、CLAUDE.md の staging 節がポインタ化されている(`pgrep … xargs kill` の実行レシピが CLAUDE.md から消滅 — 残る言及は禁止事項の説明のみ)
- [x] idle ブランチの記述が `main` に統一されている(CLAUDE.md / STAGING.md / CLAUDE.md 内のメモリ参照記述)
- [x] staging `.env` に `E2E_TEST_THREAD_ID` が設定され、検証 curl が実際にスレッドへ届いて Claude が起動する(下記 — `run_claude: enter` を確認)
- [x] 再起動2回後も1回目のログファイルが残っている(per-run ログ: `/tmp/clord-bot-c-lord-parallel-3-20260610-{134604,135122,135147,135201}.log` の4本が共存)

## TDD Evidence

RED(スクリプト不在): `tests/test_staging_script.py — 5 failed`
GREEN(実装後): `9 passed`(guard 系5 + スクリプト側 identity 照合4)

## Staging Evidence (証跡)

### ⚠️ 検証中に発生させた事故の開示(初版スクリプトの欠陥 → 修正済み)

初版スクリプト(env 消毒なし・スクリプト側照合なし)で staging を restart した際、**本番 identity (C-lord#8255) のプロセスを staging clone から起動してしまった**(2026-06-10 13:46:07、生存約20秒、即 PID kill)。原因: 当時 staging の main は #324 未取り込みで、実行シェルが継承していた本番 env が .env に勝った(#322 そのもの)。副作用は冪等な slash command sync のみで、メッセージ投稿・スレッド操作なし。本番プロセス・gateway は無事を確認済み。
**この事故が「スクリプトは対象 clone のコード版を信用してはいけない」ことを実証**したため、(a) env 消毒の復活、(b) スクリプト側 identity 照合(`check-log`)を追加した。修正後の再検証は以下。

<details>
<summary>GREEN 1 — restart フルサイクル(修正版、2026-06-10 13:51)</summary>

```
$ bash scripts/staging.sh restart
no running instance for /home/yousan/c-lord-parallel-3
launched -> /tmp/clord-bot-c-lord-parallel-3-20260610-135122.log
2026-06-10 13:51:25 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
2026-06-10 13:51:25 [INFO] c_lord.bot: Watching channel ID: 1503196656265597082
identity verified: 1503195981142032405   ← スクリプト側照合
instances: 1
OK / exit 0
```
</details>

<details>
<summary>GREEN 2 — 誤 identity は起動拒否(negative path、staging トークンのみで安全に実証)</summary>

```
$ (EXPECTED_BOT_USER_ID を一時的に 999… に変更して) bash scripts/staging.sh restart
2026-06-10 13:51:52 [CRITICAL] c_lord.bot: IDENTITY MISMATCH: logged in as bot user id 1503195981142032405 but EXPECTED_BOT_USER_ID=999999999999999999 — refusing to run
ERROR: identity mismatch — 誤った bot として起動しようとした (#323 ガード作動)
script exit: 1
(.env は直後に復元)
```
</details>

<details>
<summary>GREEN 3 — status / E2E 経路疎通 / per-run ログ</summary>

```
$ bash scripts/staging.sh status
clone:     /home/yousan/c-lord-parallel-3
branch:    main / channel: 1503196656265597082 / expected: 1503195981142032405
instances: 1

# E2E_TEST_THREAD_ID 追加後、検証 curl で Claude が実際に起動:
2026-06-10 13:53:04 [INFO] c_lord.cogs._run_helper: [thread=1514085380666691664 session=tmux-…] run_claude: enter

# per-run ログ4本が共存(truncate されない):
/tmp/clord-bot-c-lord-parallel-3-20260610-{134604,135122,135147,135201}.log
```
</details>

原状復帰済み: staging = main (#343 含む最新) で稼働、単一インスタンス、lease 解放。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes(scoped green、CI が最終確認)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass(c_lord/ に変更なし)
- [x] Staging Evidence above is filled in(事故開示含む)
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新した(本 PR 自体が運用ドキュメントの単一ソース化。Discord 利用者視点は `no-user-visible-change`)
- [x] `Closes #327` — Issue の AC 6項目すべて充足(独立行に記載済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
