### PR TITLE
fix: menu watchdog が tmux manager 未解決で stranded メニューを橋渡しできない問題を修正 (#420)

### DIFF
--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -576,6 +576,17 @@ class MenuWatchdogLoop:
             tmux_manager = await channel_cog.resolve_tmux_manager(parent_id)
         if tmux_manager is None:
             tmux_manager = getattr(self._bot, "tmux_manager", None)
+        if tmux_manager is None and session_name:
+            # #420: A channel without a /clord-init binding resolves no manager,
+            # and bot.tmux_manager is unwired (main.py never passes one). But the
+            # sweep already located the live tmux session this menu's window lives
+            # in (we captured the pane from it), so target that session directly —
+            # same construction resolve_tmux_manager itself uses. Without this the
+            # watchdog gives up every tick and the tmux→Discord mirror "cuts off":
+            # the stranded menu never reaches Discord buttons.
+            from .tmux import TmuxSessionManager
+
+            tmux_manager = TmuxSessionManager(session_name=session_name)
         if tmux_manager is None:
             logger.warning("menu watchdog: no tmux manager for thread=%d", thread_id)
             return

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -954,3 +954,75 @@ async def test_watchdog_ignores_pane_without_menu():
         await loop._maybe_bridge_open_menu(115, "sess", "w1", "❯ \n-- INSERT --")
         await asyncio.sleep(0)
     bridge.assert_not_awaited()
+
+
+# -- #420: stranded menu when no manager resolves -----------------------------
+# A channel without a /clord-init binding resolves no TmuxSessionManager
+# (resolve_tmux_manager → None) and bot.tmux_manager is unwired (main.py never
+# passes one), so the watchdog used to log "no tmux manager" and give up every
+# tick — the open menu never reached Discord and the tmux→Discord mirror "cut
+# off". But the sweep ALREADY knows the session_name the window lives in (it
+# captured the pane from it), so the bridge must still happen.
+
+
+@pytest.mark.asyncio
+async def test_watchdog_bridges_using_swept_session_when_no_manager_resolves():
+    """#420: resolve_tmux_manager=None AND bot.tmux_manager=None must NOT strand
+    the menu — the watchdog builds a manager from the swept session_name and
+    bridges. RED before the fix: it logged 'no tmux manager' and never bridged."""
+    from c_lord.cogs.channel_repo import ChannelRepoCog
+    from c_lord.tmux import TmuxSessionManager
+
+    bot = MagicMock()
+    bot.tmux_manager = None  # global default not wired (main.py:226)
+    bot.ask_repo = None
+    # Parent channel has no /clord-init binding → resolve returns None.
+    cog = MagicMock(spec=ChannelRepoCog)
+    cog.resolve_tmux_manager = AsyncMock(return_value=None)
+    bot.get_cog.return_value = cog
+    thread = MagicMock(spec=thread_state_sync.discord.Thread)
+    thread.parent_id = 999
+    bot.get_channel.return_value = thread
+
+    loop = thread_state_sync.MenuWatchdogLoop(bot, interval_seconds=60)
+    pane = _fixture("ask_rich_descriptions.txt")
+    with (
+        patch.object(thread_state_sync, "_capture_pane_text", return_value=pane),
+        patch("c_lord.discord_ui.ask_handler.bridge_pane_ask", new=AsyncMock()) as bridge,
+    ):
+        await loop._maybe_bridge_open_menu(222, "clord", "w94", pane)
+        await asyncio.sleep(0)
+        task = loop._ask_bridges.get(222)
+        assert task is not None, "menu was stranded — watchdog gave up instead of bridging"
+        await task
+
+    bridge.assert_awaited_once()
+    # The runner must target the session the sweep located, not a re-resolved one.
+    assert bridge.await_args is not None
+    runner = bridge.await_args.args[2]
+    assert isinstance(runner._tmux, TmuxSessionManager)
+    assert runner._tmux.session_name == "clord"
+
+
+@pytest.mark.asyncio
+async def test_watchdog_still_gives_up_when_session_name_empty():
+    """The empty-session_name guard stays: with nothing to target, the watchdog
+    must not fabricate a default session — it logs and returns (safety preserved)."""
+    bot = MagicMock()
+    bot.tmux_manager = None
+    bot.ask_repo = None
+    bot.get_cog.return_value = None
+    thread = MagicMock(spec=thread_state_sync.discord.Thread)
+    thread.parent_id = 999
+    bot.get_channel.return_value = thread
+
+    loop = thread_state_sync.MenuWatchdogLoop(bot, interval_seconds=60)
+    pane = _fixture("ask_rich_descriptions.txt")
+    with (
+        patch.object(thread_state_sync, "_capture_pane_text", return_value=pane),
+        patch("c_lord.discord_ui.ask_handler.bridge_pane_ask", new=AsyncMock()) as bridge,
+    ):
+        await loop._maybe_bridge_open_menu(223, "", "w94", pane)
+        await asyncio.sleep(0)
+    bridge.assert_not_awaited()
+    assert 223 not in loop._ask_bridges


### PR DESCRIPTION
## What does this PR do?

紐付け無しチャンネルで、ターンが finalize した後（quiet なツール実行 / 長考）や bot 再起動後に **AskUserQuestion / plan メニューが tmux に出ても Discord にボタンが出ず操作不能**になる（＝「たまに tmux→Discord のミラーが切れる」）症状を修正する。

## Why?

menu watchdog (#359) は「live poll が所有していないメニュー」を救済する最後の砦。ここが詰むと利用者は tmux 内のメニューに **Discord から一切答えられず**セッションが進まない（実機では Session timed out に至る）。「過程が見えないだけ」ではなく**操作不能**。

## 利用者から見た before/after（1行・必須）

紐付け無しチャンネルで finalize 後/再起動後に出たメニューが、**before: Discord に出ず詰まる → after: 救済役の watchdog が確実にボタンを出す**。

## 原因と修正

menu watchdog (`MenuWatchdogLoop._maybe_bridge_open_menu`) は 60s sweep で対象 window の `session_name`/`window_name` を**既に握っている**のに、橋渡し用 runner を作るとき既知 session を**捨てて** `resolve_tmux_manager(parent_id)` → `bot.tmux_manager` で再解決していた。紐付け無し → resolve は None（`channel_repo.py:125-126`）、グローバルも None（`main.py:226` 未配線）→ 両方 None で `"no tmux manager"` warning して return。**60秒ごとに諦め続け、メニューは永久に出ない。**

**修正**: 両方 None でも、引数として既に握っている `session_name` から `TmuxSessionManager(session_name=...)` を構築して救済する（`resolve_tmux_manager` 自身と同じ構築）。manager 解決が None を返す**理由を問わず**頑健。`session_name` 空のときのみ従来どおり諦める（安全側維持）。

```python
if tmux_manager is None and session_name:
    from .tmux import TmuxSessionManager
    tmux_manager = TmuxSessionManager(session_name=session_name)
```

Refs #420

## Acceptance Criteria (copied from the issue)

- [x] `tests/test_thread_state_sync.py` に RED→GREEN テスト追加（修正前 FAIL / 修正後 PASS）
- [x] `_maybe_bridge_open_menu` は両方 None でも `session_name` 非空なら `TmuxSessionManager(session_name=...)` で救済
- [x] `session_name` 空のときのみ "no tmux manager" warning して return（安全側維持）
- [x] **RED は本番ログ＋unit で再現済み。GREEN は本 PR デプロイ後に本番で `no tmux manager` 警告消失を実測**（#420 で合意した改訂 AC#4 / 実測まで #420 は open）
- [x] `ruff check` / `ruff format --check` / `pyright` / `pytest` 全 green

## Staging Evidence (証跡)

**faithful な staging RED→GREEN は本バグでは構造上再現困難**（skip 理由）: staging フリート（#1–#4）は全 channel が clone に bind 済み（STAGING.md L47）で `resolve_tmux_manager` が None を返さない。本番 RED 条件（resolve→None ＋ メニュー残存のレース）を staging で決定的に作るには共有 staging の binding 削除＋人為再現が要り、原状復帰失敗リスクが高い。yousan と合意のうえ **本番ログ RED ＋ 本番実測 GREEN** に代替（#420 の 2026-06-12 コメント）。

**RED（本番の実挙動ログ — モックでない real tmux/Discord）** 本番スレッド `W94 / 1514793636280271072`:

<details><summary>ログ抜粋</summary>

```
2026-06-12 15:04:23 [INFO]    menu watchdog: bridging unwatched TUI menu (thread=1514793636280271072 header='再現環境')
2026-06-12 14:23:30 [WARNING] menu watchdog: no tmux manager for thread=1514793636280271072
... (60秒ごとに 14:23〜15:24 まで継続) ...
2026-06-12 15:24:39 [WARNING] menu watchdog: no tmux manager for thread=1514793636280271072
```
</details>

利用者から見た RED（メニューが進まず Session timed out / メニュー詰まり）:

![repro-session-timeout](https://github.com/yousan/c-lord/releases/download/evidence/i420-repro-i420-repro-session-timeout-20260612T064321Z-00.png)
![repro-menu-stuck](https://github.com/yousan/c-lord/releases/download/evidence/i420-repro-i420-repro-menu-stuck-20260612T064321Z-01.png)

**TDD RED line**（新テストが本番と同じログを出して失敗）:

```
WARNING  c_lord.thread_state_sync: menu watchdog: no tmux manager for thread=222
E  AssertionError: menu was stranded — watchdog gave up instead of bridging
E  assert None is not None
```

**GREEN（本番実測・予定）**: 本 PR デプロイ後、本番ログで `no tmux manager` が消え `bridging unwatched TUI menu` 後にボタンが出ることを実測し、#420 にスクショ追記して close。

## 検証ログ

- `ruff check c_lord/` … All checks passed
- `ruff format --check c_lord/` … 81 files already formatted
- `pyright c_lord/` … 0 errors, 0 warnings
- `pytest tests/`（クリーン env） … **1769 passed, 3 skipped**
  - ※ このセッション dir は bot の `CLORD_*`/`DISCORD_*` env が載るため通常実行では `test_skills`/`test_tmux` が env 由来で落ちる。**clean main でも同様に落ちる**（私の変更と無関係）ことを確認済み。env を外すと全 green。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメント（仕様 / README / docs）も更新した。変えないなら本文に `no-user-visible-change` と明記した
  - 利用者の見え方は変わる（stranded メニューが出る）が、watchdog の挙動を定義する spec doc は存在しない。本修正は #359 `MenuWatchdogLoop` docstring が掲げる「再起動後に出たメニューも救済する」目的を実際に満たすバグ修正で、誤った説明をしている spec が無いため drift しない（コードコメントに #420 の意図を明記）。
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met (else `Refs #N`), and written on its own line
