### PR TITLE
fix: 完了ゲートが押し上げられた spinner を取りこぼし早期完了する (#365 follow-up)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -485,6 +485,18 @@ _GENERATION_STATUS_RE = re.compile(r"^(?!❯)[\u2700-\u27BF*·] .+$")
 # Additional explicit markers.
 _GENERATION_STATUS_MARKERS = ("Tip:", "·")
 
+# #365 (follow-up): the live working spinner shows a "(<elapsed> · …)" timer that
+# only exists while Claude is actively generating/executing, e.g.
+#   ✻ Running… (12s · ↑ 4.2k tokens · esc to interrupt)
+# While a tool runs, its result preview + the input box + footer push that timer
+# line 10-20 lines off the bottom, so a bottom-6-only scan misses it and the turn
+# is finalized early (premature mention before the real answer). We scan the
+# timer across a WIDE bottom window — the same heuristic the #190 lamp detector
+# (`thread_state_sync._pane_lamp_state`) already uses. Matching the timer (not the
+# bare glyph) avoids false-positives on stale completed spinners in scrollback.
+_RUNNING_PROBE_LINES = 30
+_RUNNING_SPINNER_RE = re.compile(r"\((?:\d+h\s*)?(?:\d+m\s*)?\d+s\s*·")
+
 # Markers that indicate Claude has actually started producing output:
 #   ● — assistant response paragraph
 #   ⎿ — tool result
@@ -1514,6 +1526,17 @@ class TmuxClaudeRunner:
         the ellipsis off the end and the turn was wrongly finalized early (#179).
         """
         lines = text.rstrip().splitlines()
+        # #365 follow-up: scan the live-spinner "(Ns ·" timer across a WIDE bottom
+        # window. While a tool runs, its result preview + input box + footer push
+        # the timer line 10-20 lines off the bottom; a bottom-6-only scan misses
+        # it and the turn is finalized early. The timer only exists while actively
+        # working, so a wide scan does not false-positive on idle panes.
+        for line in lines[-_RUNNING_PROBE_LINES:]:
+            if _RUNNING_SPINNER_RE.search(line):
+                return True
+        # Fallback: an ellipsis-bearing status glyph in the bottom few lines —
+        # catches a spinner that has no timer line yet (just "✻ Running…"). Kept
+        # narrow so a stale in-progress spinner up in scrollback is not matched.
         for line in lines[-6:]:
             stripped = line.strip()
             if _GENERATION_STATUS_RE.match(stripped) and "…" in stripped:

--- a/c_lord/discord_ui/thread_dashboard.py
+++ b/c_lord/discord_ui/thread_dashboard.py
@@ -5,6 +5,23 @@ threads are processing automatically vs. waiting for user input.
 When a thread transitions to WAITING_INPUT, the bot mentions the owner
 so Discord's notification system surfaces the request immediately.
 
+Why the mention is its OWN message (not appended to Claude's final reply)
+------------------------------------------------------------------------
+Two different actors post: Claude posts the answer itself via the discord-reply
+skill (``POST /api/reply``), while c-lord posts this ``@owner`` mention when the
+bot's turn-completion detector fires (WAITING_INPUT). Merging them into one
+message was considered (issue discussion under #365) and is intentionally NOT
+done:
+
+* Editing Claude's last message to append ``@owner`` does **not** work — Discord
+  edits do not trigger a push notification, which defeats the entire purpose of
+  the mention (pinging the owner's device).
+* Having the skill append ``@owner`` to Claude's final reply *would* ping (it is
+  a new message), but it moves the notification's reliability from the bot
+  (which authoritatively detects "turn done") to Claude (which does not reliably
+  know which of its replies is the final one). That trade-off was judged not
+  worth it, so the mention stays a separate, bot-authored message.
+
 Issue: https://github.com/yousan/c-lord/issues/67
 """
 

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -1470,6 +1470,39 @@ class TestIsGenerating:
         """Empty pane text → False."""
         assert TmuxClaudeRunner._is_generating("") is False
 
+    def test_is_generating_spinner_pushed_off_bottom_six(self) -> None:
+        """#365 follow-up: the live spinner is pushed >6 lines off the bottom.
+
+        Real incident (prod thread 1514448641635385447, 08:51 JST): a continuing
+        turn finalized after 14s and fired the owner mention before the real
+        answer. Root cause — while Claude runs a tool, the tool-result preview +
+        input box + footer push the spinner's timer line 10-20 lines off the
+        bottom (the same layout #190 documented for the lamp). ``_is_generating``
+        only scanned the bottom 6 lines, missed the spinner, reported "not
+        generating", and the completion detector finalized the turn early.
+
+        Detection must scan the live-spinner timer ``(Ns ·`` over a wide bottom
+        window (as the #190 lamp detector already does), not just the bottom 6.
+        """
+        text = "\n".join(
+            [
+                "❯ 前のターンの質問",
+                "",
+                "● 調査しています。まず関連ファイルを読みます。",
+                "✻ Running… (12s · ↑ 4.2k tokens · esc to interrupt)",
+                "  ⎿ Bash(uv run pytest tests/test_tmux_runner.py -q)",
+                "     ........................................ [ 41%]",
+                "     ........................................ [ 83%]",
+                "     .............................            [100%]",
+                "     173 passed in 120s",
+                "─" * 40,
+                "❯",
+                "─" * 40,
+                "-- INSERT -- ⏵⏵ bypass permissions on",
+            ]
+        )
+        assert TmuxClaudeRunner._is_generating(text) is True
+
 
 class TestToolExecutionCompletion:
     """Tests that tool execution does not trigger false early completion."""
@@ -2906,7 +2939,10 @@ class TestParseAskNewLayouts:
         assert q is not None
         assert q.header == "リリース方式"
         assert [o.label for o in q.options] == [
-            "カナリアリリース", "ブルーグリーン", "ローリング更新", "一斉切り替え",
+            "カナリアリリース",
+            "ブルーグリーン",
+            "ローリング更新",
+            "一斉切り替え",
         ]
         assert all(len(o.description) > 20 for o in q.options)
         assert q.multi_select is False


### PR DESCRIPTION
## What does this PR do?

`_is_generating`(継続ターンの完了ゲート)が **spinner を画面下部6行でしか探していなかった**のを、`#190` の lamp 検出と同じ**広い窓(30行)× ライブ spinner タイマー `(Ns ·`**で探すように修正。ツール実行中に結果プレビュー＋入力ボックス＋フッターで spinner が 10〜20 行押し上げられても検出できるようにする。

## Why?

PR #367(#365 の最初の修正)後も、**「Claude has finished — your reply is needed」メンションが実応答より前に出る**事象が本番で再発した。

- 本番 thread `1514448641635385447`, 08:51 JST: 1964字のプロンプトが **14秒で run_claude exit(早期完了)** → メンションが先、実応答(83秒のターン)が後。
- git reflog で、この bot(pid 1827942, 22:46起動)は **#367 修正入りの checkout (`3849be6`, tmux_runner.py mtime 22:44:42) をロード済み**と確定 → **#367 は不完全だった**。
- 根因: `_is_generating` は bottom 6 行のみ走査。ツール実行中は spinner タイマー行が押し上げられて検出漏れ → 「生成していない」と誤判定 → 完了検出が中間で発火。`#190` の修正は lamp(`thread_state_sync._pane_lamp_state`)には入っていたが、**完了ゲート(`_is_generating`)には入っていなかった**。

Refs #365

（#365 は本 PR で**クローズしない**。一度「直った」と誤って言った反省から、設置した #365 監視 cron が**数日にわたり再発ゼロを示すまで open のまま**にする。）

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: ツール実行を挟む継続ターンで「Claude has finished」メンションが実応答より前に飛ぶことがある → ツール実行中の spinner を取りこぼさなくなり、メンションが本物の最終応答の後に出る。

## Acceptance Criteria

- [x] AC1: `tests/test_tmux_runner.py::TestIsGenerating::test_is_generating_spinner_pushed_off_bottom_six` 追加（spinner が bottom6 外＝修正前 False=RED / 修正後 True=GREEN）
- [x] AC2: 既存 `TestIsGenerating`（completion summary "Cooked for 56s" → False 等）が引き続き全て PASS
- [x] AC3: `ruff` / `ruff format --check` / `pyright` / 全 `pytest` green
- [ ] AC4: #365 監視 cron が本番で再発ゼロを継続確認（数日）→ 確認後に #365 close

## Staging Evidence (証跡)

**この不具合は #365 と同じく timing/検出依存で、webhook 駆動の staging で deterministic に再現窓を強制できない。** 主証跡:

### RED — 本番で観測された現象（実環境 + reflog 確定）

<details><summary>本番ログ + reflog</summary>

```
# 本番 thread 1514448641635385447 (JST)
08:51:23  run_claude: enter (prompt=1964 chars)
08:51:37  run_claude: exit          ← 14秒で完了扱い → メンション発火
08:51:57  run_claude: enter (prompt=315 chars)
08:53:20  run_claude: exit          ← 83秒（実応答）

# git reflog — この bot は #367 修正入り checkout をロード済み
3849be6 HEAD@{2026-06-11 22:44:42}: pull --ff-only   (tmux_runner.py mtime=22:44:42)
eb80ca0 HEAD@{2026-06-11 22:06:39}: pull --ff-only   (#365/#367)
# bot pid 1827942 started 22:46:52 > 22:44:42 → 修正入りファイルをロード
```
Discord 順序: `ユーザー発言(08:51:21) → 🟡 メンション(08:51:38) → 実応答(08:53:19)`
</details>

### RED→GREEN — deterministic なユニットテスト

```
# RED（修正前）
FAILED tests/test_tmux_runner.py::TestIsGenerating::test_is_generating_spinner_pushed_off_bottom_six
  assert TmuxClaudeRunner._is_generating(text) is True  →  False

# GREEN（修正後）
tests/test_tmux_runner.py::TestIsGenerating 7 passed
# full suite（bot env 除外 = CI 同等）: 1717 passed, 3 skipped
```

### 継続的な本番検証

#365 監視 cron（2日毎・このスレッド投稿・6/27 自動停止）が「prompt≥200字 & exit<15秒」を抽出。今回の `14秒/1964字` はまさにこの条件に合致 → **本 PR デプロイ後、監視のフラグ数が落ちるかで実運用での効きを継続確認**する。これがライブ staging スクショの代替。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked（AC4 は監視による継続確認項目。本 PR の実装・テストは完了）
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted（`is True → False`）
- [x] `uv run pytest tests/ -v` passes（CI 同等 env: 1717 passed）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in（timing/検出依存のため live-staging skip、本番ログ+reflog+deterministic ユニット+監視で代替。理由明記）
- [x] No unrelated changes in the diff; self-review done（`_is_generating` の窓拡張 + 定数2つ + 新テスト + メンション設計の docstring のみ）
- [x] 動きを変えたら「あるべき動き」も更新: メンションが別メッセージである設計理由（Q2）を `thread_dashboard.py` docstring に明記。完了検出の挙動修正に対応する spec doc は無い
- [x] `Closes` ではなく `Refs #365`（監視で再発ゼロ確認後に close）— 独立行に記載
