### PR TITLE
chore: .staging-lease を .gitignore に追加 (#354)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tmux.sh
 
 # Version file generated at build time by hatch-vcs (source of truth = git tags)
 c_lord/_version.py
+.staging-lease


### PR DESCRIPTION
## What does this PR do?
リースファイル `.staging-lease`(#328 のランタイム状態)を .gitignore に追加する。

## Why?
Issue #328 の設計どおり git 管理外にする(PR #349 で漏れていた)。誤コミット防止。

Closes #354

## 利用者から見た before/after(1行・必須)
- before → after: `no-user-visible-change`(誤コミット防止のみ)

## Acceptance Criteria (copied from the issue)
- [x] `.gitignore` に `.staging-lease` が追加されている(本 PR の diff)
- [x] borrow 済みの clone で `git status` に `.staging-lease` が表示されない(ローカル確認済み)

## Definition of Done checklist
> `no-runtime-change` ラベル → TDD / Staging 検証は免除対象
- [x] Every AC checked / 免除項目以外すべて充足
- [x] No unrelated changes; self-review done
- [x] `Closes #354` 独立行記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)