### PR TITLE
fix: staging.sh の find_pids ハング対策 + 高速化 (#383)

### DIFF
--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -168,15 +168,24 @@ env_get() {
 
 find_pids() {
   # この clone を cwd とする c_lord.main プロセスだけを列挙する。
-  # cmdline パターンマッチ (pgrep -f) は使わない: 自分のシェルへの自己
-  # マッチ・相対パス起動の取り逃し・他環境への誤爆があるため。
+  #
+  # 手順: pgrep -f で「c_lord.main を含むプロセス」を候補に絞り (高速)、
+  # 各候補の /proc/<pid>/cwd が $CLONE_DIR と一致するものだけ採用する。
+  # pgrep を「候補抽出」だけに使い、最終判定は必ず cwd 照合で行うので、
+  # かつて pgrep 直 kill を避けた理由 (自己マッチ・他 clone への誤爆) は
+  # cwd 照合がそのまま吸収する。staging.sh は常に `python -m c_lord.main`
+  # で起動するため -f で確実に拾える (相対パス起動の取り逃しも無い)。
+  #
+  # timeout ガード (#383): WSL2 等で応答しないマウント上に cwd を持つ
+  # プロセスがあると readlink /proc/<pid>/cwd が uninterruptible に
+  # ブロックし、これを毎反復呼ぶ restart の待機ループごとハングする
+  # (2026-06-11 に約11分のハングを観測)。readlink を 2 秒で打ち切り、
+  # 1つの stuck pid が関数全体を巻き込まないようにする。pgrep 前段で
+  # 候補が数個に絞られるので fork 回数も少ない。
   local pid cwd
-  for pid in $(ps -eo pid --no-headers); do
-    cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null)" || continue
-    [ "$cwd" = "$CLONE_DIR" ] || continue
-    if tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null | /usr/bin/grep -q "c_lord\.main"; then
-      echo "$pid"
-    fi
+  for pid in $(pgrep -f "c_lord\.main" 2>/dev/null); do
+    cwd="$(timeout 2 readlink "/proc/$pid/cwd" 2>/dev/null)" || continue
+    [ "$cwd" = "$CLONE_DIR" ] && echo "$pid"
   done
 }
 


### PR DESCRIPTION
## 概要

`scripts/staging.sh` の `find_pids()` が、全 pid に対し `readlink /proc/<pid>/cwd` していたため、WSL2 等で応答しないマウント上に cwd を持つ stuck プロセスが1つでもあると readlink が uninterruptible にブロックし、`restart` の待機ループ全体がハングした（2026-06-11 の staging 増設時に**約11分のハングを観測**、bot 自体は正常起動していた）。

## 変更

- `readlink` を `timeout 2` で保護 → 単一 stuck pid が関数全体を巻き込まない
- 候補抽出を `pgrep -f c_lord.main` に変更 → 全 pid を readlink せず候補(数個)のみ照合。最終判定は従来どおり `$CLONE_DIR` との **cwd 照合**なので、かつて pgrep 直 kill を避けた理由(自己マッチ・他 clone 誤爆)は cwd 照合がそのまま吸収する。

## どう変わるか(利用者目線)

- `staging.sh restart` / `status` / `stop` が **stuck な /proc があっても固まらず有限時間で完了**する。
- 副次的に高速化: find_pids 実測 **8.9s → 0.15s**(全 pid readlink → pgrep 候補のみ)。

## Acceptance Criteria

- [x] `find_pids()` の `/proc/<pid>/cwd` readlink に `timeout` ガードを入れ、単一 stuck pid で関数全体がハングしない
- [x] 正常な pid を従来どおり正しく列挙する(回帰なし) — 各 clone(staging-2/3/4・prod・parallel-3)で instances=1 を確認
- [x] `staging.sh restart` の待機ループが有限時間で必ず return する(find_pids が timeout 上限で必ず返るため)

## Staging Evidence

staging.sh 自体の修正であり、ハングは非決定的(stuck /proc に依存)で RED の確定再現はできないため、検証は **find_pids の回帰実測**で行った(実行ホスト = 本番/staging 稼働ホスト):

```
c-lord-staging-2   instances=1 pids=94840   (0.16s)
c-lord-staging-3   instances=1 pids=108717  (0.16s)
c-lord-staging-4   instances=1 pids=109510  (0.15s)
c-lord             instances=1 pids=355323  (0.14s)
c-lord-parallel-3  instances=1 pids=231514  (0.15s)
```

`bash -n scripts/staging.sh` 構文OK。ハング非再発は timeout による構造的保証(単一 readlink が必ず2秒で返る)。

## Definition of Done checklist

- [x] Acceptance Criteria above is checked
- [x] No unrelated changes in the diff; self-review done(`scripts/staging.sh` の find_pids のみ)
- [x] 「あるべき動き」: 挙動説明は STAGING.md の `restart` 記述(/proc/cwd で同定)と整合。実装詳細の変更で利用者フローは不変
- N/A TDD: bash スクリプトでハングは非決定的。回帰は上記実測で担保
- N/A `pytest`/`ruff`/`pyright`: Python 変更なし(CI でも確認)
- [x] `Closes #383` は AC 100% 達成のため使用

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)