### PR TITLE
fix(thread-name): issue_ref の本文 #NNN 検出を初回メッセージ限定にする (#428)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -313,6 +313,11 @@ class ClaudeChatCog(commands.Cog):
         locked = bool(record.auto_topic_locked) if record else False
         state = (record.state if record else None) or "alive"
         issue_ref = record.issue_ref if record else None
+        # #428: text-based issue-ref detection runs ONLY on the thread's first
+        # message (the branch is still read every turn). Captured before topic
+        # generation: no topic persisted yet and none pending = first naming.
+        # Otherwise a casual mid-thread '#1' would be captured and stick forever.
+        is_first_message = not topic and thread.id not in self._pending_topic
 
         # Drain any topic / issue-ref / window-id pending from a previous call
         # where the session row did not yet exist.
@@ -380,7 +385,9 @@ class ClaudeChatCog(commands.Cog):
         # message's #NNN / issue URL is only a fallback used until a number is
         # known. Never auto-cleared — a known number persists until a *different*
         # branch number appears.
-        detected_ref = await self._detect_issue_ref(working_dir, first_message, current=issue_ref)
+        detected_ref = await self._detect_issue_ref(
+            working_dir, first_message, current=issue_ref, allow_text=is_first_message
+        )
         if detected_ref and detected_ref != issue_ref:
             issue_ref = detected_ref
             if record is not None:
@@ -444,17 +451,20 @@ class ClaudeChatCog(commands.Cog):
         first_message: str,
         *,
         current: str | None,
+        allow_text: bool,
     ) -> str | None:
         """Resolve the thread's Issue/PR number (#414), or ``None``.
 
         Priority: the session's git branch (authoritative, re-read each call) →
-        the first message's ``#NNN`` / issue URL (fallback, only while no number
-        is known yet) → the current value (no change).
+        the first message's ``#NNN`` / issue URL (only when ``allow_text`` — i.e.
+        the thread's first message, #428 — and no number is known yet) → the
+        current value (no change). Reading text on later messages would let a
+        casual mid-thread ``#1`` be captured and stick forever.
         """
         branch_ref = await self._read_branch_issue_ref(working_dir)
         if branch_ref:
             return branch_ref
-        if not current:
+        if allow_text and not current:
             return issue_ref_module.extract_from_text(first_message or "")
         return current
 

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -2442,13 +2442,23 @@ class TestApplyThreadNamingIssueRef:
 
     @pytest.mark.asyncio
     async def test_first_message_number_used_when_branch_has_none(self):
-        """No branch number → fall back to the first message's #NNN."""
+        """No branch number → the FIRST message's #NNN is used (#414/#428)."""
         from unittest.mock import patch
 
-        record = self._make_record(issue_ref=None)
+        from c_lord.cogs import claude_chat as cc_module
+
+        # First message = no topic yet (topic gets generated this turn).
+        record = self._make_record(topic=None, issue_ref=None)
         cog, thread, tmux = self._make_cog_with_repo(record)
 
-        with patch.object(cog, "_git_current_branch", return_value="main"):
+        with (
+            patch.object(cog, "_git_current_branch", return_value="main"),
+            patch.object(
+                cc_module.topic_module,
+                "generate_topic",
+                new=AsyncMock(return_value=("トピック", "llm")),
+            ),
+        ):
             await cog._apply_thread_naming(
                 thread=thread,
                 tmux_manager=tmux,
@@ -2457,6 +2467,28 @@ class TestApplyThreadNamingIssueRef:
             )
 
         cog.repo.set_issue_ref.assert_awaited_once_with(55555, "512")
+
+    @pytest.mark.asyncio
+    async def test_later_message_hashref_not_captured(self):
+        """#428: a #NNN in a LATER message (topic already set) must NOT be captured.
+
+        Text detection is first-message-only; otherwise a casual '#1' mid-thread
+        sticks forever (the monitoring-thread false positive).
+        """
+        from unittest.mock import patch
+
+        record = self._make_record(topic="既存トピック", issue_ref=None)
+        cog, thread, tmux = self._make_cog_with_repo(record)
+
+        with patch.object(cog, "_git_current_branch", return_value="main"):
+            await cog._apply_thread_naming(
+                thread=thread,
+                tmux_manager=tmux,
+                first_message="ついでに #999 も見ておいて",
+                working_dir="/tmp/clone",
+            )
+
+        cog.repo.set_issue_ref.assert_not_awaited()  # #999 ignored (not first message)
 
     @pytest.mark.asyncio
     async def test_known_number_not_overwritten_by_casual_mention(self):


### PR DESCRIPTION
## What does this PR do?

`issue_ref` の本文検出を**スレッドの初回メッセージだけ**に限定する。これまで `_detect_issue_ref` は issue_ref 未確定の間**毎メッセージ**で本文の `#NNN` を検査しており、仕様（`docs/specs/thread-name.md`「本文 #NNN は初回だけ見る」）とドリフトしていた。git ブランチ検出は従来どおり毎ターン。

## Why?

会話途中の何気ない `#1` 等を拾って永続化してしまう誤検出があった（実例: monitoring スレッドがブランチ `fix/quota-spike-aggregation`＝番号無しなのに `issue_ref='1'`）。本文検出を初回限定にして誤検出を防ぐ。**コードを既存スペックに合わせる修正。**

Closes #428

## 利用者から見た before/after（1行）

before: 会話途中の `#1` 等を拾って `W5 │ #1 …` と誤った番号が付くことがある → after: 初回メッセージ以外の `#NNN` は番号にしない（誤検出が減る）。

## Acceptance Criteria (copied from #428)

- [x] 2通目以降の本文に `#NNN` があっても issue_ref に採用されない（初回のみ）— `test_later_message_hashref_not_captured`
- [x] 初回メッセージの `#NNN` / issue URL は従来どおり採用 — `test_first_message_number_used_when_branch_has_none`
- [x] branch 由来の番号は従来どおり毎回追従 — `test_branch_number_persisted_and_shown_in_name`
- [x] `pytest` で「2通目の #NNN を無視／初回の #NNN を採用」を検証（RED→GREEN）
- [x] 検証は unit test の RED→GREEN で実施（staging は環境制約で不可 → `no-runtime-change` で免除・利用者合意）

## TDD evidence

- RED: `test_later_message_hashref_not_captured` が現行コード（毎メッセージ検査）で fail（#999 が捕捉される）
- GREEN: 実装後 pass。`test_first_message_number_used_when_branch_has_none`（初回は採用）も pass。`TestApplyThreadNamingIssueRef` 5 passed。全体 1843 passed（既存14失敗は main 共通の環境依存）。

## Staging Evidence (証跡)

**staging 検証は環境制約で実施できませんでした（正直に）**:
- staging-4 の DB / ローカル main が過去セッションでドリフトしていた（`issue_ref` 列欠落・stale main）。本 PR 作業中に `origin/main` へ更新して修復済み。
- さらに **staging E2E スレッドへの REST POST が一貫して `405 Method Not Allowed`**（archived/rate-limit ではない）でトリガー投入自体ができず。webhook も未設定（`E2E_TEST_WEBHOOK_URL=PENDING`）。

本変更は **Discord/tmux 連携の無い純粋な検出タイミングのロジック**で、unit test が `_apply_thread_naming` を直接呼んで `set_issue_ref` の挙動を RED→GREEN で正確に検証している（staging が確認するのと同じロジック）。`docs/specs/thread-name.md` の既存記述に実装を合わせる修正でもある。

> dod-gate の証跡画像要件について: 本変更は「誤った番号が**付かなくなる**」という不在系の改善で、スクショ向きの positive artifact が作りにくい。扱いは本文末の相談参照。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked（staging のみ環境制約で不可・理由明記）
- [x] TDD: RED→GREEN
- [x] `pytest` / `ruff` / `pyright`（`c_lord/`）pass
- [x] Staging: 環境制約で不可 → unit test で代替（`no-runtime-change`・合意済み）
- [x] No unrelated changes; self-review done
- [x] 既存スペック（`docs/specs/thread-name.md`）に実装を一致させる修正（ドキュメント変更不要）
- [x] `Closes #428`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
