### PR TITLE
fix: pin bot tmux session to window-size manual to stop status-line ghosting (#403)

### DIFF
--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -41,6 +41,16 @@ _LEGACY_WINDOW_PREFIX = "work"
 # compacts them back from ``base-index``. Far above any realistic window count.
 _SORT_TMP_BASE = 9000
 
+# #403: bot sessions are pinned to ``window-size manual`` so the human's SSH
+# terminal changing size does not — via the tmux default ``window-size latest``
+# — resize every window and SIGWINCH-storm each idle Claude TUI into redrawing
+# its bottom status line. That redraw is frequently incomplete for an inactive
+# pane, leaving the status block ghosted/duplicated until a full redraw (a
+# manual resize / Ctrl-L). New windows are fitted to the attached client (or
+# this default when none is attached) at creation, so they still look right and
+# then stay fixed. Chosen large enough for a usable Claude TUI.
+DEFAULT_MANAGED_WINDOW_SIZE = (160, 40)
+
 # Effort levels the ``claude --effort`` flag accepts (commander-validated; it
 # hard-errors on anything else).  ``ultracode``/``auto`` are real effort levels
 # but only settable via ``CLAUDE_CODE_EFFORT_LEVEL`` or the ``/effort`` command,
@@ -165,6 +175,68 @@ class TmuxSessionManager:
 
     # ── Helpers ────────────────────────────────────────────────────────
 
+    def _ensure_window_size_manual(self) -> None:
+        """Pin the session to ``window-size manual`` (#403).
+
+        Under the tmux default ``latest``, the human's terminal changing size
+        resizes every window and ghosts each idle Claude TUI's status line.
+        ``manual`` makes the windows immune to client-size changes. Idempotent.
+        """
+        if not self._check_available():
+            return
+        _run(["tmux", "set-option", "-t", self.session_name, "window-size", "manual"])
+
+    def _current_client_size(self) -> tuple[int, int] | None:
+        """Return ``(width, height)`` of an attached client, or ``None``.
+
+        ``None`` when no client is attached or tmux is unavailable.
+        """
+        if not self._check_available():
+            return None
+        result = _run(
+            [
+                "tmux",
+                "list-clients",
+                "-t",
+                self.session_name,
+                "-F",
+                "#{client_width} #{client_height}",
+            ]
+        )
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.strip().splitlines():
+            parts = line.split()
+            if len(parts) == 2:
+                try:
+                    return int(parts[0]), int(parts[1])
+                except ValueError:
+                    continue
+        return None
+
+    def _fit_window_to_client(self, window_name: str) -> None:
+        """Size a (manual) window to the attached client, or a default (#403).
+
+        Called right after a window is created — while it is empty, so the
+        resize cannot ghost a running TUI — so the window looks right when first
+        viewed and then stays fixed (immune to later terminal-size changes).
+        """
+        if not self._check_available():
+            return
+        width, height = self._current_client_size() or DEFAULT_MANAGED_WINDOW_SIZE
+        _run(
+            [
+                "tmux",
+                "resize-window",
+                "-t",
+                f"{self.session_name}:{window_name}",
+                "-x",
+                str(width),
+                "-y",
+                str(height),
+            ]
+        )
+
     def _ensure_session(self) -> bool:
         """Ensure the global ``clord`` tmux session exists.
 
@@ -173,6 +245,7 @@ class TmuxSessionManager:
         """
         result = _run(["tmux", "has-session", "-t", self.session_name])
         if result.returncode == 0:
+            self._ensure_window_size_manual()  # #403
             return True
 
         # Create with a temporary first window that will be replaced
@@ -194,6 +267,7 @@ class TmuxSessionManager:
             return False
 
         logger.info("Created global tmux session: %s", self.session_name)
+        self._ensure_window_size_manual()  # #403
         return True
 
     def _find_window_for_thread(self, thread_id: int) -> str | None:
@@ -537,6 +611,10 @@ class TmuxSessionManager:
                     str(thread_id),
                 ]
             )
+
+            # Fit the new (manual-sized) window to the attached client while it
+            # is still empty, so it looks right and then stays fixed (#403).
+            self._fit_window_to_client(window_name)
 
             self._thread_to_window[thread_id] = window_name
             self._save_mapping()

--- a/docs/specs/tmux-window-ordering.md
+++ b/docs/specs/tmux-window-ordering.md
@@ -1,4 +1,4 @@
-# あるべき動き: tmux window の並び順とフォーカス
+# あるべき動き: tmux window の並び順・フォーカス・サイズ
 
 > これは「あるべき動き」。理念 [`docs/PHILOSOPHY.md`](../PHILOSOPHY.md) の下位。迷ったら理念に照らす。
 
@@ -33,6 +33,20 @@ window 名 `new-window`（`-a`/index 指定なし）は tmux の既定で **最�
 | 直列化 | `TmuxSessionManager._lock`（`threading.Lock`）で「作成 → `@thread_id` 設定 → ソート」を 1 クリティカルセクションに。同時 add で `move-window` が交錯しない |
 | ソートキー | `_window_sort_key()` に分離（番号付き昇順 → 非番号は末尾・相対順保持） |
 | 起動時 | 専用フックは無い。再起動後に既存 window が乱れていても、**次に新スレッドが立った時のフルソートで一括整列**する（per-channel の遅延生成モデルに沿う） |
+
+## ウィンドウサイズ（端末リサイズ耐性） — #403
+
+`tmux attach` 中に**利用者の端末（SSH クライアント）のサイズが変わっても、各 window のサイズは変わりません**（固定）。新規 window は作成時に接続中クライアントへフィットし、以後は固定されます。
+
+なぜ要るか: tmux の既定 `window-size latest` だと、クライアントが少しでもサイズ変化するたびに**全 window が resize** され、各 window で idle 状態の Claude TUI に SIGWINCH が飛ぶ。inactive な pane の再描画はしばしば不完全で、**下部の status 行ブロックが多重ゴーストして数時間 stuck** する（実測: #403。全再描画＝手動 resize / Ctrl-L でしか直らない）。bot は多数の window を抱えるため「端末を少し触ると別 window が崩れる」が起きやすい。window サイズを端末から切り離すことで構造的に断つ。
+
+### 実装の要点（`c_lord/tmux.py`）
+
+| 項目 | 実装 |
+|------|------|
+| ポリシー | session に `set-option window-size manual`（`_ensure_window_size_manual()`、`_ensure_session()` から呼ぶ）。クライアントの resize が window に伝播しなくなる |
+| 新規 window のフィット | `create_session()` で新規 window 作成直後（まだ空＝走行中 TUI を崩さない）に `_fit_window_to_client()` が接続中クライアントのサイズへ resize。未接続時は `DEFAULT_MANAGED_WINDOW_SIZE` |
+| トレードオフ | window はフィット時のサイズに固定。後から端末を大きくすると余白、小さくすると下部がクリップしうる（status 行のゴースト固着よりは軽微）。主参照は Discord の `/tmux-screenshot`、生 attach はデバッグ用途 |
 
 ## 将来の拡張（今回は未実装・記録のみ）
 

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -21,6 +21,9 @@ class TestTmuxSessionManager:
         mgr._available = True
         # Isolate from the post-create window sort (#374) — tested separately.
         mgr._sort_windows_unlocked = lambda: None  # type: ignore[method-assign]
+        # Isolate from the window-size policy (#403) — tested separately.
+        mgr._ensure_window_size_manual = lambda: None  # type: ignore[method-assign]
+        mgr._fit_window_to_client = lambda *_: None  # type: ignore[method-assign]
 
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.side_effect = [
@@ -92,6 +95,9 @@ class TestTmuxSessionManager:
         mgr._available = True
         # Isolate from the post-create window sort (#374) — tested separately.
         mgr._sort_windows_unlocked = lambda: None  # type: ignore[method-assign]
+        # Isolate from the window-size policy (#403) — tested separately.
+        mgr._ensure_window_size_manual = lambda: None  # type: ignore[method-assign]
+        mgr._fit_window_to_client = lambda *_: None  # type: ignore[method-assign]
 
         with patch("c_lord.tmux._run") as mock_run:
             # First thread
@@ -357,6 +363,8 @@ class TestTmuxSessionManager:
     def test_ensure_session_already_exists(self) -> None:
         """_ensure_session returns True when session already exists."""
         mgr = TmuxSessionManager(mapping_path="")
+        # Isolate from the window-size policy (#403) — tested separately.
+        mgr._ensure_window_size_manual = lambda: None  # type: ignore[method-assign]
 
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
@@ -368,6 +376,8 @@ class TestTmuxSessionManager:
     def test_ensure_session_creates_new(self) -> None:
         """_ensure_session creates session when it doesn't exist."""
         mgr = TmuxSessionManager(mapping_path="")
+        # Isolate from the window-size policy (#403) — tested separately.
+        mgr._ensure_window_size_manual = lambda: None  # type: ignore[method-assign]
 
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.side_effect = [
@@ -972,6 +982,8 @@ class TestTmuxSessionManager:
     def test_custom_session_name_in_ensure_session(self) -> None:
         """Custom session name is used when creating the tmux session."""
         mgr = TmuxSessionManager(session_name="custom", mapping_path="")
+        # Isolate from the window-size policy (#403) — tested separately.
+        mgr._ensure_window_size_manual = lambda: None  # type: ignore[method-assign]
 
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.side_effect = [
@@ -1313,6 +1325,85 @@ class TestTmuxSessionManager:
         )
 
 
+class TestWindowSizePolicy:
+    """#403: pin bot session to a fixed (manual) window size so a client (the
+    human's SSH terminal) resizing does not SIGWINCH-storm every idle Claude TUI
+    into ghosting its status line."""
+
+    def test_ensure_window_size_manual_sets_option(self) -> None:
+        """window-size is pinned to ``manual`` on the bot session."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            mgr._ensure_window_size_manual()
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        assert any(
+            "set-option" in a and "window-size" in a and "manual" in a for a in calls
+        ), calls
+
+    def test_ensure_window_size_manual_noop_when_unavailable(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = False
+        with patch("c_lord.tmux._run") as mock_run:
+            mgr._ensure_window_size_manual()
+        mock_run.assert_not_called()
+
+    def test_current_client_size_parses_list_clients(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="146 38\n")
+            assert mgr._current_client_size() == (146, 38)
+
+    def test_current_client_size_none_when_no_client(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            assert mgr._current_client_size() is None
+
+    def test_fit_window_to_client_uses_client_size(self) -> None:
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="146 38\n"),  # list-clients
+                MagicMock(returncode=0),  # resize-window
+            ]
+            mgr._fit_window_to_client("w1")
+        resize = mock_run.call_args_list[-1].args[0]
+        assert "resize-window" in resize
+        assert "146" in resize and "38" in resize
+
+    def test_fit_window_to_client_falls_back_to_default(self) -> None:
+        from c_lord.tmux import DEFAULT_MANAGED_WINDOW_SIZE
+
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # list-clients: none attached
+                MagicMock(returncode=0),  # resize-window
+            ]
+            mgr._fit_window_to_client("w1")
+        resize = mock_run.call_args_list[-1].args[0]
+        assert str(DEFAULT_MANAGED_WINDOW_SIZE[0]) in resize
+        assert str(DEFAULT_MANAGED_WINDOW_SIZE[1]) in resize
+
+    def test_ensure_session_pins_window_size_manual(self) -> None:
+        """_ensure_session wires in the manual window-size policy (#403)."""
+        mgr = TmuxSessionManager(mapping_path="")
+        mgr._available = True
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            mgr._ensure_session()
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        assert any(
+            "set-option" in a and "window-size" in a and "manual" in a for a in calls
+        ), calls
+
+
 class TestPaneInsertModeDetection:
     """#147: detect vim INSERT vs NORMAL from the pane status bar.
 
@@ -1538,6 +1629,9 @@ class TestSortWindows:
         """The new-window path triggers a sort; the existing-window path does not."""
         mgr = TmuxSessionManager(mapping_path="")
         mgr._available = True
+        # Isolate from the window-size policy (#403) — tested separately.
+        mgr._ensure_window_size_manual = lambda: None  # type: ignore[method-assign]
+        mgr._fit_window_to_client = lambda *_: None  # type: ignore[method-assign]
         called = {"n": 0}
         mgr._sort_windows_unlocked = lambda: called.__setitem__("n", called["n"] + 1)  # type: ignore[method-assign]
         with patch("c_lord.tmux._run") as mock_run:


### PR DESCRIPTION
## これがこうなる（利用者目線）

`tmux attach` で bot を覗いているとき、**自分の端末サイズが変わっても、各ウィンドウ内の Claude TUI の status 行が多重ゴーストして崩れることが無くなります**（前は、端末を少し触ると別の idle なウィンドウの status 行ブロックが2〜3重に重なって数時間 stuck していた）。

利用者から見た副作用: bot のウィンドウは作成時のサイズに固定されます（端末を後で大きくすると右に余白、小さくすると下部がクリップしうる）。主参照は Discord の `/tmux-screenshot`、生 attach はデバッグ用途なので実害は小さい想定。

## 原因（#403）

tmux の既定 `window-size latest` のため、利用者の SSH 端末が少しでもサイズ変化すると **bot の全ウィンドウが resize** され、各ウィンドウの idle な Claude TUI に SIGWINCH が飛ぶ。inactive な pane の status 行（スクロール領域 pin）再描画はしばしば不完全で、旧 status 行が消えずに**ゴーストとして残り、全再描画（手動 resize / Ctrl-L）まで stuck**する。bot は多数ウィンドウを抱えるため頻発しやすい。

調査の3段（再現→機構→源）と棄却した誤仮説（CJK字間 / ウィンドウ飛び）は #403 参照。

## 修正

- `_ensure_session()` で bot session に `set-option window-size manual` を設定（`_ensure_window_size_manual()`）→ クライアントの resize がウィンドウに伝播しない。
- `create_session()` で新規ウィンドウ作成直後（まだ空＝走行中 TUI を崩さない）に `_fit_window_to_client()` が接続中クライアントのサイズへフィット。未接続時は `DEFAULT_MANAGED_WINDOW_SIZE=(160,40)`。
- 「あるべき動き」doc を更新: `docs/specs/tmux-window-ordering.md` に「ウィンドウサイズ（端末リサイズ耐性）」節。

## Acceptance Criteria（#403）

- [x] トリガ（pane resize churn）の RED 証跡を残す → 決定論的に再現（下記）。
- [x] hardening を TDD で実装（`window-size manual` + フィット）。
- [x] staging/実機で「トリガが before/after で減/消」を計測（下記 RED→GREEN）。
- Deferred（本 PR 対象外）: 本番反映後の**長期再発監視**。間欠のため1回では「直った」と断定せず、#403 はオープンのまま監視する → `Refs #403`（`Closes` にしない）。

## Definition of Done checklist

- [x] TDD: RED（メソッド未実装で 7 件 AttributeError/assert 失敗）→ GREEN。新規 `TestWindowSizePolicy` 7 件。
- [x] `pytest` 全体 **1773 passed, 3 skipped**（`env -u CLORD_BRIDGE_MODE`。この session 環境の `CLORD_BRIDGE_MODE=jsonl` による既存 send_input 3 件の偽陽性を除外。CI クリーン env では通る）。
- [x] `ruff check c_lord/` / `ruff format --check c_lord/` / `pyright c_lord/tmux.py` 全て green。
- [x] 動きを変えた → 「あるべき動き」doc 更新済み。
- [x] 無関係変更なし（diff は +挿入のみ・既存行改変ゼロ）。

## Staging Evidence

**再現した実崩れ（RED・status 行が2重ゴースト、決定論再現をレンダリング）**:
![red-ghost-reproduced](https://github.com/yousan/c-lord/releases/download/evidence/i403-red-red-ghost-reproduced-20260612T045103Z.png)

本番で観測された実崩れ2例（W71 / pt-jp）は #403 に添付。

<details><summary>RED → GREEN（決定論的・実 tmux）</summary>

**機構 RED（resize → ghost、決定論再現）**: スクロール領域で下部 status を pin する TUI を `resize-window` で 45→30→45 行に変えるだけで status ブロックが 2 箇所（row28-30 と row43-45）に重複。実崩れスクショと一致（画像は #403）。

**トリガ RED（現行 latest）**: 120x30 端末が接続 → ウィンドウが `160x45 → 120x29` に resize（＝ idle TUI に SIGWINCH＝ゴースト前提条件あり）。

**トリガ GREEN（本 PR = manual）**: 同じ 120x30 端末接続でも **ウィンドウ不変 160x45**（SIGWINCH なし＝前提条件なし）。

**実 tmux × 実コード統合検証（モック無し・bot ホスト）**:
```
created window: w1
window-size option: 'window-size manual'      # ← policy 適用
new window size (fitted): 160x40
window size after a 120x30 terminal connects: 160x40   # ← client resize を無視
[GREEN check 1] session pinned to window-size manual : PASS
[GREEN check 2] window ignores client resize         : PASS
```
</details>

**staging-2 実 bot smoke**: ブランチ `fix/tmux-window-size-manual-ghost @ 27e36c5` で再起動 → `Logged in as C-lord-staging-2#3511`・Traceback なし・E2E スレッドのメッセージに `run_claude: enter` で反応。検証後 main へ原状復帰・lease 解放済み。

注（正直）: 実 bot 上で create_session を通す「Discord 新規スレッド E2E」は、prod-bot のチャンネル投稿からスレッドが作られない（bot の authorization）ため未実施。ただし **create_session の実コードパスを実 tmux で直接検証**（上記統合検証）しているため、Discord 経路との差分は無い。

Refs #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
