### PR TITLE
feat: dod-gate に証跡リンク必須チェックを追加 (#391)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,7 +37,7 @@ Refs #
 
 ## Staging Evidence (証跡)
 
-> 挙動/UI を変える報告は**スクショを主証跡**にする（テキストログは補助）。**証跡は催促される前に貼る（必須）。** Discord 実画面は AI が `scripts/discord_evidence_shot.sh`（#243）で撮り、`scripts/evidence_upload.py <png>... --issue <N>` で GitHub Release アセット（`evidence` prerelease）にアップロードして出力 URL を貼る（#390。git ツリーには commit しない／Discord CDN の添付 URL は期限付きなので直貼り禁止）。原因側の tmux ペイン PNG（#286）とペアで貼る。
+> 挙動/UI を変える報告は**スクショを主証跡**にする（テキストログは補助）。**証跡は催促される前に貼る（必須）。** Discord 実画面は AI が `scripts/discord_evidence_shot.sh`（#243）で撮り、`scripts/evidence_upload.py <png>... --issue <N>` で GitHub Release アセット（`evidence` prerelease）にアップロードして出力 URL を貼る（#390。git ツリーには commit しない／Discord CDN の添付 URL は期限付きなので直貼り禁止）。原因側の tmux ペイン PNG（#286）とペアで貼る。**`dod-gate` は本文に証跡画像（`![...](URL)`）も Release アセット URL も無い非免除 PR を落とす（#391）。証跡が真に不要なら `no-runtime-change` / `documentation` ラベルを付ける。**
 
 <!-- REQUIRED for behavior changes (bug fixes / features).
      Skip ONLY for pure-docs or provably no-behavior-change refactors —
@@ -78,7 +78,7 @@ Discord screenshot (user-provided): <attach / link>
 
 See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.
 
-> **Label exemptions** (`no-runtime-change` or `documentation` label): the DoD-completion checklist below is waived (notably **TDD evidence** and **Staging Evidence**).
+> **Label exemptions** (`no-runtime-change` or `documentation` label): the DoD-completion checklist below is waived (notably **TDD evidence**, **Staging Evidence**, and the **evidence-link requirement** #391).
 > **`Closes` discipline is always enforced**, regardless of label: if you use `Closes`/`Resolves #N`, the Acceptance Criteria above must still be fully checked (else use `Refs #N`).
 
 - [ ] Every Acceptance Criterion above is checked

--- a/.github/scripts/dod_gate.js
+++ b/.github/scripts/dod_gate.js
@@ -24,6 +24,11 @@ function evaluateDod({ body = '', labels = [] } = {}) {
   };
   const countUnchecked = (text) => (text.match(/- \[ \]/g) || []).length;
 
+  // 証跡シグナル (#391): markdown 画像 / <img> / Release アセット URL /
+  // GitHub user-attachments URL / 画像拡張子つき URL。
+  const EVIDENCE_RE =
+    /!\[[^\]]*\]\([^)]+\)|<img\s|https?:\/\/\S+\/releases\/download\/\S+|https?:\/\/\S*user-attachments\/\S+|https?:\/\/\S+\.(?:png|jpe?g|gif|svg|webp)(?:[?#]\S*)?/i;
+
   const dodSection = section('Definition of Done checklist');
   const acSection = section('Acceptance Criteria');
 
@@ -61,6 +66,17 @@ function evaluateDod({ body = '', labels = [] } = {}) {
         );
       }
     }
+  }
+
+  // Rule 3 (#391): 挙動/UI を変える PR は証跡（画像 or Release アセット URL）が本文に必須。
+  // 免除ラベル（documentation / no-runtime-change）があればスキップ。証跡を「言われる前に
+  // 貼る」を機械的に強制する層。テキストログだけ（画像/URL 無し）は素通りさせない。
+  if (!ruleOneExempt && !EVIDENCE_RE.test(body)) {
+    errors.push(
+      '証跡が見つからない。挙動/UI を変える PR は本文に証跡画像（`![...](URL)`）か ' +
+        'Release アセット URL（`scripts/evidence_upload.py` で生成）を貼ること。' +
+        '純リファクタ/CI/docs で証跡が不要なら `no-runtime-change` か `documentation` ラベルを付ける。'
+    );
   }
 
   return { errors };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,10 +358,11 @@ incident that motivated this.
 
 **Label-based exemptions** (enforced by `dod-gate` CI — see `.github/workflows/dod-gate.yml`):
 
-- `no-runtime-change` or `documentation` label: **waives the DoD-completion checklist below** (notably the **TDD evidence** and **Staging verification** requirements). Use for pure-docs, CI/tooling, or provably no-behavior-change commits.
+- `no-runtime-change` or `documentation` label: **waives the DoD-completion checklist below** (notably the **TDD evidence**, **Staging verification**, and the **evidence-link requirement**). Use for pure-docs, CI/tooling, or provably no-behavior-change commits.
 - **`Closes` discipline is always enforced**, regardless of labels: if a PR uses `Closes`/`Resolves #N`, that Issue's Acceptance Criteria must be 100% met (else use `Refs #N`).
+- **Evidence-link required** (#391): a PR **without** an exempt label must contain a 証跡 image (`![...](URL)`) or a Release-asset URL in its body, or `dod-gate` fails. Text logs alone do not pass — paste an actual screenshot/URL (`scripts/evidence_upload.py`), or apply `no-runtime-change`/`documentation` if evidence is genuinely N/A.
 
-<!-- 参照はルール名で固定（番号で指さない）。項目を挿入すると番号がずれ免除対象がずれるため。dod-gate.yml の実挙動: ラベルあり → DoD 完了要件 (Rule 1) を免除 / `Closes` 規律 (Rule 2) は常時適用。 -->
+<!-- 参照はルール名で固定（番号で指さない）。項目を挿入すると番号がずれ免除対象がずれるため。dod-gate.yml の実挙動: ラベルあり → DoD 完了要件 (Rule 1) + 証跡リンク必須 (Rule 3) を免除 / `Closes` 規律 (Rule 2) は常時適用。 -->
 
 A PR may be merged only when:
 

--- a/docs/discord-evidence-capture.md
+++ b/docs/discord-evidence-capture.md
@@ -104,6 +104,8 @@ URL は Discord 上でチャンネル/メッセージを右クリック → 「�
 
 - **証跡は催促される前に貼る (必須)**。「言われたら付ける」ではなく、挙動/UI を
   変える PR・Issue には最初から RED / GREEN (前/後) の両方を貼る。
+  **`dod-gate` CI は、免除ラベル (`no-runtime-change` / `documentation`) の無い PR の
+  本文に証跡画像 (`![...](URL)`) も Release アセット URL も無ければ落とす (#391)。**
 - **やってはいけない**:
   - PNG を `docs/evidence/<issue番号>/` 等に commit する (旧規約。既存の
     commit 済み PNG は過去 PR のリンク保全のため残すが、新規は作らない)。

--- a/tests/test_dod_gate.py
+++ b/tests/test_dod_gate.py
@@ -28,6 +28,9 @@ _DOD_OK = (
     "- [x] Closes discipline\n"
 )
 
+# 証跡画像断片 (#391: 免除ラベルの無い挙動変更 PR は証跡必須)。
+_IMG = "\n![red](https://example.com/shot.png)\n"
+
 
 def _run_gate(body: str, labels: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
     event = {"pull_request": {"body": body, "labels": [{"name": n} for n in labels]}}
@@ -42,7 +45,8 @@ def _run_gate(body: str, labels: list[str], tmp_path: Path) -> subprocess.Comple
 
 
 def test_proper_ac_heading_all_checked_with_closes_passes(tmp_path: Path) -> None:
-    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + "\nCloses #1\n"
+    # 非免除 PR は証跡画像 (_IMG) が必須 (#391)。AC 全チェック + Closes + 証跡で通過。
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + _IMG + "\nCloses #1\n"
     result = _run_gate(body, [], tmp_path)
     assert result.returncode == 0, result.stderr
 
@@ -79,3 +83,43 @@ def test_missing_dod_section_fails(tmp_path: Path) -> None:
     body = "## Acceptance Criteria\n\n- [x] AC1\n\nbody without a DoD section\n"
     result = _run_gate(body, [], tmp_path)
     assert result.returncode == 1, result.stdout
+
+
+# --- Rule 3 (#391): 挙動変更 PR は証跡画像 / Release アセット URL が必須 ---
+
+
+def test_behavior_change_without_evidence_fails(tmp_path: Path) -> None:
+    # 免除ラベル無し・証跡画像無し → 落ちる。
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + "\nCloses #1\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 1, result.stdout
+    assert "証跡" in result.stderr
+
+
+def test_markdown_image_satisfies_evidence(tmp_path: Path) -> None:
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + _IMG + "\nCloses #1\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_release_asset_url_satisfies_evidence(tmp_path: Path) -> None:
+    # 拡張子の無い裸の Release ダウンロード URL でも証跡として認める。
+    url = "https://github.com/yousan/c-lord/releases/download/evidence/i1-red"
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + f"\n証跡: {url}\n\nCloses #1\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_bare_user_attachments_url_satisfies_evidence(tmp_path: Path) -> None:
+    # ドラッグ&ドロップ画像は ![](...) になるが、裸の user-attachments URL でも認める。
+    url = "https://github.com/user-attachments/assets/0a1b2c3d-evidence"
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + f"\n{url}\n\nCloses #1\n"
+    result = _run_gate(body, [], tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_no_runtime_change_label_exempts_evidence(tmp_path: Path) -> None:
+    # 免除ラベルがあれば証跡画像が無くても通る。
+    body = "## Acceptance Criteria\n\n- [x] AC1\n\n" + _DOD_OK + "\nCloses #1\n"
+    result = _run_gate(body, ["no-runtime-change"], tmp_path)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## これがこうなる（利用者目線）

**挙動/UI を変える PR は、証跡画像（`![...](URL)`）か Release アセット URL を本文に貼らないと `dod-gate` が落ちる**ようになります。＝「証跡を言われる前に貼る」が CI で機械的に強制されます（あなたが何度も催促していた「PR/Issue に画像が無い」を構造的に防ぐ）。

- 証跡が**真に不要**な PR（純リファクタ / CI / docs）は `no-runtime-change` か `documentation` ラベルを付ければ免除されます（従来の Rule 1 免除と同じラベル）。
- テキストログだけ（画像/URL 無し）は通りません。

`Closes #391`

## Acceptance Criteria（#391 から全コピー）

- [x] `no-runtime-change` / `documentation` ラベルが付いていない PR で、本文に画像/Release アセット URL が 1 つも無い場合 `dod-gate` が **fail** する
- [x] ラベル免除が効く（免除ラベルがあれば証跡チェックを skip）
- [x] `dod-gate` のロジックは node 駆動の unit test で RED→GREEN を提示（CLAUDE.md の DoD 注記に従う）
- [x] PR テンプレ / CLAUDE.md（+ docs/discord-evidence-capture.md）にこの強制ルールを追記

## Evidence（gate ロジックの RED→GREEN — CI ロジック変更なので証跡は gate_sim テスト）

このPRは CI ツールの変更（bot ランタイム不変）なので、証跡は Discord スクショではなく **`tests/test_dod_gate.py`（node 駆動）の RED→GREEN** です。

**RED**（Rule 3 実装前 — 証跡無し・非免除 PR が誤って通過）:
```
tests/test_dod_gate.py::test_behavior_change_without_evidence_fails
>       assert result.returncode == 1, result.stdout
E       AssertionError: DoD Gate 通過
E       assert 0 == 1
```

**GREEN**（Rule 3 実装後）:
```
tests/test_dod_gate.py .........  (10 passed)
full suite: 1726 passed, 3 skipped  (env-stripped = CI 相当)
ruff check / format: clean
```

<details>
<summary>検出する証跡シグナル（EVIDENCE_RE）</summary>

- markdown 画像 `![alt](url)`（ドラッグ&ドロップ画像はこの形になる）
- `<img ` タグ
- Release アセット URL（`…/releases/download/…`）
- GitHub `user-attachments/…` URL
- 画像拡張子つき URL（`.png/.jpg/.jpeg/.gif/.svg/.webp`）

非免除 PR で上記がどれも無ければ fail。
</details>

## Definition of Done checklist

> `no-runtime-change` ラベル付きのため Rule 1（TDD/Staging/証跡リンク完了要件）は免除。Closes 規律は適用 — 上の AC は全チェック済み。

- [x] Every Acceptance Criterion above is checked
- [x] TDD: RED（証跡無しが誤通過）→ GREEN（fail するよう実装）を node テストで提示・上記に RED 行を貼付
- [x] `uv run pytest tests/ -v` passes（1726 passed / 3 skipped）
- [x] `uv run ruff check` + `ruff format --check` pass（pyright は CI 担保。JS は対象外）
- [ ] Staging Evidence above is filled in (or a skip reason is written)　← skip: CI ロジック変更で bot ランタイム不変。証跡は gate_sim の RED→GREEN
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新した（CLAUDE.md / PRテンプレ / docs/discord-evidence-capture.md）
- [x] `Closes #391` は 100% AC 達成のため使用、独立行に記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)
