### PR TITLE
fix: skip synthetic/zero-usage assistant entries in read_latest_usage (#425)

### DIFF
--- a/c_lord/claude/context_usage.py
+++ b/c_lord/claude/context_usage.py
@@ -64,11 +64,23 @@ class ContextUsage:
         return self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens
 
 
+# Claude Code writes a synthetic assistant entry (this placeholder model id,
+# all-zero usage) for failed tool-call parses and no-op turns.  These do not
+# occupy context and must not be treated as the latest real turn (#425).
+_SYNTHETIC_MODEL = "<synthetic>"
+
+
 def read_latest_usage(jsonl_path: Path) -> ContextUsage | None:
-    """Return the usage of the most recent assistant turn in ``jsonl_path``.
+    """Return the usage of the most recent *real* assistant turn in ``jsonl_path``.
+
+    Synthetic / no-op assistant entries are skipped: Claude Code emits a
+    ``<synthetic>``-model entry with all-zero usage for failed tool-call parses
+    and no-op turns.  Reporting one would show 0 tokens used (a wrong
+    ``0% context`` line) and key the context-window probe on a phantom model
+    (#425), so the last entry carrying real usage is used instead.
 
     Returns ``None`` when the file is missing or contains no assistant message
-    with a ``usage`` block.  Malformed lines are skipped.
+    with real ``usage``.  Malformed lines are skipped.
     """
     if not jsonl_path.is_file():
         return None
@@ -89,13 +101,18 @@ def read_latest_usage(jsonl_path: Path) -> ContextUsage | None:
             usage = message.get("usage")
             if not isinstance(usage, dict):
                 continue
-            latest = ContextUsage(
+            candidate = ContextUsage(
                 input_tokens=int(usage.get("input_tokens", 0) or 0),
                 output_tokens=int(usage.get("output_tokens", 0) or 0),
                 cache_read_tokens=int(usage.get("cache_read_input_tokens", 0) or 0),
                 cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0) or 0),
                 model=message.get("model"),
             )
+            # Skip synthetic / no-op entries (#425): they carry no real context
+            # tokens, so the last entry with real usage is the true window state.
+            if candidate.model == _SYNTHETIC_MODEL or candidate.used == 0:
+                continue
+            latest = candidate
     return latest
 
 

--- a/tests/test_context_usage.py
+++ b/tests/test_context_usage.py
@@ -111,6 +111,69 @@ class TestReadLatestUsage:
         assert usage is not None
         assert usage.used == 1000
 
+    def test_skips_trailing_synthetic_zero_usage_entry(self, tmp_path: Path) -> None:
+        """#425: Claude Code writes a synthetic assistant entry (model
+        ``<synthetic>``, all-zero usage) for failed tool-call parses / no-op
+        turns.  If it is the last entry, reporting it would show 0 tokens used
+        (a wrong "0% context" line) and key the context-window probe on a phantom
+        model.  The last entry with real usage must be returned instead.
+        """
+        f = tmp_path / "s.jsonl"
+        self._write(
+            f,
+            [
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "model": "claude-opus-4-8",
+                        "usage": {
+                            "input_tokens": 5,
+                            "cache_creation_input_tokens": 1_000,
+                            "cache_read_input_tokens": 300_000,
+                            "output_tokens": 120,
+                        },
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "model": "<synthetic>",
+                        "usage": {
+                            "input_tokens": 0,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                            "output_tokens": 0,
+                        },
+                    },
+                },
+            ],
+        )
+        usage = read_latest_usage(f)
+        assert usage is not None
+        # The real opus turn is reported, not the trailing synthetic one.
+        assert usage.model == "claude-opus-4-8"
+        assert usage.used == 5 + 1_000 + 300_000
+
+    def test_returns_none_when_only_synthetic_entries(self, tmp_path: Path) -> None:
+        """All entries synthetic/zero-usage → nothing meaningful to report."""
+        f = tmp_path / "s.jsonl"
+        self._write(
+            f,
+            [
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "model": "<synthetic>",
+                        "usage": {"input_tokens": 0},
+                    },
+                }
+            ],
+        )
+        assert read_latest_usage(f) is None
+
 
 class TestParseContextTotal:
     def test_parses_1m_suffix(self) -> None:


### PR DESCRIPTION
## What does this PR do?

`read_latest_usage()`（`c_lord/claude/context_usage.py`）が、Claude Code の**合成 assistant エントリ**（`model="<synthetic>"`、usage 全項目 0：ツール呼び出しパース失敗 / no-op turn のときに書かれる）を拾わないようにする。`model=="<synthetic>"` または used==0 のエントリをスキップし、**最後の「実 usage を持つ」ターン**を返す。

## Why?

最後の assistant エントリが合成だと:
1. `used=0` として読まれ、Discord のコンテキスト使用量行が実際 ~30% でも **「0% context」と誤表示**（利用者に見える実害）。
2. #370 の窓サイズ永続化が `<synthetic>` を別モデル扱いし、余計な `/context` probe を1回撃って `settings` に `context_window:<synthetic>` という幻キーを作る。

Closes #425

## 利用者から見た before/after（1行・必須）

- before → after: ツール呼び出し失敗等で終わったターンの後に Discord のコンテキスト使用量が「0% context」と誤表示されることがある → 直前の実ターンの実際の % が出る（`<synthetic>` 由来の余計な `/context` probe も消える）。

## Acceptance Criteria (copied from the issue)

- [x] transcript の末尾が合成エントリ（`model="<synthetic>"`, usage 全0）でも、`read_latest_usage()` は直前の実ターンの usage/model を返す（`test_skips_trailing_synthetic_zero_usage_entry`）
- [x] 全エントリが合成/0 usage のときは `None` を返す（`test_returns_none_when_only_synthetic_entries`）
- [x] 結果として、最後が合成でも Discord のコンテキスト使用量行が実際の % を出す（0% 誤表示しない）
- [x] `<synthetic>` を別モデルとして probe/永続化しない（`read_latest_usage` が `<synthetic>` を返さないため、新たな `context_window:<synthetic>` を作らない）
- [x] TDD: 末尾合成エントリの fixture で RED→GREEN

## Staging Evidence (証跡)

> **staging 検証は省略。理由を明記**（CLAUDE.md「それ以外で staging 検証を省略するときは PR 本文に省略理由を書く」に従う）。

**省略理由**: 本バグは「ターンが**合成エントリ（ツール呼び出しパース失敗）で終わる**」ときだけ発生し、これは**意図的に発生させられない**（モデルが parse 失敗するかどうかに依存）ので staging で RED→GREEN を on-demand 再現できない。加えてフリートの `staging.sh restart` ハング（#401）が staging 切替自体を阻害中。代わりに **prod 実データで採取した実物の合成エントリ形状を fixture 化**して unit で RED→GREEN を確定させた（下記）。本番デプロイ後に「`context_window:<synthetic>` が新規作成されない / コンテキスト使用量行が実 % を出す」を観測する。

**RED（本番で実際に発生していた誤表示・実物）**: prod thread `1511558219011592312` で、合成エントリ（ツール呼び出しパース失敗）の直後にコンテキスト使用量が **`0% context (0/1.0M)`** と誤表示。実メッセージ:

- [msg 1516277798438834176](https://discord.com/channels/1285582352596209694/1511558219011592312/1516277798438834176) — 本文: `The model's tool call could not be parsed (retry also failed).` + `-# 📊 0% context (0/1.0M)` ← **バグ**
- [msg 1516270502077796422](https://discord.com/channels/1285582352596209694/1511558219011592312/1516270502077796422) — 同上の 0% 誤表示
- 対比（通常ターンは正常）: [msg 1515904183310749746](https://discord.com/channels/1285582352596209694/1511558219011592312/1515904183310749746) — `-# 📊 4% context`

![red](https://github.com/yousan/c-lord/releases/download/evidence/i425-red-clord_425_red-20260616T054230Z.png)

**診断の一次証跡（prod 実データ）**: 同 thread の transcript に `<synthetic>`×4（usage 全0、text="The model's tool call could not be parsed (retry also failed)." / "No response requested."）。prod `settings` DB に幻キー `context_window:<synthetic>=1000000` が生成されていた。

**GREEN**: 合成エントリは on-demand 再現不可のため実画面 GREEN は採取できない。修正後は `read_latest_usage` が合成エントリをスキップし、上記「通常ターン=実 %」と同じ挙動になる（直前の実ターンの % を表示）。unit で fixture により RED→GREEN を確定（下記 TDD evidence）。本番デプロイ後、`context_window:<synthetic>` が新規作成されないことを観測する。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted（下記）
- [x] `uv run pytest tests/ -v` passes（新規2件含む `TestReadLatestUsage` 緑、`pyright c_lord/` = 0 errors）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)（↑省略理由を明記：合成エントリは on-demand 再現不可 + #401。prod 実データの fixture で unit RED→GREEN、本番デプロイ後に観測）
- [x] No unrelated changes in the diff; self-review done（変更2ファイル: `context_usage.py` / `test_context_usage.py`）
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新した（`read_latest_usage` の docstring を「合成/no-op をスキップして最後の実ターンを返す」に更新。別 spec doc 無し）
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met, and written on its own line

### TDD evidence

**RED**（修正前）:
```
FAILED tests/test_context_usage.py::TestReadLatestUsage::test_skips_trailing_synthetic_zero_usage_entry
FAILED tests/test_context_usage.py::TestReadLatestUsage::test_returns_none_when_only_synthetic_entries
E  AssertionError: assert ContextUsage(... model='<synthetic>') is None
```
**GREEN**（修正後）: `TestReadLatestUsage` 全件 + `TestPersistedContextWindow` + `TestPostContextUsage` = 24 passed。

### Security audit

`read_latest_usage`（ローカル jsonl の read）への入力フィルタのみ。subprocess / shell / eval / env 追加なし。CRITICAL/HIGH/MEDIUM なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
