### PR TITLE
feat(monitor): 実トラフィック常時監視（ログ+スレッド異常スキャン, #404）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,18 @@ SESSION_TIMEOUT_SECONDS=300
 # FUZZ_TEST_THREAD_ID=               # only for --inject webhook (falls back to E2E_TEST_THREAD_ID)
 # CLORD_LEASE_OWNER=fuzz-hourly      # lease identity used to borrow/release staging
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Traffic monitor (#404) — scripts/monitor, the read-only anomaly monitor.
+# Scans bot logs + live threads for tracebacks/errors/stuck-threads and reports
+# only NEW anomalies. Read-only (no lease/inject/restart) — safe on prod + fleet.
+# See docs/specs/monitor.md. With --dry-run + --logs it needs none of the below.
+# MONITOR_LOGS=/tmp/clord-bot-c-lord*.log   # comma-separated log paths/globs to scan
+# MONITOR_CHANNELS=                  # comma-separated channel ids to scope thread scan
+# MONITOR_GUILD_ID=                  # server id — discovers active threads + clickable links
+# MONITOR_REPORT_CHANNEL=            # channel to post the anomaly summary
+# MONITOR_STATE_FILE=docs/monitor-runs/state.json   # incremental offset+seen state
+# MONITOR_STUCK_TIMEOUT=600          # 🟢-without-🟡 seconds before THREAD_STUCK
+
 # Skill-based reply (issue #52 — capture-pane scraping replacement, Phase 1)
 # When enabled, c-lord injects a `discord-reply` skill into each session dir
 # so Claude pushes its final answer to Discord via the REST API, bypassing

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ c_lord/_version.py
 # Commit a specific run only as PR evidence under docs/evidence/<issue>/.
 docs/fuzz-runs/*
 !docs/fuzz-runs/.gitkeep
+
+# Monitor run artifacts (#404) — keep the dir (.gitkeep), ignore the runs.
+docs/monitor-runs/*
+!docs/monitor-runs/.gitkeep

--- a/docs/evidence/404/first-scan.md
+++ b/docs/evidence/404/first-scan.md
@@ -1,0 +1,45 @@
+# #404 monitor 初回スキャン — 実ログから本物の不具合を検出（方向Aの検証）
+
+ファザー(#377)は11回走って0件。一方この monitor は**実 staging+prod ログを1回スキャンしただけ**で
+以下を検出。狙いどおり「実トラフィックには実バグが出ている」ことを実証。
+
+```
+実行: python -m scripts.monitor --dry-run --logs '/tmp/clord-bot-c-lord-staging-{1..4}.log,/tmp/clord-bot-c-lord.log'
+
+total: 4 / by kind: {'LOG_ERROR': 3, 'LOG_TRACEBACK': 1}
+
+- LOG_ERROR | clord-bot-c-lord-staging-4-20260612-085705.log | thread= 1514546025631580260
+   evidence: discord.ext.commands.bot: Ignoring exception in command None
+- LOG_ERROR | clord-bot-c-lord-staging-4-20260612-085705.log | thread= 1514546025631580260
+   evidence: discord.ext.commands.bot: Ignoring exception in command None
+- LOG_ERROR | clord-bot-c-lord-20260612-103154.log | thread= 1514462096601907331
+   evidence: c_lord.cogs._run_helper: [ ] Error running Claude CLI
+- LOG_TRACEBACK | clord-bot-c-lord-20260612-103154.log | thread= 1514462096601907331
+   evidence: KeyError: <id>
+```
+
+## 最重要: prod bot の未処理 traceback（KeyError, tmux capture 経路）
+
+これは診断の核心を裏付ける — 実バグは text→reply ではなく **tmux イベント経路**に出る:
+
+```
+Traceback (most recent call last):
+  File "/home/yousan/c-lord/c_lord/cogs/_run_helper.py", line 346, in run_claude_with_config
+    async for event in runner.run(config.prompt, session_id=config.session_id):
+  File "/home/yousan/c-lord/c_lord/claude/tmux_runner.py", line 836, in run
+    raw_current = await asyncio.to_thread(self._tmux.capture_pane, self._thread_id)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/asyncio/threads.py", line 25, in to_thread
+    return await loop.run_in_executor(None, func_call)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
+    result = self.fn(*self.args, **self.kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yousan/c-lord/c_lord/tmux.py", line 1074, in capture_pane
+    window = self._find_window_for_thread(thread_id)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/yousan/c-lord/c_lord/tmux.py", line 222, in _find_window_for_thread
+    del self._thread_to_window[thread_id]
+        ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
+KeyError: 1514462096601907331
+```

--- a/docs/monitor-runs/.gitkeep
+++ b/docs/monitor-runs/.gitkeep
@@ -1,0 +1,3 @@
+# Monitor run artifacts (<timestamp>.json/.md) + state.json are written here by
+# scripts/monitor. The artifacts are gitignored; this file keeps the dir present.
+# Commit a specific scan only as PR evidence under docs/evidence/<issue>/ instead.

--- a/docs/specs/monitor.md
+++ b/docs/specs/monitor.md
@@ -1,0 +1,92 @@
+# Traffic monitor — 実トラフィック常時監視（#404）
+
+`scripts/monitor/` は、**実際のトラフィック**（bot ログ＋稼働中スレッド）を定期スキャンして異常を拾い、
+報告する **read-only** ツール。合成入力を作らず、ユーザが既に生成している実シナリオを観測対象にする。
+
+このドキュメントが monitor の「**あるべき動き**」の一次情報源。
+
+## Why（理念・経緯）
+
+自然言語ファザー(#377)は staging で多数回走って **c-lord 本体バグ検出0**。原因は「一番薄くて堅い層
+（単発テキスト→返信）」を叩き、オラクルが構造的破綻しか見ないため（診断は memory `fuzz-tests-wrong-layer`
+／Issue #404）。実バグは **対話UI/状態ライフサイクル/描画/タイミング** に集中し、それは**実利用で踏まれて
+ログ・リアクション・ペインに痕跡を残す**。だから「合成入力を強くする」より「**実トラフィックを監視する**」方が
+当たる。実際この monitor は初回スキャンで prod bot の未処理 `KeyError`（tmux capture 経路）等を即検出した
+（`docs/evidence/404/`）。
+
+## 一連の流れ（あるべき動き）
+
+定期（cron, 例 10 分毎）、1 回の実行で:
+
+```
+state を読む（前回までのログ offset と報告済み fingerprint）
+   ▼
+(1) ログ増分スキャン: 各ログファイルを前回 offset から末尾まで読み、
+    traceback / [ERROR] / IDENTITY MISMATCH を拾う。[thread=/session=] 文脈を抽出
+   ▼
+(2) スレッド健全性スキャン（任意 / 要 bot token + guild または --threads）:
+    稼働スレッドの trigger が 🟢 のまま 🟡 が付かず timeout 超過(=hang/no-response)、
+    ❌、最新返信に chrome/traceback、を拾う
+   ▼
+fingerprint で dedup（既報告は除外）→ NEW 異常のみ
+   ▼
+docs/monitor-runs/<ts>.{json,md} を出力、state（offset + seen）を更新
+   ▼
+NEW があれば報告チャンネルへ投稿
+```
+
+利用者から見た変化: 監視チャンネルに「**新規異常 N 件**＋種別＋該当スレッド/ログ」が届く。traceback は
+本文（exception 行）と発生スレッドまで辿れる。何も新規が無ければ静かに（投稿は NEW がある時だけ）。
+
+## なぜこの設計か
+
+- **external（bot 内 Cog ではない）**: hang/no-response は「bot が応えない」状態 → 内部監視では報告不能。
+  外から（ログ＋REST）見る必要がある。prod + staging フリート全台を1本で監視できる。
+- **read-only**: lease 取得なし・注入なし・restart なし。prod に当てても安全（観測専用）。
+- **ログ走査が主軸**: traceback / `[ERROR]` は「バグを踏んだ瞬間」の最も曖昧さの無い信号。構造化ログ
+  `[thread=/session=]`（`log_ctx`）で発生スレッドまで辿れる。**正規化**（timestamp/id/context を除去）で
+  同一エラーの再掲を fingerprint dedup。
+- **増分**: ログは offset 管理で前回の続きから。`…-latest.log` symlink が再起動で別ファイルを指しても、
+  実パス解決＋truncation 検出で取りこぼさない（新ファイルは頭から走査）。
+- fuzz の primitive（`Anomaly`/`fingerprint`/oracle の chrome・exception・emoji 判定）を再利用。
+
+## 検出カタログ
+
+| kind | severity | 源 | 意味 |
+|------|----------|----|------|
+| `LOG_TRACEBACK` | high | log | bot ログに traceback（未処理例外） |
+| `LOG_ERROR` | medium | log | `[ERROR]` レベルのログ行 |
+| `IDENTITY_MISMATCH` | critical | log | 誤った identity でログイン |
+| `THREAD_STUCK` | high | thread | trigger が 🟢 のまま 🟡 にならず timeout 超過（hang/no-response） |
+| `ERROR_REACTION` | high | thread | trigger に ❌ |
+| `STALL` | medium | thread | trigger に ⏳/⚠️ |
+| `CHROME_LEAK` / `EXCEPTION_LEAK` | high | thread | 最新返信に TUI chrome / traceback |
+
+検出は**候補**。人間が triage する。
+
+## 動かす
+
+```bash
+# ログだけ dry-run（投稿/ state 書き込みなし）。token 不要
+python -m scripts.monitor --dry-run --logs '/tmp/clord-bot-c-lord*.log'
+
+# 本番運用相当（ログ + スレッド + 報告）
+python -m scripts.monitor \
+  --logs '/tmp/clord-bot-c-lord*.log' \
+  --guild <guild_id> --channels <ch1,ch2> --report-channel <report_ch>
+
+# cron（10 分毎・:00 を避ける）
+3,13,23,33,43,53 * * * * MONITOR_LOGS='/tmp/clord-bot-c-lord*.log' \
+  MONITOR_GUILD_ID=<g> MONITOR_CHANNELS=<chs> MONITOR_REPORT_CHANNEL=<ch> \
+  /home/you/c-lord/scripts/monitor/cron.sh
+```
+
+主なフラグ: `--logs`(glob可) / `--channels` / `--threads`(guild の代わりに直接指定) / `--guild` /
+`--report-channel` / `--stuck-timeout`(既定600s) / `--state-file` / `--dry-run` / `--no-report`。
+設定キーは `.env.example` の Monitor 節参照。
+
+## 既知の限界 / 将来（別 Issue）
+
+- ログの `[ERROR]` には良性のものも混じる（dedup で再掲は抑えるが初回は出る）。重要度の学習的フィルタは将来。
+- スレッド走査は active threads（guild）か明示 thread 一覧。アーカイブ済みは未対象。
+- **B**: 対話フロー能動駆動 + tmuxペインvs Discord の視覚差分 + LLM/vision 判定（別 Issue, #404 out-of-scope）。

--- a/scripts/monitor/__init__.py
+++ b/scripts/monitor/__init__.py
@@ -1,0 +1,25 @@
+"""Passive traffic monitor for c-lord (Issue #404).
+
+Direction A from the #377 retrospective: the natural-language fuzzer tests the
+thinnest, most-hardened layer (single-turn text → reply) and its oracle only
+catches structural breaks, so it misses the real bug surface (interactive UI
+flows, lifecycle/state, rendering, timing). The real bugs are already being hit
+by real users in real Discord threads — so instead of synthesizing inputs, this
+*read-only* monitor watches the real traffic for anomalies:
+
+  * bot logs — new tracebacks / ERROR lines / identity mismatches (the clearest
+    "a user just hit a bug" signal), with the structured ``[thread=/session=]``
+    context extracted;
+  * thread health — a trigger still 🟢 (running) with no 🟡 past a timeout
+    (stuck/no-response/hang), ❌ reactions, or chrome/traceback leaked into a
+    reply (reusing the fuzz oracle).
+
+It must be external (not an in-bot Cog): a hung bot cannot report its own hang.
+Anomalies are fingerprint-deduped and only *new* ones are reported.
+"""
+
+from __future__ import annotations
+
+from .logscan import scan_log_text
+
+__all__ = ["scan_log_text"]

--- a/scripts/monitor/__main__.py
+++ b/scripts/monitor/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point: ``python -m scripts.monitor`` (Issue #404)."""
+
+from __future__ import annotations
+
+import sys
+
+from .runner import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/monitor/cron.sh
+++ b/scripts/monitor/cron.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# =============================================================================
+# cron.sh — run the read-only traffic monitor once (Issue #404)
+# =============================================================================
+# Install (crontab -e), e.g. every 10 minutes (off the :00 mark):
+#
+#   3,13,23,33,43,53 * * * * MONITOR_LOGS='/tmp/clord-bot-c-lord*.log' \
+#     MONITOR_GUILD_ID=<guild> MONITOR_CHANNELS=<ch1,ch2> MONITOR_REPORT_CHANNEL=<ch> \
+#     /ABS/PATH/c-lord/scripts/monitor/cron.sh
+#
+# Read-only: scans bot logs (incremental, via state file) + live threads for
+# anomalies and posts only NEW ones to the report channel. No lease/inject/restart,
+# so it is safe to run against prod + the staging fleet at the same time.
+#
+# Config comes from env (above) or the harness clone's .env. Per-run logs land in
+# $MONITOR_LOG_DIR (default /tmp). Tunables: MONITOR_STUCK_TIMEOUT, MONITOR_EXTRA_ARGS.
+# =============================================================================
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VENV_PY="$HARNESS_DIR/.venv/bin/python3"
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+LOG_DIR="${MONITOR_LOG_DIR:-/tmp}"
+NAME="$(basename "$HARNESS_DIR")"
+TS="$(date +%Y%m%d-%H%M%S)"
+LOG="$LOG_DIR/clord-monitor-$NAME-$TS.log"
+ln -sf "$LOG" "$LOG_DIR/clord-monitor-$NAME.log" 2>/dev/null || true
+
+if [ ! -x "$VENV_PY" ]; then
+  echo "ERROR: no venv python at $VENV_PY (run uv sync --dev in $HARNESS_DIR)" >&2
+  exit 1
+fi
+
+ARGS=()
+[ -n "${MONITOR_LOGS:-}" ] && ARGS+=(--logs "$MONITOR_LOGS")
+[ -n "${MONITOR_CHANNELS:-}" ] && ARGS+=(--channels "$MONITOR_CHANNELS")
+[ -n "${MONITOR_GUILD_ID:-}" ] && ARGS+=(--guild "$MONITOR_GUILD_ID")
+[ -n "${MONITOR_REPORT_CHANNEL:-}" ] && ARGS+=(--report-channel "$MONITOR_REPORT_CHANNEL")
+[ -n "${MONITOR_STUCK_TIMEOUT:-}" ] && ARGS+=(--stuck-timeout "$MONITOR_STUCK_TIMEOUT")
+# shellcheck disable=SC2206
+[ -n "${MONITOR_EXTRA_ARGS:-}" ] && ARGS+=(${MONITOR_EXTRA_ARGS})
+
+cd "$HARNESS_DIR" || exit 1
+echo "[cron] $(date -Is) monitor run → $LOG"
+"$VENV_PY" -m scripts.monitor "${ARGS[@]}" >"$LOG" 2>&1
+rc=$?
+echo "[cron] $(date -Is) monitor run exited $rc (log: $LOG)"
+exit "$rc"

--- a/scripts/monitor/logscan.py
+++ b/scripts/monitor/logscan.py
@@ -1,0 +1,109 @@
+"""Bot-log anomaly detection (Issue #404). Pure functions only.
+
+Scans a chunk of new log text and returns :class:`Anomaly` candidates for
+tracebacks, ERROR-level lines, and identity mismatches — the clearest signals
+that a real user just hit a bug. The structured ``[thread=/session=/task=]``
+context (from ``log_ctx``) is attached so the anomaly points back at the
+offending thread, and a normalized signature is used as the evidence so the same
+recurring error dedups across runs (changing timestamps / thread ids fold away).
+"""
+
+from __future__ import annotations
+
+import re
+
+from scripts.fuzz.oracle import Anomaly
+
+_CTX_KEYS = ("thread", "session", "task", "channel")
+_TS_RE = re.compile(r"^\s*\d{4}-\d\d-\d\d[ T]\d\d:\d\d:\d\d[.,]?\d*\s*")
+_LOG_LINE_RE = re.compile(r"^\d{4}-\d\d-\d\d[ T]\d\d:\d\d:\d\d")
+_ID_RE = re.compile(r"\b\d{15,}\b")
+
+
+def _extract_ctx(line: str) -> dict[str, str]:
+    ctx: dict[str, str] = {}
+    for key in _CTX_KEYS:
+        m = re.search(rf"{key}=([^\s\]]+)", line)
+        if m:
+            ctx[key] = m.group(1)
+    return ctx
+
+
+def _normalize(text: str) -> str:
+    """Strip the variable parts (timestamp, ids, context) for a stable signature."""
+    out = _TS_RE.sub("", text)
+    for key in _CTX_KEYS:
+        out = re.sub(rf"{key}=[^\s\]]+", "", out)
+    out = _ID_RE.sub("<id>", out)
+    return re.sub(r"\s+", " ", out).strip()
+
+
+def _error_message(line: str) -> str:
+    tail = line.split("[ERROR]", 1)[1] if "[ERROR]" in line else line
+    return tail.strip()
+
+
+def _read_traceback(lines: list[str], start: int) -> tuple[str, str]:
+    """Return (exception_signature, raw_block) for a traceback starting at *start*."""
+    block = [lines[start]]
+    exc = ""
+    j = start + 1
+    while j < len(lines):
+        ln = lines[j]
+        if _LOG_LINE_RE.match(ln):  # next real log entry → traceback ended
+            break
+        block.append(ln)
+        if ln.strip() and not ln.startswith((" ", "\t")):
+            exc = ln.strip()  # last non-indented line = the exception type+message
+        j += 1
+    return (exc or lines[start].strip()), "\n".join(block).strip()
+
+
+def scan_log_text(text: str, *, source: str = "") -> list[Anomaly]:
+    """Find anomalies in a chunk of new log lines (possibly empty)."""
+    out: list[Anomaly] = []
+    ctx: dict[str, str] = {}
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        found = _extract_ctx(line)
+        if found:
+            ctx = found
+        sid = ctx.get("thread", "-")
+        base_fields = {**ctx, "source": source, "raw": line.strip()}
+
+        if "IDENTITY MISMATCH" in line:
+            out.append(
+                Anomaly(
+                    sid,
+                    "IDENTITY_MISMATCH",
+                    "critical",
+                    "bot logged in as the wrong identity",
+                    _normalize(line),
+                    fields=base_fields,
+                )
+            )
+        elif "[ERROR]" in line:
+            out.append(
+                Anomaly(
+                    sid,
+                    "LOG_ERROR",
+                    "medium",
+                    "ERROR-level log line",
+                    _normalize(_error_message(line)),
+                    fields=base_fields,
+                )
+            )
+
+        if "Traceback (most recent call last)" in line:
+            exc, raw_block = _read_traceback(lines, i)
+            out.append(
+                Anomaly(
+                    sid,
+                    "LOG_TRACEBACK",
+                    "high",
+                    "traceback in bot log",
+                    _normalize(exc),
+                    fields={**ctx, "source": source, "raw": raw_block},
+                )
+            )
+    return out

--- a/scripts/monitor/runner.py
+++ b/scripts/monitor/runner.py
@@ -1,0 +1,325 @@
+"""Monitor orchestration + config + CLI (Issue #404). Read-only.
+
+Each run: scan new bot-log text (incremental) for tracebacks/errors, scan live
+threads for stuck/❌/chrome, dedup against seen fingerprints, and report only the
+NEW anomalies. No lease, no injection, no restart — safe against prod + fleet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from scripts.fuzz.oracle import Anomaly, fingerprint, severity_rank
+from scripts.monitor.logscan import scan_log_text
+from scripts.monitor.state import load_state, read_new_log_text, save_state
+from scripts.monitor.threadscan import detect_thread_anomalies
+
+UA = "DiscordBot (https://github.com/yousan/c-lord, 1.0)"
+DISCORD_API = "https://discord.com/api/v10"
+DISCORD_EPOCH_MS = 1420070400000
+DEFAULT_OUT_DIR = "docs/monitor-runs"
+DEFAULT_STATE = "docs/monitor-runs/state.json"
+DEFAULT_STUCK_TIMEOUT = 600.0
+_SEV_EMOJI = {"critical": "🟥", "high": "🟧", "medium": "🟨", "low": "⬜", "info": "⬜"}
+
+
+def log(msg: str) -> None:
+    print(f"[monitor] {msg}", flush=True)
+
+
+def snowflake_age_s(message_id: str, *, now_ms: float) -> float:
+    try:
+        created = (int(message_id) >> 22) + DISCORD_EPOCH_MS
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, (now_ms - created) / 1000.0)
+
+
+# --------------------------------------------------------------------------
+# Discord REST (read + report only)
+# --------------------------------------------------------------------------
+class MonitorClient:
+    def __init__(self, bot_token: str) -> None:
+        self._token = bot_token
+
+    def _get(self, path: str):
+        req = urllib.request.Request(f"{DISCORD_API}{path}")
+        req.add_header("User-Agent", UA)
+        req.add_header("Authorization", f"Bot {self._token}")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+
+    def bot_user_id(self) -> str:
+        try:
+            return str(self._get("/users/@me")["id"])
+        except Exception:
+            return ""
+
+    def fetch_messages(self, channel_id: str, *, limit: int = 50) -> list[dict]:
+        try:
+            return self._get(f"/channels/{channel_id}/messages?limit={limit}")
+        except (urllib.error.URLError, OSError):
+            return []
+
+    def active_threads(self, guild_id: str) -> list[dict]:
+        try:
+            return self._get(f"/guilds/{guild_id}/threads/active").get("threads", [])
+        except (urllib.error.URLError, OSError):
+            return []
+
+    def post_message(self, channel_id: str, content: str) -> tuple[bool, str | None]:
+        data = json.dumps({"content": content}).encode()
+        req = urllib.request.Request(
+            f"{DISCORD_API}/channels/{channel_id}/messages", data=data, method="POST"
+        )
+        req.add_header("User-Agent", UA)
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", f"Bot {self._token}")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.status in (200, 201), None
+        except urllib.error.HTTPError as exc:
+            return False, f"{exc.code}: {exc.read()[:200]!r}"
+
+
+_STATUS_EMOJI = {"🟢", "🟡", "❌", "⏳", "⚠️", "⚠"}
+
+
+def _reaction_names(message: dict) -> list[str]:
+    return [
+        (r or {}).get("emoji", {}).get("name", "")
+        for r in (message.get("reactions") or [])
+        if (r or {}).get("emoji", {}).get("name")
+    ]
+
+
+def observe_thread(
+    client: MonitorClient, thread_id: str, bot_id: str, *, now_ms: float
+) -> tuple[list[str], str | None, float] | None:
+    """Return (trigger_reactions, latest_reply_text, trigger_age_s) or None."""
+    msgs = client.fetch_messages(thread_id, limit=50)
+    if not msgs:
+        return None
+    trigger = next((m for m in msgs if set(_reaction_names(m)) & _STATUS_EMOJI), None)
+    if trigger is None:
+        return None  # no active turn to judge
+    reactions = _reaction_names(trigger)
+    age = snowflake_age_s(str(trigger["id"]), now_ms=now_ms)
+    reply = None
+    for m in msgs:  # newest-first; first plain-content bot message is the latest reply
+        if m.get("author", {}).get("id") == bot_id and not m.get("webhook_id"):
+            content = (m.get("content") or "").strip()
+            if content and not content.startswith("-#"):
+                reply = m.get("content")
+                break
+    return reactions, reply, age
+
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+def load_env_file(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        env[key.strip()] = value.strip()
+    return env
+
+
+@dataclass
+class MonitorConfig:
+    bot_token: str | None
+    logs: list[str]
+    channels: list[str]
+    report_channel: str | None
+    guild_id: str | None
+    state_file: str
+    out_dir: str
+    stuck_timeout: float
+
+
+def _csv(val: str | None) -> list[str]:
+    return [x.strip() for x in (val or "").split(",") if x.strip()]
+
+
+def build_config(env: dict[str, str], args: argparse.Namespace) -> MonitorConfig:
+    def pick(*keys: str, default: str | None = None) -> str | None:
+        for k in keys:
+            if env.get(k):
+                return env[k]
+        return default
+
+    return MonitorConfig(
+        bot_token=pick("DISCORD_BOT_TOKEN"),
+        logs=_csv(args.logs or pick("MONITOR_LOGS")),
+        channels=_csv(args.channels or pick("MONITOR_CHANNELS")),
+        report_channel=args.report_channel or pick("MONITOR_REPORT_CHANNEL", "DISCORD_CHANNEL_ID"),
+        guild_id=args.guild or pick("MONITOR_GUILD_ID", "FUZZ_GUILD_ID", "DISCORD_GUILD_ID"),
+        state_file=args.state_file
+        or pick("MONITOR_STATE_FILE", default=DEFAULT_STATE)
+        or DEFAULT_STATE,
+        out_dir=args.out_dir,
+        stuck_timeout=args.stuck_timeout,
+    )
+
+
+# --------------------------------------------------------------------------
+# Reporting (inline; reuses fuzz fingerprint/severity)
+# --------------------------------------------------------------------------
+def _thread_url(guild: str | None, thread: str | None) -> str | None:
+    return f"https://discord.com/channels/{guild}/{thread}" if guild and thread else None
+
+
+def render_summary(new_anoms: list[Anomaly], total: int, *, guild: str | None) -> str:
+    if not new_anoms:
+        return f"👁️ **traffic monitor** · スキャン異常 {total} / 新規 0 → ✅ 新しい異常なし"
+    lines = [f"👁️ **traffic monitor** · 異常 {total} / **新規 {len(new_anoms)}**", ""]
+    for a in sorted(new_anoms, key=lambda x: severity_rank(x.severity)):
+        sev = _SEV_EMOJI.get(a.severity, "⬜")
+        thread = a.fields.get("thread")
+        src = a.fields.get("source", "")
+        url = _thread_url(guild, thread if thread and thread != "-" else None)
+        loc = f" <{url}>" if url else (f" [{src}]" if src else "")
+        ev = (a.evidence or "").replace("\n", " ")[:80]
+        lines.append(f"{sev} `{a.kind}` {a.detail} — `{ev}`{loc}")
+    text = "\n".join(lines)
+    return text[:1980] + "…" if len(text) > 1990 else text
+
+
+def _anomaly_dict(a: Anomaly) -> dict:
+    return {
+        "kind": a.kind,
+        "severity": a.severity,
+        "detail": a.detail,
+        "evidence": a.evidence,
+        "fingerprint": fingerprint(a),
+        "fields": a.fields,
+    }
+
+
+# --------------------------------------------------------------------------
+# Run
+# --------------------------------------------------------------------------
+def run(cfg: MonitorConfig, args: argparse.Namespace) -> int:
+    run_id = datetime.now().strftime("%Y%m%d-%H%M%S")
+    now_ms = datetime.now().timestamp() * 1000
+    state = load_state(Path(cfg.state_file))
+    anomalies: list[Anomaly] = []
+
+    # 1) incremental log scan
+    real_paths: list[Path] = []
+    for pattern in cfg.logs:
+        for hit in sorted(glob.glob(pattern)):
+            real_paths.append(Path(hit).resolve())
+    for rp in real_paths:
+        text, new_off = read_new_log_text(rp, state.offsets.get(str(rp), 0))
+        state.offsets[str(rp)] = new_off
+        if text:
+            anomalies.extend(scan_log_text(text, source=rp.name))
+    log(f"log scan: {len(real_paths)} file(s) → {len(anomalies)} log anomaly(ies)")
+
+    # 2) live thread health scan (read-only)
+    if cfg.bot_token and (cfg.guild_id or args.threads):
+        client = MonitorClient(cfg.bot_token)
+        bot_id = client.bot_user_id()
+        threads: list[dict] = []
+        if args.threads:
+            threads = [{"id": t, "parent_id": None} for t in _csv(args.threads)]
+        elif cfg.guild_id:
+            threads = client.active_threads(cfg.guild_id)
+            if cfg.channels:
+                allow = set(cfg.channels)
+                threads = [t for t in threads if str(t.get("parent_id")) in allow]
+        for t in threads[: args.thread_limit]:
+            obs = observe_thread(client, str(t["id"]), bot_id, now_ms=now_ms)
+            if obs is None:
+                continue
+            reactions, reply, age = obs
+            anomalies.extend(
+                detect_thread_anomalies(
+                    reactions=reactions,
+                    latest_reply_text=reply,
+                    trigger_age_s=age,
+                    stuck_timeout_s=cfg.stuck_timeout,
+                    thread_id=str(t["id"]),
+                    source=f"thread:{t.get('name', t['id'])}",
+                )
+            )
+        log(f"thread scan: {len(threads)} thread(s) checked")
+
+    # 3) dedup + report
+    seen = state.seen_set
+    new = [a for a in anomalies if fingerprint(a) not in seen]
+    out_dir = Path(cfg.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report = {
+        "run_id": run_id,
+        "counts": {"anomalies": len(anomalies), "new": len(new)},
+        "anomalies": [_anomaly_dict(a) for a in anomalies],
+    }
+    (out_dir / f"{run_id}.json").write_text(json.dumps(report, ensure_ascii=False, indent=2))
+    (out_dir / f"{run_id}.md").write_text(render_summary(new, len(anomalies), guild=cfg.guild_id))
+    log(f"report → {out_dir}/{run_id}.json · {len(new)} new anomaly(ies)")
+
+    for a in new:
+        state.seen.append(fingerprint(a))
+    if not args.dry_run:
+        save_state(Path(cfg.state_file), state)
+        if not args.no_report and cfg.report_channel and cfg.bot_token and new:
+            ok, err = MonitorClient(cfg.bot_token).post_message(
+                cfg.report_channel, render_summary(new, len(anomalies), guild=cfg.guild_id)
+            )
+            log(f"posted to #{cfg.report_channel}" if ok else f"report post failed: {err}")
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="python -m scripts.monitor",
+        description="Read-only traffic monitor for c-lord (Issue #404).",
+    )
+    p.add_argument("--logs", default=None, help="comma-separated log file paths/globs to scan")
+    p.add_argument("--channels", default=None, help="comma-separated channel ids to scope threads")
+    p.add_argument(
+        "--threads", default=None, help="comma-separated thread ids (instead of guild scan)"
+    )
+    p.add_argument("--report-channel", default=None, help="channel id to post the summary")
+    p.add_argument("--guild", default=None, help="guild id for active-thread discovery + links")
+    p.add_argument("--state-file", default=None, help="incremental state file")
+    p.add_argument("--out-dir", default=DEFAULT_OUT_DIR, help="artifact output dir")
+    p.add_argument(
+        "--stuck-timeout",
+        type=float,
+        default=DEFAULT_STUCK_TIMEOUT,
+        help="🟢-without-🟡 stuck threshold (s)",
+    )
+    p.add_argument("--thread-limit", type=int, default=40, help="max threads to check per run")
+    p.add_argument("--env-file", default=None, help="explicit .env to read")
+    p.add_argument("--no-report", action="store_true", help="do not post a Discord summary")
+    p.add_argument(
+        "--dry-run", action="store_true", help="scan + write artifacts; no state write, no post"
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    env = load_env_file(Path(args.env_file) if args.env_file else Path(".env"))
+    return run(build_config(env, args), args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/monitor/state.py
+++ b/scripts/monitor/state.py
@@ -1,0 +1,56 @@
+"""Incremental scan state: per-logfile byte offsets + seen fingerprints (#404).
+
+Offsets are keyed by the *resolved* real path so the bot's ``…-latest.log``
+symlink repointing to a fresh per-run file (each restart) is scanned from the
+start of the new file rather than skipped. A file that shrank below its recorded
+offset (truncation / rotation) is re-read from 0.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class MonitorState:
+    offsets: dict[str, int] = field(default_factory=dict)
+    seen: list[str] = field(default_factory=list)  # fingerprints (list for JSON)
+
+    @property
+    def seen_set(self) -> set[str]:
+        return set(self.seen)
+
+
+def load_state(path: Path) -> MonitorState:
+    if not path.exists():
+        return MonitorState()
+    try:
+        data = json.loads(path.read_text())
+        return MonitorState(offsets=dict(data.get("offsets", {})), seen=list(data.get("seen", [])))
+    except (ValueError, OSError):
+        return MonitorState()
+
+
+def save_state(path: Path, state: MonitorState) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"offsets": state.offsets, "seen": sorted(set(state.seen))}, indent=1)
+    )
+
+
+def read_new_log_text(real_path: Path, prev_offset: int) -> tuple[str, int]:
+    """Return (new_text_since_offset, new_offset). Missing file → ("", 0)."""
+    try:
+        size = real_path.stat().st_size
+    except OSError:
+        return "", 0
+    start = 0 if size < prev_offset else prev_offset  # truncated/rotated → from 0
+    try:
+        with real_path.open("r", encoding="utf-8", errors="replace") as f:
+            f.seek(start)
+            text = f.read()
+        return text, size
+    except OSError:
+        return "", prev_offset

--- a/scripts/monitor/threadscan.py
+++ b/scripts/monitor/threadscan.py
@@ -1,0 +1,76 @@
+"""Live-thread health detection (Issue #404). Pure functions only.
+
+Reuses the fuzz oracle's chrome/exception checks and status-emoji constants so
+the two stay in sync. Adds THREAD_STUCK: a trigger still 🟢 (running) with no 🟡
+(done) past a timeout — i.e. the bot took the turn but never finished it (a hang
+/ no-response that a single fuzz injection would also have caught, but here seen
+on real traffic).
+"""
+
+from __future__ import annotations
+
+from scripts.fuzz.oracle import (
+    EMOJI_ERROR,
+    EMOJI_RUNNING,
+    EMOJI_STALL_HARD,
+    EMOJI_STALL_SOFT,
+    EMOJI_WAITING,
+    Anomaly,
+    _chrome_reason,
+    _exception_reason,
+    _strip_vs,
+)
+
+
+def detect_thread_anomalies(
+    *,
+    reactions: list[str],
+    latest_reply_text: str | None,
+    trigger_age_s: float,
+    stuck_timeout_s: float,
+    thread_id: str,
+    source: str = "",
+) -> list[Anomaly]:
+    """Anomaly candidates for one live thread's trigger + latest reply."""
+    out: list[Anomaly] = []
+    fields = {"thread": thread_id, "source": source}
+    rset = {_strip_vs(r) for r in reactions}
+    running = _strip_vs(EMOJI_RUNNING) in rset
+    waiting = _strip_vs(EMOJI_WAITING) in rset
+
+    if _strip_vs(EMOJI_ERROR) in rset:
+        out.append(
+            Anomaly(
+                thread_id, "ERROR_REACTION", "high", "trigger marked ❌", EMOJI_ERROR, fields=fields
+            )
+        )
+    if rset & {_strip_vs(EMOJI_STALL_SOFT), _strip_vs(EMOJI_STALL_HARD)}:
+        out.append(
+            Anomaly(
+                thread_id, "STALL", "medium", "trigger shows ⏳/⚠️ (stall)", "stall", fields=fields
+            )
+        )
+    if running and not waiting and trigger_age_s > stuck_timeout_s:
+        out.append(
+            Anomaly(
+                thread_id,
+                "THREAD_STUCK",
+                "high",
+                f"running 🟢 with no 🟡 after {int(trigger_age_s)}s (hang/no-response)",
+                "stuck",
+                fields=fields,
+            )
+        )
+
+    text = latest_reply_text or ""
+    chrome = _chrome_reason(text)
+    if chrome is not None:
+        out.append(
+            Anomaly(thread_id, "CHROME_LEAK", "high", "TUI chrome in reply", chrome, fields=fields)
+        )
+    exc = _exception_reason(text)
+    if exc is not None:
+        out.append(
+            Anomaly(thread_id, "EXCEPTION_LEAK", "high", "traceback in reply", exc, fields=fields)
+        )
+    return out

--- a/tests/test_monitor_logscan.py
+++ b/tests/test_monitor_logscan.py
@@ -1,0 +1,72 @@
+"""Unit tests for scripts.monitor.logscan — bot-log anomaly detection (#404).
+
+The log scan is the monitor's highest-signal source: a traceback / ERROR line is
+emitted exactly when a real user hits a bug. Parsing must extract the structured
+``[thread=/session=]`` context and produce a *stable* fingerprint (so the same
+recurring error dedups across runs despite changing timestamps / thread ids).
+"""
+
+from __future__ import annotations
+
+from scripts.fuzz.oracle import fingerprint
+from scripts.monitor.logscan import scan_log_text
+
+
+def test_detects_traceback_with_thread_context() -> None:
+    text = (
+        "2026-06-12 10:00:00 [INFO] c_lord.bot: ok\n"
+        "2026-06-12 10:00:01 [ERROR] c_lord.cogs.claude_chat: run failed "
+        "[thread=12345 session=abcd1234]\n"
+        "Traceback (most recent call last):\n"
+        '  File "/x/claude_chat.py", line 10, in run\n'
+        "    do()\n"
+        "RuntimeError: boom happened\n"
+        "2026-06-12 10:00:02 [INFO] c_lord.bot: continuing\n"
+    )
+    anoms = scan_log_text(text, source="staging-1.log")
+    kinds = {a.kind for a in anoms}
+    assert "LOG_TRACEBACK" in kinds
+    assert "LOG_ERROR" in kinds
+    tb = next(a for a in anoms if a.kind == "LOG_TRACEBACK")
+    assert "RuntimeError: boom happened" in tb.evidence
+    assert tb.fields.get("thread") == "12345"
+    assert tb.fields.get("source") == "staging-1.log"
+
+
+def test_clean_log_yields_no_anomaly() -> None:
+    text = "2026-06-12 10:00:00 [INFO] c_lord.bot: ok\n... [WARNING] minor thing\n"
+    assert scan_log_text(text) == []
+
+
+def test_identity_mismatch_is_critical() -> None:
+    anoms = scan_log_text("2026-06-12 10:00:00 [ERROR] IDENTITY MISMATCH: as 1 expected 2\n")
+    assert any(a.kind == "IDENTITY_MISMATCH" and a.severity == "critical" for a in anoms)
+
+
+def test_fingerprint_stable_across_timestamp_and_thread() -> None:
+    a1 = scan_log_text(
+        "2026-06-12 10:00:01 [ERROR] c_lord.x: db is locked [thread=111]\n"
+        "Traceback (most recent call last):\n"
+        "aiosqlite.OperationalError: database is locked\n"
+    )
+    a2 = scan_log_text(
+        "2026-06-12 11:30:59 [ERROR] c_lord.x: db is locked [thread=222]\n"
+        "Traceback (most recent call last):\n"
+        "aiosqlite.OperationalError: database is locked\n"
+    )
+    tb1 = next(a for a in a1 if a.kind == "LOG_TRACEBACK")
+    tb2 = next(a for a in a2 if a.kind == "LOG_TRACEBACK")
+    assert fingerprint(tb1) == fingerprint(tb2)
+    err1 = next(a for a in a1 if a.kind == "LOG_ERROR")
+    err2 = next(a for a in a2 if a.kind == "LOG_ERROR")
+    assert fingerprint(err1) == fingerprint(err2)  # thread id normalized out
+
+
+def test_error_line_extracts_session_context() -> None:
+    anoms = scan_log_text(
+        "2026-06-12 10:00:01 [ERROR] c_lord.cogs.scheduler: task blew up "
+        "[thread=999 session=deadbeef task=7]\n"
+    )
+    err = next(a for a in anoms if a.kind == "LOG_ERROR")
+    assert err.fields.get("session") == "deadbeef"
+    assert err.fields.get("thread") == "999"

--- a/tests/test_monitor_runner.py
+++ b/tests/test_monitor_runner.py
@@ -1,0 +1,134 @@
+"""Unit tests for scripts.monitor.runner — config, rendering, observe (#404)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.monitor.runner import (
+    MonitorClient,
+    _csv,
+    build_config,
+    observe_thread,
+    parse_args,
+    render_summary,
+    run,
+    snowflake_age_s,
+)
+
+
+def test_csv_splits_and_strips() -> None:
+    assert _csv("/a.log, /b.log ,") == ["/a.log", "/b.log"]
+    assert _csv(None) == []
+
+
+def test_build_config_precedence() -> None:
+    env = {
+        "DISCORD_BOT_TOKEN": "tok",
+        "MONITOR_LOGS": "/x.log",
+        "DISCORD_CHANNEL_ID": "999",
+        "FUZZ_GUILD_ID": "guild1",
+    }
+    cfg = build_config(env, parse_args([]))
+    assert cfg.bot_token == "tok"
+    assert cfg.logs == ["/x.log"]
+    assert cfg.report_channel == "999"  # falls back to DISCORD_CHANNEL_ID
+    assert cfg.guild_id == "guild1"
+    # CLI overrides env
+    cfg2 = build_config(env, parse_args(["--logs", "/y.log", "--report-channel", "111"]))
+    assert cfg2.logs == ["/y.log"]
+    assert cfg2.report_channel == "111"
+
+
+def test_snowflake_age_positive() -> None:
+    # a snowflake created well before "now" → positive age
+    created_ms = 1700000000000  # 2023-ish
+    sid = str((created_ms - 1420070400000) << 22)
+    age = snowflake_age_s(sid, now_ms=created_ms + 60_000)
+    assert 59 < age < 61
+
+
+def test_render_summary_clean() -> None:
+    s = render_summary([], total=3, guild="g")
+    assert "新規 0" in s and "✅" in s
+
+
+def test_render_summary_with_anomaly_has_link_and_under_limit() -> None:
+    from scripts.fuzz.oracle import Anomaly
+
+    a = Anomaly("555", "THREAD_STUCK", "high", "stuck", "stuck", fields={"thread": "555"})
+    s = render_summary([a], total=1, guild="42")
+    assert len(s) <= 2000
+    assert "THREAD_STUCK" in s
+    assert "discord.com/channels/42/555" in s
+
+
+class _FakeClient:
+    def __init__(self, msgs):
+        self._msgs = msgs
+
+    def fetch_messages(self, channel_id, *, limit=50):
+        return self._msgs
+
+
+def _m(mid, *, author="bot", content="", webhook=False, reactions=None):
+    d = {"id": mid, "author": {"id": author}, "content": content}
+    if webhook:
+        d["webhook_id"] = "w"
+    if reactions:
+        d["reactions"] = [{"emoji": {"name": n}} for n in reactions]
+    return d
+
+
+def test_observe_thread_picks_trigger_with_status_and_latest_reply() -> None:
+    # newest-first: a clean bot reply, then the trigger (a webhook msg) carrying 🟢
+    msgs = [
+        _m("30", author="bot", content="here is your answer"),
+        _m("20", author="x", webhook=True, content="user question", reactions=["🟢"]),
+        _m("10", author="bot", content="-# 💻 status"),
+    ]
+    out = observe_thread(_FakeClient(msgs), "t", bot_id="bot", now_ms=4_000_000_000_000)
+    assert out is not None
+    reactions, reply, age = out
+    assert reactions == ["🟢"]
+    assert reply == "here is your answer"
+    assert age > 0
+
+
+def test_observe_thread_none_when_no_status_reaction() -> None:
+    out = observe_thread(_FakeClient([_m("1", content="hi")]), "t", bot_id="bot", now_ms=1e12)
+    assert out is None
+
+
+def test_run_logscan_only_writes_report(tmp_path: Path) -> None:
+    logf = tmp_path / "bot.log"
+    logf.write_text(
+        "2026-06-12 10:00:00 [INFO] ok\n"
+        "2026-06-12 10:00:01 [ERROR] c_lord.x: boom [thread=77]\n"
+        "Traceback (most recent call last):\n"
+        "ValueError: bad\n"
+    )
+    args = parse_args(
+        [
+            "--logs",
+            str(logf),
+            "--state-file",
+            str(tmp_path / "state.json"),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--no-report",
+        ]
+    )
+    cfg = build_config({}, args)  # no token → thread scan skipped
+    rc = run(cfg, args)
+    assert rc == 0
+    outs = list((tmp_path / "out").glob("*.json"))
+    assert outs, "a report json should be written"
+    import json
+
+    rep = json.loads(outs[0].read_text())
+    kinds = {a["kind"] for a in rep["anomalies"]}
+    assert {"LOG_ERROR", "LOG_TRACEBACK"} <= kinds
+
+
+def test_monitor_client_constructs() -> None:
+    MonitorClient("token")  # smoke: no network in ctor

--- a/tests/test_monitor_state.py
+++ b/tests/test_monitor_state.py
@@ -1,0 +1,45 @@
+"""Unit tests for scripts.monitor.state — incremental scan state (#404)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.monitor.state import MonitorState, load_state, read_new_log_text, save_state
+
+
+def test_state_roundtrip(tmp_path: Path) -> None:
+    p = tmp_path / "state.json"
+    save_state(p, MonitorState(offsets={"/a.log": 42}, seen=["fp1", "fp2"]))
+    s = load_state(p)
+    assert s.offsets == {"/a.log": 42}
+    assert s.seen_set == {"fp1", "fp2"}
+
+
+def test_load_missing_returns_empty(tmp_path: Path) -> None:
+    s = load_state(tmp_path / "nope.json")
+    assert s.offsets == {} and s.seen == []
+
+
+def test_read_new_from_offset(tmp_path: Path) -> None:
+    log = tmp_path / "bot.log"
+    log.write_text("line1\nline2\n")
+    first, off = read_new_log_text(log, 0)
+    assert first == "line1\nline2\n"
+    log.write_text("line1\nline2\nline3\n")
+    nxt, off2 = read_new_log_text(log, off)
+    assert nxt == "line3\n"
+    assert off2 > off
+
+
+def test_truncation_reads_from_start(tmp_path: Path) -> None:
+    log = tmp_path / "bot.log"
+    log.write_text("a much longer original content\n")
+    _, off = read_new_log_text(log, 0)
+    log.write_text("short\n")  # rotated/truncated: smaller than recorded offset
+    text, _ = read_new_log_text(log, off)
+    assert text == "short\n"
+
+
+def test_missing_file_is_empty(tmp_path: Path) -> None:
+    text, off = read_new_log_text(tmp_path / "absent.log", 99)
+    assert text == "" and off == 0

--- a/tests/test_monitor_threadscan.py
+++ b/tests/test_monitor_threadscan.py
@@ -1,0 +1,62 @@
+"""Unit tests for scripts.monitor.threadscan — live-thread health (#404)."""
+
+from __future__ import annotations
+
+from scripts.monitor.threadscan import detect_thread_anomalies
+
+
+def _d(**kw):
+    base = dict(
+        reactions=["🟡"],
+        latest_reply_text="all good",
+        trigger_age_s=30.0,
+        stuck_timeout_s=300.0,
+        thread_id="100",
+        source="#chan",
+    )
+    base.update(kw)
+    return detect_thread_anomalies(**base)
+
+
+def test_healthy_thread_no_anomaly() -> None:
+    assert _d() == []
+
+
+def test_stuck_running_past_timeout() -> None:
+    out = _d(reactions=["🟢"], latest_reply_text=None, trigger_age_s=600.0, stuck_timeout_s=300.0)
+    assert "THREAD_STUCK" in {a.kind for a in out}
+
+
+def test_running_but_within_timeout_is_ok() -> None:
+    out = _d(reactions=["🟢"], latest_reply_text=None, trigger_age_s=60.0, stuck_timeout_s=300.0)
+    assert out == []
+
+
+def test_running_and_waiting_not_stuck() -> None:
+    # both 🟢 and 🟡 present (finished) → not stuck even if old
+    out = _d(reactions=["🟢", "🟡"], trigger_age_s=9999.0)
+    assert "THREAD_STUCK" not in {a.kind for a in out}
+
+
+def test_error_reaction_flagged() -> None:
+    assert "ERROR_REACTION" in {a.kind for a in _d(reactions=["❌"])}
+
+
+def test_stall_reaction_flagged() -> None:
+    assert "STALL" in {a.kind for a in _d(reactions=["⚠️"])}
+
+
+def test_chrome_leak_in_reply() -> None:
+    assert "CHROME_LEAK" in {a.kind for a in _d(latest_reply_text="hi\nModel: x\nbye")}
+
+
+def test_traceback_leak_in_reply() -> None:
+    out = _d(latest_reply_text="oops\nTraceback (most recent call last):\n  File ...")
+    assert "EXCEPTION_LEAK" in {a.kind for a in out}
+
+
+def test_thread_id_and_source_recorded() -> None:
+    out = _d(reactions=["❌"], thread_id="555", source="#bugs")
+    a = next(x for x in out if x.kind == "ERROR_REACTION")
+    assert a.fields.get("thread") == "555"
+    assert a.fields.get("source") == "#bugs"


### PR DESCRIPTION
## 概要（利用者目線）

ファザー(#377)が**実バグを0件しか捉えなかった**ことを受けた方向A（診断は Issue #404 / memory）。
`scripts/monitor/` を追加 — **実トラフィック（bot ログ＋稼働スレッド）を定期スキャン**して異常を拾い、
報告する **read-only** ツール。合成入力を作らず、ユーザが既に生成している実シナリオを観測する。

運用者から見た変化:
- 監視チャンネルに「**新規異常 N 件**＋種別＋該当スレッド/ログ」が届く（NEW がある時だけ）。
- traceback は本文（exception 行）と発生スレッド（`[thread=]`）まで辿れる。
- prod + staging フリート全台を1本で監視。**read-only**（lease/注入/restart なし）で prod に当てても安全。

## これが効く証拠（最重要）

実 staging+prod ログを**1回スキャンしただけ**で、ファザー11回が見逃したものを検出（`docs/evidence/404/`）:
- `LOG_TRACEBACK | prod` = **未処理の `KeyError`**（`_run_helper.py:346 → tmux_runner.py:836 capture_pane`）
- `LOG_ERROR | prod` = `Error running Claude CLI`
- `LOG_ERROR | staging-4` = `Ignoring exception in command`

→ 実バグは text→reply ではなく **tmux イベント経路**に出る、という診断ど真ん中。

## Acceptance Criteria（#404 linked Issue）

- [x] `scripts/monitor/` が config（ログ群・チャンネル群・報告先）を読み**増分**スキャン（offset + seen を state に保持）
- [x] **ログ走査**: traceback / `[ERROR]` / identity mismatch を拾い `[thread=/session=]` を抽出（純パース・単体テスト）
- [x] **スレッド健全性走査**: 🟢のまま🟡無しで timeout 超過(stuck/hang)、❌、最新返信の chrome/traceback（fuzz oracle 再利用）
- [x] **NEW 異常のみ**（fingerprint dedup）を報告チャンネルへ + `docs/monitor-runs/<ts>.{json,md}`
- [x] **read-only**（lease 取得なし・注入なし・restart なし）
- [x] cron ラッパー + `docs/specs/monitor.md` + `.env.example` キー
- [x] `ruff`/`ruff format`/`pyright`/`pytest` 緑。pure logic 単体テスト

## Definition of Done checklist

- [x] **Issue の AC を全て本文にコピーしチェック**（上記）
- [x] **TDD evidence**: `tests/test_monitor_logscan.py` 等を先に書き RED（`ImportError: scan_log_text`）→ 実装で GREEN
- [x] **Detection bug fixture rule**: 該当なし（TUI prompt 検出関数は未変更）
- [x] **`pytest`+`ruff`+`format`+`pyright` 緑**（monitor 28 + fuzz 63 = 91 passed / pyright 0 errors）
- [x] **Staging behavior verified**: 下記 Staging Evidence に実 staging+prod ログのライブスキャンと検出結果。成果物 `docs/evidence/404/`
- [x] **動きを変えたら「あるべき動き」も更新**: `docs/specs/monitor.md`（新規）にあるべき動きを記載
- [x] **No unrelated changes**: diff は monitor 関連のみ（self-review 済み、16 files / +1120）
- [x] **Closes gating**: 全 AC をライブ実機で達成 → `Closes #404`（下記独立行）

## Staging Evidence

```
$ python -m scripts.monitor --dry-run \
    --logs '/tmp/clord-bot-c-lord-staging-1..4.log,/tmp/clord-bot-c-lord.log'
[monitor] log scan: 5 file(s) → 4 log anomaly(ies)
by kind: {'LOG_ERROR': 3, 'LOG_TRACEBACK': 1}
- LOG_TRACEBACK | prod | thread=...  KeyError  (_run_helper.py:346 → tmux_runner.py:836 capture_pane)
- LOG_ERROR     | prod | _run_helper: Error running Claude CLI
- LOG_ERROR     | staging-4 | discord.ext.commands.bot: Ignoring exception in command None
```

`docs/evidence/404/first-scan.md` に traceback の生ブロックを収録。

## Out of scope（別 Issue）

- **B**: 対話フロー能動駆動（ボタン/permission/restart resume）+ tmuxペインvs Discord 視覚差分 + LLM/vision オラクル。
- bot 内 Cog のリアルタイム enrichment。
- `[ERROR]` の良性ノイズに対する学習的重要度フィルタ。

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
