### PR TITLE
fix: multiSelect の AskUserQuestion を Discord から確定できるようにする (#418)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -1340,6 +1340,48 @@ class TmuxClaudeRunner:
         )
         await self._navigate_menu(index)
 
+    async def answer_menu_multi(self, indices: list[int], option_count: int) -> None:
+        """Answer a multiSelect AskUserQuestion: toggle each option then Submit (#418).
+
+        ``answer_menu`` (Down×index + Enter) is single-select only, so the bridge
+        used to drop every checkbox but the first.  The multiSelect TUI, verified
+        on a live Claude Code TUI, works differently:
+
+        - the cursor starts on option 0;
+        - **Space** toggles the checkbox under the cursor (``[ ]`` ⇄ ``[✔]``);
+        - a **"Submit"** row sits just past the real options and the
+          "Type something" affordance, i.e. at index ``option_count + 1``
+          (mirroring the ``option_count`` index :meth:`answer_menu_text` uses for
+          the "Type something" row); ``Down`` to it and ``Enter`` opens the
+          "Submit answers" review screen whose cursor defaults to submit, so a
+          final ``Enter`` records every toggled value.
+
+        Keys are sent one-per-call with ``_MENU_NAV_DELAY`` spacing — batching is
+        dropped by the TUI (#171).
+        """
+        logger.info(
+            "Answering multiSelect AskUserQuestion menu: indices=%s (thread=%d)",
+            indices,
+            self._thread_id,
+        )
+        cursor = 0
+        for idx in sorted({i for i in indices if i >= 0}):
+            for _ in range(idx - cursor):
+                await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Down")
+                await asyncio.sleep(_MENU_NAV_DELAY)
+            cursor = idx
+            await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Space")
+            await asyncio.sleep(_MENU_NAV_DELAY)
+        # Navigate to the "Submit" row (one past "Type something") and open the
+        # "Submit answers" review screen.
+        for _ in range(max(0, (option_count + 1) - cursor)):
+            await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Down")
+            await asyncio.sleep(_MENU_NAV_DELAY)
+        await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Enter")
+        await asyncio.sleep(_MENU_NAV_DELAY)
+        # Confirm the review screen (cursor defaults to "Submit answers").
+        await asyncio.to_thread(self._tmux.send_keys, self._thread_id, "Enter")
+
     async def answer_menu_text(self, text_option_index: int, text: str) -> None:
         """Answer via the free-text ("Type something.") affordance (#172).
 

--- a/c_lord/discord_ui/ask_handler.py
+++ b/c_lord/discord_ui/ask_handler.py
@@ -134,14 +134,18 @@ async def bridge_pane_ask(
         await runner.cancel_menu()
         return
 
-    label = selected[0]
     labels = [opt.label for opt in question.options]
-    if label in labels:
-        await runner.answer_menu(labels.index(label))
+    indices = [labels.index(s) for s in selected if s in labels]
+    if question.multi_select and indices:
+        # multiSelect: toggle every chosen option and Submit (#418).  Using
+        # answer_menu (single-select) here dropped all but selected[0].
+        await runner.answer_menu_multi(indices, len(question.options))
+    elif selected[0] in labels:
+        await runner.answer_menu(labels.index(selected[0]))
     else:
         # Free text from the "Other" modal → use the "Type something." option,
         # which the TUI numbers immediately after the real options.
-        await runner.answer_menu_text(len(question.options), label)
+        await runner.answer_menu_text(len(question.options), selected[0])
 
 
 async def collect_ask_answers(

--- a/c_lord/discord_ui/ask_view.py
+++ b/c_lord/discord_ui/ask_view.py
@@ -73,6 +73,10 @@ class AskView(discord.ui.View):
         self._thread_id = thread_id
         self._bus = bus if bus is not None else _default_ask_bus
         self._ask_repo = ask_repo
+        # multiSelect records the choice in the Select and submits via the
+        # ✅ confirm button (#418); single-select delivers immediately.
+        self._multi_select = question.multi_select
+        self._selected_values: list[str] = []
 
         options = question.options
         use_select = question.multi_select or len(options) > 4
@@ -93,7 +97,9 @@ class AskView(discord.ui.View):
                 ],
                 custom_id=f"ask_{thread_id}_{q_idx}_select",
             )
-            select.callback = self._select_callback
+            select.callback = (
+                self._multi_select_record if question.multi_select else self._select_callback
+            )
             self.add_item(select)
         elif options:
             for i, opt in enumerate(options[:4]):
@@ -105,6 +111,19 @@ class AskView(discord.ui.View):
                 )
                 btn.callback = _make_button_callback(self, opt.label)
                 self.add_item(btn)
+
+        # multiSelect needs an explicit submit affordance — the Select only
+        # records the choice, so without this button the user has no way to
+        # confirm (Discord's dismiss-to-submit is undiscoverable) (#418).
+        if question.multi_select and options:
+            confirm_btn = discord.ui.Button(
+                label="✅ 確定",
+                style=discord.ButtonStyle.success,
+                custom_id=f"ask_{thread_id}_{q_idx}_confirm",
+                row=1,
+            )
+            confirm_btn.callback = self._confirm_callback
+            self.add_item(confirm_btn)
 
         # Plan-approval menus (#251) suppress the free-text affordance: their
         # "Tell Claude what to change" option is selected like any other (and
@@ -152,6 +171,25 @@ class AskView(discord.ui.View):
     async def _select_callback(self, interaction: discord.Interaction) -> None:
         values: list[str] = interaction.data.get("values", [])  # type: ignore[union-attr]
         await self._deliver(interaction, values)
+
+    async def _multi_select_record(self, interaction: discord.Interaction) -> None:
+        """Record a multiSelect choice WITHOUT delivering — the user submits via
+        the ✅ confirm button (#418).  Echo the running selection so it is clear
+        what will be sent."""
+        self._selected_values = interaction.data.get("values", [])  # type: ignore[union-attr]
+        chosen = ", ".join(self._selected_values) or "（未選択）"
+        await interaction.response.edit_message(
+            content=f"-# 🔲 選択中: {chosen} — 「✅ 確定」で送信",
+        )
+
+    async def _confirm_callback(self, interaction: discord.Interaction) -> None:
+        """Deliver the recorded multiSelect choice when ✅ 確定 is pressed (#418)."""
+        if not self._selected_values:
+            await interaction.response.send_message(
+                "1つ以上選択してから「✅ 確定」を押してください。", ephemeral=True
+            )
+            return
+        await self._deliver(interaction, self._selected_values)
 
     async def _other_callback(self, interaction: discord.Interaction) -> None:
         modal = AskModal(title="Your answer")

--- a/docs/askuserquestion-bridge.md
+++ b/docs/askuserquestion-bridge.md
@@ -78,8 +78,15 @@ C案 — いったん保留
   legend in the embed body (Discord buttons cannot show descriptions) (#169).
 - **≥ 5 options, or multi-select** → a Discord **select menu**, which shows
   each option's description in its dropdown; no body legend is added.
+- **multi-select** additionally gets an explicit **`✅ 確定` (confirm) button**
+  (#418): the select only *records* the choice, the button *submits* it. Without
+  it the only way to submit was Discord's dismiss-the-dropdown gesture, which is
+  undiscoverable — users reported "no way to confirm after picking". Single-select
+  keeps immediate delivery (one pick = done, no confirm button).
 
 ## How a click is answered
+
+(Single-select. For multi-select see the next section.)
 
 The menu is still open in the pane and the cursor starts on the first option.
 On a button click c-lord computes the chosen option's 0-based index and calls
@@ -97,6 +104,27 @@ verified with the bot's actual `answer_menu` selecting the intended option.
 
 While the bridge waits for the click, the runner is suspended at its `yield`,
 so the pane is not re-polled and the menu is not re-detected (natural dedup).
+
+## How a multi-select is answered (#418)
+
+`answer_menu(index)` is single-select only — it sends `Down×index + Enter`, so a
+multi-select click used to deliver only `selected[0]` and drop every other pick.
+A multi-select question is now answered with `TmuxClaudeRunner.answer_menu_multi`,
+which mirrors the native TUI's keyboard model (verified on a live Claude Code TUI):
+
+```
+for each chosen option (ascending):
+    Down (×offset)   then   Space      # Space toggles the checkbox  [ ] ⇄ [✔]
+Down (× to reach the "Submit" row at option_count + 1)   then   Enter   # → review screen
+Enter                                  # confirm "Submit answers" (cursor defaults to it)
+```
+
+The `Submit` row sits one past the `Type something` meta-row (`option_count + 1`).
+Reaching it + `Enter` opens the "Submit answers" review screen, whose cursor
+defaults to submit, so a final `Enter` records **every** toggled value. Keys are
+spaced by `_MENU_NAV_DELAY` (#171). Free text from `✏️ Other` in a multi-select
+question still goes through the single free-text path below (Other yields one
+typed string, not toggled options).
 
 ## How free text (`✏️ Other`) is answered (#172)
 
@@ -149,5 +177,6 @@ needed.
 | Detect & yield `pane_ask` event | `tmux_runner.py::run` (poll loop) |
 | Show buttons / route answer | `c_lord/discord_ui/ask_handler.py::bridge_pane_ask` |
 | Buttons & legend | `c_lord/discord_ui/ask_view.py`, `embeds.py::ask_embed` |
-| Send selection keystrokes | `tmux_runner.py::answer_menu` / `answer_menu_text` |
+| Send selection keystrokes | `tmux_runner.py::answer_menu` / `answer_menu_multi` (#418) / `answer_menu_text` |
+| Multi-select confirm button | `ask_view.py::AskView` (`_multi_select_record` + `_confirm_callback`, #418) |
 | Regression fixtures | `tests/fixtures/panes/ask_user_question_*.txt` |

--- a/tests/test_ask_feature.py
+++ b/tests/test_ask_feature.py
@@ -8,6 +8,8 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from c_lord.claude.types import AskOption, AskQuestion, ToolCategory, _parse_ask_questions
@@ -276,3 +278,97 @@ class TestAskViewOtherGating:
             allow_other=False,
         )
         assert self._other_button_ids(q) == []
+
+
+class TestAskViewMultiSelectConfirm:
+    """#418: a multiSelect question needs an explicit ✅ confirm button — the
+    Select records the choice, the button submits it (single-select stays
+    immediate, with no confirm button)."""
+
+    @staticmethod
+    def _confirm_button_ids(q: AskQuestion) -> list[str]:
+        from c_lord.discord_ui.ask_view import AskView
+
+        view = AskView(q, thread_id=123, q_idx=0)
+        return [
+            cid
+            for c in view.children
+            if (cid := getattr(c, "custom_id", "")) and cid.endswith("_confirm")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_confirm_button_present_for_multi_select(self) -> None:
+        q = AskQuestion(
+            question="pick many",
+            options=[AskOption(label="A"), AskOption(label="B"), AskOption(label="C")],
+            multi_select=True,
+        )
+        assert self._confirm_button_ids(q), "multiSelect must expose a ✅ confirm button"
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_button_for_single_select(self) -> None:
+        q = AskQuestion(
+            question="pick one",
+            options=[AskOption(label="A"), AskOption(label="B")],
+        )
+        assert q.multi_select is False
+        assert self._confirm_button_ids(q) == []
+
+    @pytest.mark.asyncio
+    async def test_select_records_only_confirm_delivers_all(self) -> None:
+        """Selecting in the dropdown records (does NOT deliver); pressing ✅
+        confirm delivers every recorded value to the bus."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from c_lord.discord_ui.ask_bus import ask_bus
+        from c_lord.discord_ui.ask_view import AskView
+
+        tid = 418_0010
+        q = AskQuestion(
+            question="pick",
+            options=[AskOption(label="A"), AskOption(label="B"), AskOption(label="C")],
+            multi_select=True,
+        )
+        view = AskView(q, thread_id=tid, q_idx=0)
+        queue = ask_bus.register(tid)
+        try:
+            # 1) Select fires — must record only, not deliver.
+            sel = MagicMock()
+            sel.data = {"values": ["A", "C"]}
+            sel.response.edit_message = AsyncMock()
+            await view._multi_select_record(sel)
+            assert queue.empty(), "selection must not deliver before confirm"
+
+            # 2) Confirm button delivers all recorded values.
+            conf = MagicMock()
+            conf.response.edit_message = AsyncMock()
+            await view._confirm_callback(conf)
+            delivered = await asyncio.wait_for(queue.get(), timeout=1.0)
+            assert delivered == ["A", "C"]
+        finally:
+            ask_bus.unregister(tid)
+
+    @pytest.mark.asyncio
+    async def test_confirm_without_selection_errors_and_does_not_deliver(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from c_lord.discord_ui.ask_bus import ask_bus
+        from c_lord.discord_ui.ask_view import AskView
+
+        tid = 418_0011
+        q = AskQuestion(
+            question="pick",
+            options=[AskOption(label="A"), AskOption(label="B")],
+            multi_select=True,
+        )
+        view = AskView(q, thread_id=tid, q_idx=0)
+        queue = ask_bus.register(tid)
+        try:
+            conf = MagicMock()
+            conf.response.send_message = AsyncMock()
+            conf.response.edit_message = AsyncMock()
+            await view._confirm_callback(conf)
+            conf.response.send_message.assert_awaited()  # ephemeral "select first"
+            assert queue.empty()
+        finally:
+            ask_bus.unregister(tid)

--- a/tests/test_ask_handler.py
+++ b/tests/test_ask_handler.py
@@ -27,6 +27,15 @@ def _question() -> AskQuestion:
     )
 
 
+def _multi_question() -> AskQuestion:
+    return AskQuestion(
+        question="which envs?",
+        header="env",
+        options=[AskOption("A1", "one"), AskOption("A2", "two"), AskOption("A3", "three")],
+        multi_select=True,
+    )
+
+
 def _thread(thread_id: int) -> tuple[MagicMock, MagicMock]:
     thread = MagicMock()
     thread.id = thread_id
@@ -93,3 +102,60 @@ async def test_discord_click_still_answers_menu(monkeypatch):
     # Option index 1 (A2) selected via keystrokes.
     runner.answer_menu.assert_awaited_once_with(1)
     runner.cancel_menu.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multi_select_click_toggles_all_options(monkeypatch):
+    """#418: a multiSelect click delivers ALL selected labels to the TUI via
+    answer_menu_multi — not just selected[0] (which dropped every choice but
+    the first).
+    """
+    monkeypatch.setattr(ask_handler, "_PANE_RESOLVE_POLL", 0.01)
+    monkeypatch.setattr(ask_handler, "_PANE_RESOLVE_MISSES", 2)
+    thread, _msg = _thread(418_0001)
+    runner = MagicMock()
+    runner.peek_pending_ask = AsyncMock(return_value=_multi_question())
+    runner.answer_menu = AsyncMock()
+    runner.answer_menu_multi = AsyncMock()
+    runner.answer_menu_text = AsyncMock()
+    runner.cancel_menu = AsyncMock()
+
+    async def _click_soon():
+        await asyncio.sleep(0.05)
+        ask_bus.post_answer(thread.id, ["A1", "A3"])
+
+    await asyncio.gather(
+        asyncio.wait_for(bridge_pane_ask(thread, _multi_question(), runner), timeout=3.0),
+        _click_soon(),
+    )
+    # All selected options (indices 0 and 2) toggled, with the option count (3)
+    # so the runner can locate the Submit row.
+    runner.answer_menu_multi.assert_awaited_once_with([0, 2], 3)
+    runner.answer_menu.assert_not_called()
+    runner.cancel_menu.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multi_select_other_freetext_uses_text_path(monkeypatch):
+    """#418: free text from ✏️ Other in a multiSelect question still goes through
+    the single free-text path (Other yields one typed string, not options)."""
+    monkeypatch.setattr(ask_handler, "_PANE_RESOLVE_POLL", 0.01)
+    monkeypatch.setattr(ask_handler, "_PANE_RESOLVE_MISSES", 2)
+    thread, _msg = _thread(418_0002)
+    runner = MagicMock()
+    runner.peek_pending_ask = AsyncMock(return_value=_multi_question())
+    runner.answer_menu = AsyncMock()
+    runner.answer_menu_multi = AsyncMock()
+    runner.answer_menu_text = AsyncMock()
+    runner.cancel_menu = AsyncMock()
+
+    async def _click_soon():
+        await asyncio.sleep(0.05)
+        ask_bus.post_answer(thread.id, ["something custom"])
+
+    await asyncio.gather(
+        asyncio.wait_for(bridge_pane_ask(thread, _multi_question(), runner), timeout=3.0),
+        _click_soon(),
+    )
+    runner.answer_menu_text.assert_awaited_once_with(3, "something custom")
+    runner.answer_menu_multi.assert_not_called()

--- a/tests/test_tmux_runner.py
+++ b/tests/test_tmux_runner.py
@@ -2537,6 +2537,53 @@ class TestRunYieldsPaneAsk:
         tmux_manager.send_keys.assert_called_once_with(12345, "Enter")
 
     @pytest.mark.asyncio
+    async def test_answer_menu_multi_toggles_each_then_submits(self, runner, tmux_manager) -> None:
+        """#418: multiSelect — Space-toggle each selected option, then navigate to
+        the 'Submit' row (option_count+1, just past 'Type something') and Enter to
+        open the review screen, then a final Enter confirms 'Submit answers'.
+
+        Verified on a live Claude Code TUI: Space toggles the checkbox under the
+        cursor; the 'Submit' row sits one below the 'Type something' affordance
+        (index option_count+1); reaching it + Enter opens the 'Submit answers'
+        review screen whose cursor defaults to submit, so a bare Enter records
+        every toggled value.
+        """
+        from unittest.mock import call
+
+        with patch("c_lord.claude.tmux_runner._MENU_NAV_DELAY", 0.0):
+            await runner.answer_menu_multi([0, 2], 4)
+        assert tmux_manager.send_keys.call_args_list == [
+            call(12345, "Space"),  # toggle option 0 (cursor starts here)
+            call(12345, "Down"),
+            call(12345, "Down"),
+            call(12345, "Space"),  # to option 2, toggle
+            call(12345, "Down"),
+            call(12345, "Down"),
+            call(12345, "Down"),  # to Submit row (index 5 = 4 + 1)
+            call(12345, "Enter"),  # open the 'Submit answers' review screen
+            call(12345, "Enter"),  # confirm review (cursor defaults to Submit)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_answer_menu_multi_dedupes_and_orders(self, runner, tmux_manager) -> None:
+        """Indices are toggled in ascending order with no double-toggle (#418)."""
+        from unittest.mock import call
+
+        with patch("c_lord.claude.tmux_runner._MENU_NAV_DELAY", 0.0):
+            await runner.answer_menu_multi([2, 0, 2], 3)
+        # Only options 0 and 2 toggled once each, then Submit row (index 4).
+        assert tmux_manager.send_keys.call_args_list == [
+            call(12345, "Space"),  # option 0
+            call(12345, "Down"),
+            call(12345, "Down"),
+            call(12345, "Space"),  # option 2
+            call(12345, "Down"),
+            call(12345, "Down"),  # to Submit row (index 4 = 3 + 1)
+            call(12345, "Enter"),
+            call(12345, "Enter"),
+        ]
+
+    @pytest.mark.asyncio
     async def test_answer_menu_text_types_onto_row_then_confirms(
         self, runner, tmux_manager
     ) -> None:


### PR DESCRIPTION
## 利用者から見た変化（先頭・主）

Discord で**複数選択（チェックボックス）の質問に答えられなかった**のが、答えられるようになりました。

- 複数選択の質問に **「✅ 確定」ボタン**が出ます。チェックを選んでこのボタンを押すと送信されます（これまでは送信する明示手段が無く、Discord の「メニュー外クリックで確定」という暗黙挙動頼みで発見不能でした）。
- 複数チェックすると、**選んだ全項目が Claude に届きます**（これまでは先頭1個しか届かず、残りは無視されていました）。
- 単一選択の質問は**従来どおり**（選んだ瞬間に送信・確定ボタン無し）。

Closes #418

## Acceptance Criteria

- [x] multiSelect の質問で Discord メッセージに ✅ 確定 ボタンが存在する（message components に `..._confirm` button が含まれる）
- [x] 確定ボタンを押すと、ドロップダウンで選んだ**全項目**が送信される（1個も取りこぼさない）
- [x] 1つも選ばずに確定を押した場合は送信せず、選択を促すエラー表示（ephemeral）を返す
- [x] bridge（tmux）経路で、Discord で選んだ複数項目が**全て** Claude に届く（staging 実測で「あなたが選んだのは: ローカル, 本番」に両方出た）
- [x] 単一選択（`multi_select=False`）の挙動は不変（即時送信のまま・確定ボタン無し）
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` green
- [x] Staging で RED→GREEN を確認し、Discord 実画面スクショを貼る

## 実装（従）

- `ask_view.py`: multiSelect は Select で選択を**記録**し、`✅ 確定` ボタンで**送信**する2段階に（`_multi_select_record` / `_confirm_callback`）。未選択での確定は ephemeral 警告で送信しない。単一選択は即時送信のまま。
- `ask_handler.py::bridge_pane_ask`: multiSelect では選んだ**全インデックス**を `answer_menu_multi` へ渡す（`selected[0]` 廃止）。`✏️ Other` 自由文は従来の text 経路のまま。
- `tmux_runner.py::answer_menu_multi`: 各 option を `Space` でトグル → `Submit` 行（`option_count+1`）→ `Enter` で review → `Enter` で確定。実機 TUI で挙動検証済み。
- `docs/askuserquestion-bridge.md`: 上記「あるべき動き」を追記（drift 防止）。

## Definition of Done checklist

- [x] **Issue の全 Acceptance Criteria を満たす**（上の `## Acceptance Criteria` 参照、全チェック済み）
- [x] **TDD evidence**: RED 先行で確認。RED 失敗行（抜粋）:
  - `AttributeError: 'AskView' object has no attribute '_confirm_callback'`
  - `test_answer_menu_multi_toggles_each_then_submits` → AttributeError（`answer_menu_multi` 未実装）
  - `test_multi_select_click_toggles_all_options` → `answer_menu_multi` 未呼び出しで失敗
  実装後 7 テスト GREEN。
- [x] **pytest + ruff + pyright green**: 変更 source は pyright 0 errors / ruff clean。フル `pytest tests/` はクリーン環境で全 pass（手元 shell に bot の env 変数が混入すると env 依存の `test_skills`/`test_tmux` が落ちるが `env -i` 再実行で全 pass。CI は clean env なので緑）。
- [x] **動きを変えた → あるべき動きも更新**: `docs/askuserquestion-bridge.md` を同 PR で更新。
- [x] **No unrelated changes**: diff は ask_view / ask_handler / tmux_runner + その3テスト + 該当 doc のみ。
- [x] **Closes gating**: 全 AC を満たすため `Closes #418`。

## Staging Evidence

staging-3（`fix/418-multiselect-confirm`、jsonl/tmux 本番同等モード）で確認。prod token で E2E スレッドに multiSelect 質問を出させ、Discord 実機で操作。

**① 確定ボタン（RED→GREEN）**

| | RED（現行 main） | GREEN（本 PR） |
|---|---|---|
| Discord components | `Select(max=4)` + `✏️ Other` のみ、**確定ボタン無し** | `Select(max=4)` + **`✅ 確定`** + `✏️ Other` |

RED（main, 確定ボタン無し）:
![red-no-confirm](https://github.com/yousan/c-lord/releases/download/evidence/i418-418-red-discord-no-confirm-20260612T064719Z-00.png)

GREEN（fix, ✅確定 ボタンあり）:
![green-confirm-button](https://github.com/yousan/c-lord/releases/download/evidence/i418-418-green-discord-confirm-button-20260612T064719Z-02.png)

**② 複数値の到達（GREEN）**

ドロップダウンで「ローカル」「本番」を選び `✅ 確定` → Discord は `✅ Selected: 本番, ローカル`、Claude は **「あなたが選んだのは: ローカル, 本番」**（両方到達）。RED の main なら `selected[0]`＝先頭1個だけ。

![green-both-values](https://github.com/yousan/c-lord/releases/download/evidence/i418-418-green-both-values-delivered-20260612T064719Z-03.png)

<details><summary>原因側: ネイティブ TUI（multiSelect は <code>✔ Submit</code> を持つ）</summary>

![cause-tmux](https://github.com/yousan/c-lord/releases/download/evidence/i418-418-cause-tmux-native-submit-20260612T064719Z-01.png)

`←  ☐ 再現環境  ✔ Submit  →` のタブ行と `Submit` 行を持つ。`answer_menu_multi` はこの Space トグル→Submit 行→Enter→Enter を自動化する。
</details>
