### PR TITLE
feat(thread-name): 権限不足でリネーム失敗時にヒントを出す (#429)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -431,10 +431,11 @@ class ClaudeChatCog(commands.Cog):
             if isinstance(exc, discord.Forbidden) and thread.id not in self._rename_hint_sent:
                 self._rename_hint_sent.add(thread.id)
                 with contextlib.suppress(discord.HTTPException):
+                    # `-# ` renders as Discord subtext (small, muted) so the hint is
+                    # unobtrusive — one quiet line, not a full warning message (#429).
                     await thread.send(
-                        "⚠️ このスレッドの名前を自動更新できませんでした（Discord の権限不足）。"
-                        "作業状況をスレッド名に反映するには、このサーバーで bot に "
-                        "**スレッドの管理 (Manage Threads)** 権限を付与してください。"
+                        "-# スレッド名を自動更新できませんでした"
+                        "（bot に「スレッドの管理 / Manage Threads」権限が必要）"
                     )
 
     async def _detect_issue_ref(

--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -147,6 +147,9 @@ class ClaudeChatCog(commands.Cog):
         # Issue #414: issue/PR number resolved before the session row exists;
         # drained by _apply_thread_naming on the next call once the row is saved.
         self._pending_issue_ref: dict[int, str] = {}
+        # Issue #429: thread ids already shown the "rename needs Manage Threads"
+        # hint, so it is posted at most once per process per thread (not per turn).
+        self._rename_hint_sent: set[int] = set()
         self._pending_tmux_window_id: dict[int, str] = {}
 
     def _is_allowed(self, member: discord.Member | discord.User) -> bool:
@@ -421,6 +424,18 @@ class ClaudeChatCog(commands.Cog):
                 getattr(exc, "code", None),
                 exc,
             )
+            # #429: a 403 means the bot lacks "Manage Threads" in this server, so it
+            # can post but never rename. Surface that to the user once per process
+            # (re-hint after a restart so it stays visible until the perm is added).
+            # Only for 403 — timeouts / other errors aren't user-actionable.
+            if isinstance(exc, discord.Forbidden) and thread.id not in self._rename_hint_sent:
+                self._rename_hint_sent.add(thread.id)
+                with contextlib.suppress(discord.HTTPException):
+                    await thread.send(
+                        "⚠️ このスレッドの名前を自動更新できませんでした（Discord の権限不足）。"
+                        "作業状況をスレッド名に反映するには、このサーバーで bot に "
+                        "**スレッドの管理 (Manage Threads)** 権限を付与してください。"
+                    )
 
     async def _detect_issue_ref(
         self,

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -2358,6 +2358,39 @@ class TestApplyThreadNamingRetitle:
 
         assert any("rename failed" in r.getMessage() for r in caplog.records), caplog.text
 
+    @pytest.mark.asyncio
+    async def test_rename_403_posts_hint_once(self):
+        """#429: a 403 (Missing Access) posts a one-time Manage-Threads hint."""
+        record = self._make_record(topic="挨拶")
+        cog, thread, tmux = self._make_cog_with_repo(record)
+        thread.name = "monitoring"  # differs → edit fires
+        thread.send = AsyncMock()
+        resp = MagicMock()
+        resp.status = 403
+        resp.reason = "Forbidden"
+        thread.edit = AsyncMock(side_effect=discord.Forbidden(resp, "Missing Access"))
+
+        await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="hi")
+        assert thread.send.await_count == 1
+        sent = thread.send.await_args.args[0] if thread.send.await_args.args else ""
+        assert "Manage Threads" in sent or "スレッドの管理" in sent
+
+        # Second 403 on the same thread must NOT re-post (one hint per process).
+        await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="hi again")
+        assert thread.send.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_rename_timeout_does_not_post_hint(self):
+        """#429: only 403 (permission) gets a hint — timeouts are not user-actionable."""
+        record = self._make_record(topic="挨拶")
+        cog, thread, tmux = self._make_cog_with_repo(record)
+        thread.name = "monitoring"
+        thread.send = AsyncMock()
+        thread.edit = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        await cog._apply_thread_naming(thread=thread, tmux_manager=tmux, first_message="hi")
+        thread.send.assert_not_awaited()
+
 
 class TestApplyThreadNamingIssueRef:
     """#414: the Issue/PR number is auto-detected from the branch / first message."""


### PR DESCRIPTION
## What does this PR do?

スレッド名の自動更新が **403（権限不足 / Discord code 50001 Missing Access）** で失敗したとき、そのスレッドに**一度だけ**「bot に Manage Threads 権限を付けて」とヒントを出す。これまでは warning ログ(#424)だけで利用者に見えなかった。**ヒントは `-# ` のサブテキスト（小さいグレー1行）**で、会話を邪魔しない控えめな見た目（loud な⚠️2行から改善）。

## Why?

bot に「スレッドの管理 (Manage Threads)」が無いサーバでは、メッセージ投稿はできてもスレッド名変更ができず、利用者は「なぜタイトルが変わらないのか」分からず黙って詰まる（実例: `#ChatGPT` / `#monitoring` が毎ターン 403）。気づけるようにする。

Closes #429

## 利用者から見た before/after（1行）

before: 権限不足でタイトルが変わらないとき**何も表示されず**気づけない → after: そのスレッドに**控えめなサブテキスト1行**で「Manage Threads 権限が必要」と一度だけ出る。

## Acceptance Criteria (copied from #429)

- [x] `thread.edit` が `discord.Forbidden`(403) を投げたとき、そのスレッドに1回ヒントを投稿
- [x] 同一スレッドの2回目以降の 403 では再投稿しない（プロセス内1回）
- [x] timeout / 403以外の HTTPException ではヒントを出さない
- [x] ヒント投稿が例外でも応答経路を止めない
- [x] warning ログ(#424)は従来どおり出る
- [x] `pytest` で検証（RED→GREEN）
- [x] 「403→ヒント1回」実機確認 → **本番で確認**（staging では 403 誘発不可。下記）

## TDD evidence

- RED: `test_rename_403_posts_hint_once` がヒント未実装で fail
- GREEN: 実装後 pass。`test_rename_timeout_does_not_post_hint`（timeout はヒント無し）も pass。`test_claude_chat.py` 121 passed。

## Staging / Prod Evidence (証跡)

**staging では 403 を誘発できない**（bot は自分の Manage Threads を剥がせない＝権限上書き PUT 自体が 403。429 は `Forbidden` でないのでヒント対象外）。→ **唯一の実再現環境は本番**（利用者が意図的に権限未付与）。

**本番で確認済み**: `#ChatGPT` スレッドで利用者がメッセージ送信 → bot が rename 試行 → `403 50001 Missing Access`（ログ下記）→ **ヒント投稿**。利用者確認で「いいカンジ、これでOK」。

```
2026-06-16 16:06:54 [WARNING] claude_chat: [thread=1516246080398954677] thread rename failed:
  'ChatGPT' → 'W7 │ ChatGPT': Forbidden status=403 code=50001: Missing Access
```
本番に投稿された実メッセージ（REST 取得）:
`-# スレッド名を自動更新できませんでした（bot に「スレッドの管理 / Manage Threads」権限が必要）`

**Before（loud・利用者提供スクショ）→ After（subtext・本番と同一文言を staging で描画）**:

![before-loud](https://github.com/yousan/c-lord/releases/download/evidence/i429-429-before-loud-20260616T070939Z-00.png)
![after-subtle](https://github.com/yousan/c-lord/releases/download/evidence/i429-429-after-subtle-20260616T070939Z-01.png)

> 利用者の個人サーバは証跡用テストアカウント未参加のため AI のキャプチャが届かない → before は利用者提供スクショ、after は**本番と一字一句同じ文言**を staging スレッドへ描画して撮影（`-# ` のレンダリングはサーバ非依存）。本番の実発火はログ＋REST 取得本文で担保。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: RED→GREEN
- [x] `pytest` / `ruff` / `pyright`（`c_lord/`）pass
- [x] 実機確認: 本番で 403→ヒント発火を確認（staging は 403 誘発不可のため・理由明記）。証跡画像あり
- [x] No unrelated changes; self-review done
- [x] `Closes #429` — AC 充足

🤖 Generated with [Claude Code](https://claude.com/claude-code)
