### PR TITLE
chore(logging): thread rename 失敗を warning で可視化 (#423)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -394,13 +394,32 @@ class ClaudeChatCog(commands.Cog):
         )
         if (thread.name or "") == new_name:
             return
-        with contextlib.suppress(discord.HTTPException, TimeoutError, asyncio.TimeoutError):
+        try:
             await asyncio.wait_for(thread.edit(name=new_name), timeout=5.0)
             logger.info(
                 "%s lamp → %s (event-driven) %r",
                 log_ctx(thread_id=thread.id),
                 state,
                 new_name,
+            )
+        except (  # noqa: UP041 — asyncio.TimeoutError != builtins.TimeoutError on Python 3.10
+            discord.HTTPException,
+            TimeoutError,
+            asyncio.TimeoutError,
+        ) as exc:
+            # #423: previously suppressed silently — a failed rename left a stuck
+            # title (e.g. the monitoring thread) with no trace of *why*. Log the
+            # reason (HTTP status/code if any) but keep swallowing: a cosmetic
+            # rename must never break the response path.
+            logger.warning(
+                "%s thread rename failed: %r → %r: %s status=%s code=%s: %s",
+                log_ctx(thread_id=thread.id),
+                thread.name,
+                new_name,
+                type(exc).__name__,
+                getattr(exc, "status", None),
+                getattr(exc, "code", None),
+                exc,
             )
 
     async def _detect_issue_ref(
@@ -1347,12 +1366,19 @@ class ClaudeChatCog(commands.Cog):
                 #   (auto_topic_locked=1).
                 # - The tmux window-index is a *hint* shown at the end of the
                 #   name; the immutable tmux window-id is stored in the DB.
-                with contextlib.suppress(Exception):
+                try:
                     await self._apply_thread_naming(
                         thread=thread,
                         tmux_manager=tmux_manager,
                         first_message=prompt,
                         working_dir=working_dir,
+                    )
+                except Exception:
+                    # #423: naming is best-effort and must not break the run, but a
+                    # failure before the rename (e.g. window lookup) was invisible.
+                    # Log it (with stacktrace) instead of swallowing silently.
+                    logger.warning(
+                        "%s thread naming failed", log_ctx(thread_id=thread.id), exc_info=True
                     )
 
             # Create a TmuxClaudeRunner for this thread.

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -2334,6 +2334,30 @@ class TestApplyThreadNamingRetitle:
 
         mock_retitle.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_rename_failure_is_logged_not_silent(self, caplog):
+        """#423: a swallowed thread.edit failure must surface in the log (not silent).
+
+        Previously the rename was wrapped in ``contextlib.suppress`` so a stuck
+        title (e.g. the monitoring thread) left no trace of *why* it failed.
+        """
+        import logging
+
+        record = self._make_record(topic="挨拶")
+        cog, thread, tmux = self._make_cog_with_repo(record)
+        thread.name = "monitoring"  # differs from computed 'W1 │ 挨拶' → edit fires
+
+        resp = MagicMock()
+        resp.status = 403
+        resp.reason = "Forbidden"
+        thread.edit = AsyncMock(side_effect=discord.HTTPException(resp, "Missing Permissions"))
+
+        with caplog.at_level(logging.WARNING):
+            # Must NOT propagate — the response path keeps working.
+            await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="hi")
+
+        assert any("rename failed" in r.getMessage() for r in caplog.records), caplog.text
+
 
 class TestApplyThreadNamingIssueRef:
     """#414: the Issue/PR number is auto-detected from the branch / first message."""


### PR DESCRIPTION
## What does this PR do?

`_apply_thread_naming` の `thread.edit(name=…)` を `contextlib.suppress(...)` で囲っていたため、rename が失敗してもログに何も残らず「タイトルが更新されない」原因が追えなかった。失敗時に理由（例外型・HTTP status/code・旧名→新名）を **`logger.warning`** で出すようにし、`_apply_thread_naming` が rename 到達前に落ちた場合も呼び出し側で warning + stacktrace を出す。

## Why?

thread-init した `monitoring` スレッドのタイトルが `monitoring` のまま固着。調査で権限OK/archived無し/手動ロック無しまで潰せたが、**rename がなぜ落ちるかコードもログも教えてくれない**（握り潰し）。本修正はその観測性を足す**診断の一歩**で、これで真因を捕まえてから本修正に進む。

Closes #423

## 利用者から見た before/after（1行・必須）

`no-user-visible-change` — Discord 上の挙動は不変（ログにだけ warning が増える）。

## Acceptance Criteria (copied from #423)

- [x] `thread.edit` が `discord.HTTPException` を投げたとき、旧名・新名・例外型・status/code を `logger.warning` で出す。例外は伝播させない
- [x] `_apply_thread_naming` が rename 到達前に例外を投げたとき、呼び出し側で warning + stacktrace。伝播させない
- [x] 正常 rename 時は従来どおり `lamp →` info のみ（warning 無し）
- [x] `pytest` で「edit が例外→warning が出る／例外は伝播しない」を検証（RED→GREEN）
- [x] Discord 上の挙動は不変（`no-runtime-change`）

## TDD evidence

RED（パッチ前、握り潰しで warning 出ず）:
```
tests/test_claude_chat.py::...::test_rename_failure_is_logged_not_silent
  assert any("rename failed" in r.getMessage() ...) → False  (no log emitted)
```
GREEN（パッチ後）: `1 passed`。`test_claude_chat.py` 159 passed（回帰なし）。

## Staging Evidence (証跡)

`no-runtime-change`（ログ追加のみ・Discord 挙動不変）のため staging スクショは N/A。**実地の診断価値はデプロイ後**に発生する: monitoring スレッド（rename が固着している実スレッド）に次の1通が来たとき、新しい warning が**実際の失敗理由**を吐く。マージ→本番デプロイ後にそのログを採取して #423/後続 Issue に貼る。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: RED→GREEN（上記）
- [x] `pytest` / `ruff check` / `ruff format --check` / `pyright`（`c_lord/`）pass（ローカル全体の14失敗は main 共通の環境依存で無関係）
- [x] Staging: `no-runtime-change` のため N/A（理由を明記）
- [x] No unrelated changes; self-review done
- [x] `no-user-visible-change`（挙動不変・ドキュメント更新不要）
- [x] `Closes #423` — AC 100% 充足

🤖 Generated with [Claude Code](https://claude.com/claude-code)
