### PR TITLE
fix: トークン基準のホスト全域ロックで同一トークンの二重接続を拒否する (#325)

### DIFF
--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import fcntl
+import hashlib
 import logging
 import os
 import signal
@@ -57,6 +58,57 @@ def acquire_single_instance_lock(data_dir: Path) -> IO[bytes] | None:
             e,
         )
         sys.exit(1)
+    return lock_fp
+
+
+def acquire_token_lock(token: str, lock_dir: Path | None = None) -> IO[str] | None:
+    """Acquire a host-global exclusive flock keyed on the bot TOKEN (#325).
+
+    The #212 data-dir lock keys on a filesystem path, but the real hazard is
+    two processes sharing one Discord token: a clone with a different data dir
+    (e.g. an ``.env`` pointing at production) passes the data-dir lock and
+    double-connects to the gateway anyway. This lock enforces the actual
+    invariant — one process per token — before Discord is ever touched.
+
+    The lock file is named by a SHA-256 prefix of the token (no plaintext
+    token on disk) and records the holder's pid/cwd so a refused second
+    process can say WHO is already running. flock auto-releases on exit.
+
+    Returns ``None`` when ``CLORD_ALLOW_MULTI_INSTANCE=1`` (same escape hatch
+    as the data-dir lock). Calls ``sys.exit(1)`` on conflict.
+    """
+    if os.getenv("CLORD_ALLOW_MULTI_INSTANCE") == "1":
+        logger.warning("CLORD_ALLOW_MULTI_INSTANCE=1 set; skipping token-lock guard")
+        return None
+
+    if lock_dir is None:
+        lock_dir = Path.home() / ".cache" / "c-lord" / "locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(token.encode()).hexdigest()[:16]
+    lock_path = lock_dir / f"token-{digest}.lock"
+    # Not a context manager: the handle must outlive this function so the
+    # flock stays held for the process lifetime (released on process exit).
+    lock_fp = open(lock_path, "a+")  # noqa: SIM115
+    try:
+        fcntl.flock(lock_fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        lock_fp.seek(0)
+        holder = lock_fp.read().strip() or "(unknown)"
+        lock_fp.close()
+        logger.error(
+            "Another bot process is already running with the SAME Discord "
+            "token — refusing to start to avoid a gateway double-connect "
+            "(#325). Holder: %s. If this is intentional, set "
+            "CLORD_ALLOW_MULTI_INSTANCE=1.",
+            holder,
+        )
+        sys.exit(1)
+        return None  # only reached in tests where sys.exit is mocked
+    # Record holder info for the error message of a refused second process.
+    lock_fp.seek(0)
+    lock_fp.truncate()
+    lock_fp.write(f"pid={os.getpid()} cwd={Path.cwd()}\n")
+    lock_fp.flush()
     return lock_fp
 
 
@@ -146,6 +198,11 @@ async def main(env_path: Path | None = None) -> None:
     # flock auto-releases on close/exit. Assigning to a local that lives until
     # main() returns is sufficient; we don't need to reference it again.
     _instance_lock = acquire_single_instance_lock(data_dir)  # noqa: F841
+
+    # Issue #325: additionally refuse if another process already holds THIS
+    # TOKEN (host-global). The data-dir lock alone cannot stop a same-token
+    # double-connect launched from a different clone/directory.
+    _token_lock = acquire_token_lock(config["token"])  # noqa: F841
 
     db_path = str(data_dir / "sessions.db")
 

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -30,7 +30,7 @@ CLAUDE.md・メモリ・他ドキュメントに別レシピが書いてあっ�
 1. **directory == identity** (#324): `.env` に書かれたキーは継承 env に常に勝つ。正しいディレクトリで起動すれば正しい bot になる。
 2. **identity fail-fast** (#323): `.env` の `EXPECTED_BOT_USER_ID` と実ログイン identity が違えば bot は即 exit(1)。**新しい環境の .env には必ず設定すること。**
 3. **センチネル .env** (#326): `c-lord-parallel` / `-2` / `c-lord-issue63` の `.env` は無効値。そこから bot は起動できない(本番 token の読み取りは `/home/yousan/c-lord/.env` を絶対パスで)。
-4. **単一インスタンス flock** (#212): 同一 data dir の二重起動は拒否される。トークン基準のロックは #325 で予定。
+4. **単一インスタンス flock**: 同一 data dir の二重起動 (#212) に加え、**同一トークンの二重起動**もホスト全域ロックで拒否される (#325, `~/.cache/c-lord/locks/token-<hash>.lock`)。別ディレクトリからでも同じ bot は2つ立てられない。緊急回避は `CLORD_ALLOW_MULTI_INSTANCE=1`(両ロックを無効化 — 理解した上でのみ)。
 
 ## 操作 — `scripts/staging.sh`(clone のルートで実行)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,71 @@ from pathlib import Path
 
 import pytest
 
-from c_lord.main import load_config, resolve_data_dir
+from c_lord.main import acquire_token_lock, load_config, resolve_data_dir
+
+
+class TestTokenLock:
+    """Issue #325: host-global flock keyed on the bot TOKEN, not the data dir.
+
+    The #212 data-dir flock cannot stop a same-token double-connect from a
+    different clone (different data dir -> different lock file). The real
+    invariant is "one process per token"; this lock enforces it before the
+    Discord gateway is ever touched.
+    """
+
+    def test_same_token_second_acquire_exits(self, tmp_path: Path) -> None:
+        import sys
+        from unittest.mock import patch
+
+        first = acquire_token_lock("tok-A", lock_dir=tmp_path)
+        assert first is not None
+        with patch.object(sys, "exit") as mock_exit:
+            acquire_token_lock("tok-A", lock_dir=tmp_path)
+        mock_exit.assert_called_with(1)
+        first.close()
+
+    def test_different_tokens_both_acquire(self, tmp_path: Path) -> None:
+        a = acquire_token_lock("tok-A", lock_dir=tmp_path)
+        b = acquire_token_lock("tok-B", lock_dir=tmp_path)
+        assert a is not None and b is not None
+        a.close()
+        b.close()
+
+    def test_no_plaintext_token_on_disk(self, tmp_path: Path) -> None:
+        token = "super-secret-token-value"
+        handle = acquire_token_lock(token, lock_dir=tmp_path)
+        assert handle is not None
+        try:
+            for f in tmp_path.iterdir():
+                assert token not in f.name
+                assert token not in f.read_text(errors="replace")
+        finally:
+            handle.close()
+
+    def test_refusal_reports_holder_pid_and_cwd(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+        import sys
+        from unittest.mock import patch
+
+        first = acquire_token_lock("tok-A", lock_dir=tmp_path)
+        assert first is not None
+        with (
+            caplog.at_level(logging.ERROR, logger="c_lord.main"),
+            patch.object(sys, "exit"),
+        ):
+            acquire_token_lock("tok-A", lock_dir=tmp_path)
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert str(os.getpid()) in joined  # holder pid
+        assert str(Path.cwd()) in joined  # holder cwd
+        first.close()
+
+    def test_multi_instance_escape_hatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLORD_ALLOW_MULTI_INSTANCE", "1")
+        assert acquire_token_lock("tok-A", lock_dir=tmp_path) is None
 
 
 class TestResolveDataDir:


### PR DESCRIPTION
## What does this PR do?

`acquire_token_lock()` を追加: bot トークンの **sha256 先頭16桁**をファイル名にした `~/.cache/c-lord/locks/token-<hash>.lock` にホスト全域 flock を取る。同一トークンの2プロセス目は **Discord 接続前に**保持者の pid/cwd を表示して exit(1)。既存の data-dir ロック (#212) と併用し、`CLORD_ALLOW_MULTI_INSTANCE=1` で両方回避(既存の脱出口と同一)。平文トークンはファイル名にも内容にも残らない。

## Why?

#212 の flock は **data dir のパス**で鍵をかけるが、本当の危険は**同じトークンでの二重接続**。別ディレクトリ + 同一トークン(かつて存在した本番 symlink クローン等)はロックを素通りして本番 gateway に二重接続できた — #212 が防ぎたかった事故がそのまま残っていた(#322 根因A)。実際の不変条件「1トークン=1プロセス」を直接強制する。

Closes #325

## 利用者から見た before/after(1行・必須)

- before(この PR 前)→ after(この PR 後): `no-user-visible-change`(正常運用の見え方は不変。誤って同じ bot を2つ起動しようとした場合のみ、2つ目が即座に「誰がどこで動いているか」を表示して終了するようになる — 従来は静かに二重接続してメッセージ二重処理が起きていた)

## Acceptance Criteria (copied from the issue)

- [x] 同一トークンで別ディレクトリから2プロセス目を起動すると、Discord 接続前に失敗し非0で終了する(ユニットテスト RED→GREEN + 実機)
- [x] 異なるトークンの2プロセス(本番 + staging 相当)は同時起動できる(`test_different_tokens_both_acquire` + 本番/staging が現に並走)
- [x] エラーメッセージに既存プロセスの pid と cwd が表示される(テスト + 実機ログ)
- [x] ロックファイル名・内容にトークン平文が含まれない(`test_no_plaintext_token_on_disk`。実機ファイル名: `token-772a99d7994cb017.lock`)
- [x] staging 実機で「同一トークン別ディレクトリからの起動が拒否される」ことを確認(下記。※AC 起票時の「symlink クローン」は #326 で既にセンチネル化され存在しないため、同じ危険形状 = 「staging トークンを持つ別ディレクトリ」で等価に検証)

## TDD Evidence

RED(実装前): `ImportError: cannot import name 'acquire_token_lock'` → `TestTokenLock — error`
GREEN(実装後): `tests/test_main.py — 14 passed`(token lock 5本含む)

## Staging Evidence (証跡)

実機 (`c-lord-parallel-3`, staging トークンのみ使用・本番不関与) 2026-06-10 16:22-16:27。lease 取得→検証→main 復帰・解放済み。

<details>
<summary>RED (旧コード main) — 別 dir + 同一トークンが二重接続できてしまう</summary>

```
$ cd /tmp/clord-325-red && timeout 12 (parallel-3 の venv)/python3 -m c_lord.main
exit: 124 (= タイムアウトまで生存 = 二重接続が素通り)
2026-06-10 16:22:07 [INFO] c_lord.bot: Logged in as C-lord-3#1206 (ID: 1503195981142032405)
(実 staging bot と同時に同一トークンで接続 — #212 ロックは別 data dir のため作動せず)
```
</details>

<details>
<summary>GREEN (fix 版) — 接続前に保持者情報つきで拒否</summary>

```
staging bot を fix/325-token-lock で再起動(ロック保持)後、同じ /tmp dir から:
$ timeout 20 python3 -m c_lord.main
exit: 1
2026-06-10 16:27:38 [ERROR] __main__: Another bot process is already running with the
SAME Discord token — refusing to start to avoid a gateway double-connect (#325).
Holder: pid=1570551 cwd=/home/yousan/c-lord-parallel-3. If this is intentional, set
CLORD_ALLOW_MULTI_INSTANCE=1.
("Logged in as" 行なし = Discord に一切触れず拒否)
```
</details>

検証用のトークンコピー (/tmp/clord-325-red) は検証直後に完全削除済み。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes(scoped 23 passed、CI が最終確認)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新した(docs/STAGING.md の安全原理を更新。Discord 利用者視点は `no-user-visible-change`)
- [x] `Closes #325` — Issue の AC 5項目すべて充足(独立行に記載済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
