### PR TITLE
fix(transcript): bot/ホスト再起動後の jsonl 全履歴 Discord 大量再送を止める (#433)

### DIFF
--- a/c_lord/transcript/tail.py
+++ b/c_lord/transcript/tail.py
@@ -5,6 +5,14 @@ is re-selected on every poll as the mtime-latest ``*.jsonl`` under the project
 directory, so ``/clear`` (which causes Claude Code to start a new
 ``<session-id>.jsonl``) is followed without restarting the tail.  Truncation
 or rewrite of the current file is handled by resetting the read offset to 0.
+
+Re-reading from byte 0 (truncation / in-place rewrite / new active file) must
+never re-emit an event that was already yielded — otherwise a ``--resume`` that
+rewrites the active jsonl in place (preserving history) would flood the consumer
+with the whole transcript again (Issue #433).  Each event is therefore yielded
+at most once per follow session, deduplicated by its stable ``uuid``.  At start
+(``from_start=False``) the uuids already present in the file are seeded so the
+pre-existing history is treated as already-delivered and never replayed.
 """
 
 from __future__ import annotations
@@ -16,6 +24,32 @@ from pathlib import Path
 from typing import Any
 
 from .resolver import latest_session_jsonl
+
+
+def _seed_seen_uuids(path: Path, upto_offset: int, seen: set[str]) -> None:
+    """Record the uuids of events in ``path[:upto_offset]`` into ``seen``.
+
+    Reads exactly ``upto_offset`` bytes (the same baseline the follow loop skips
+    past) so events that existed when the tail started are marked already-seen
+    and are never re-emitted on a later offset-0 reset.  A partial trailing line
+    (offset cutting mid-line) fails to parse and is ignored — it is read afresh
+    by the follow loop from ``upto_offset``.
+    """
+    try:
+        with path.open("rb") as f:
+            data = f.read(upto_offset)
+    except OSError:
+        return
+    for line in data.decode("utf-8", errors="replace").split("\n"):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        uid = event.get("uuid")
+        if isinstance(uid, str) and uid:
+            seen.add(uid)
 
 
 async def tail_events(
@@ -46,6 +80,17 @@ async def tail_events(
     initial_offset = (
         initial_path.stat().st_size if initial_path is not None and not from_start else 0
     )
+
+    # Issue #433: events already yielded (or present at start) must not be
+    # re-emitted when the read offset is reset to 0 (truncation / in-place
+    # rewrite / new active file).  Dedup by stable ``uuid``; events without a
+    # uuid are non-rendered metadata (mode/permission-mode/file-history-snapshot/
+    # …) that the consumer drops, so re-emitting them on a reset is harmless and
+    # they are intentionally not deduplicated (avoids collapsing two distinct
+    # uuid-less records that happen to serialise identically).
+    seen_uuids: set[str] = set()
+    if initial_path is not None and not from_start:
+        _seed_seen_uuids(initial_path, initial_offset, seen_uuids)
 
     current_path: Path | None = None
     offset = 0
@@ -97,8 +142,14 @@ async def tail_events(
                 if not line.strip():
                     continue
                 try:
-                    yield json.loads(line)
+                    event = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                uid = event.get("uuid")
+                if isinstance(uid, str) and uid:
+                    if uid in seen_uuids:
+                        continue  # already emitted — do not replay on offset reset
+                    seen_uuids.add(uid)
+                yield event
 
         await asyncio.sleep(poll_interval)

--- a/docs/specs/transcript-mirror-replay-safety.md
+++ b/docs/specs/transcript-mirror-replay-safety.md
@@ -1,0 +1,52 @@
+# Transcript mirror — replay safety across restarts/rewrites (#433)
+
+このドキュメントは、`CLORD_BRIDGE_MODE=jsonl` のときに動く JSONL transcript ミラー
+(`c_lord/transcript/`、`c_lord/cogs/transcript_mirror.py`) の **「あるべき動き」**
+のうち「過去ログを二度 Discord に流さない」保証を定める。
+
+## あるべき動き (利用者から見た期待)
+
+- bot / ホストが再起動しても、**古いスレッドに過去の会話履歴が再投稿されない**。
+- 再起動後に古いスレッドへ話しかけると、**届くのはその新しいターンの応答だけ**。
+  6/1〜6/17 にすでに送られた応答が、もう一度スレッドに流れてくることはない。
+- これは `/clear`（新しいセッション jsonl への切り替え）や、クラッシュ後の
+  `--resume`（Claude Code がアクティブ jsonl を**履歴を保ったまま書き換える**）を
+  またいでも成り立つ。
+
+## なぜこの保証が要るか (#433 の実害)
+
+ミラーは Claude Code のセッション jsonl を tail し、`assistant` の最終応答などを
+Discord へ転送する。`c_lord/transcript/tail.py` は通常 **EOF から** 追従するので
+起動時に過去分は流さない。しかし、
+
+- truncation（`size < offset`）
+- 同一サイズの in-place rewrite（`size == offset && mtime 更新`）
+- 新しい active jsonl への切り替え（`/clear`）
+
+を検知すると **読み取り offset を 0 にリセットして先頭から読み直す**。
+
+クラッシュで tmux 内の Claude が死んだ状態で古いスレッドに話しかけると、
+`--resume` が走り Claude Code がアクティブ jsonl を**履歴ごと書き換える**。これが
+上記リセットを誘発し、ミラーが**全 `assistant` 履歴を Discord に再投稿**してしまう
+（2026-06-18: 約44秒で1スレッドの98発話が再送される実害）。
+
+## 実装上の不変条件 (regression を防ぐ)
+
+`tail_events` は **1 回の追従セッション中、同じイベントを二度 yield しない**。
+
+- dedup キーは各イベントの安定した `uuid`。投稿対象（`assistant` / `user` /
+  `system`）は必ず `uuid` を持つ。`uuid` を持たないメタデータ（`mode` /
+  `permission-mode` / `file-history-snapshot` 等）は `render_event` が `None` を
+  返す＝そもそも投稿されないため dedup 対象外（同一内容メタの誤った取りこぼしを
+  避ける）。
+- 起動時（`from_start=False`）は、ファイルに既に存在する `uuid` を baseline として
+  seen に投入する。これにより、起動直後に `--resume` で offset が 0 にリセットされ
+  ても、**起動前から在った履歴は「配信済み」として二度と流れない**。
+- `from_start=True`（明示的な全リプレイ）では baseline seeding を行わず、各イベントは
+  一度だけ流れる（リセットが起きても重複しない）。
+
+テスト: `tests/transcript/test_tail.py`
+(`test_tail_does_not_replay_history_on_resume_rewrite`,
+`test_tail_does_not_re_yield_already_followed_event_on_rewrite`) と
+`tests/transcript/test_mirror.py`
+(`test_mirror_does_not_repost_history_on_resume_rewrite`)。

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -996,3 +996,75 @@ async def test_mirror_skips_ask_when_bus_active(tmp_path: Path) -> None:
         ask_bus.unregister(tid)
 
     assert spawned is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #433: resume (after host crash) rewrites the active jsonl in place,
+# preserving history. The mirror must NOT re-post that history to Discord.
+# ---------------------------------------------------------------------------
+
+
+def _assistant_text_uuid(text: str, uuid: str, pad: int = 0) -> dict:
+    d = _assistant_text(text)
+    d["uuid"] = uuid
+    if pad:
+        d["pad"] = "x" * pad
+    return d
+
+
+def _turn_end(uuid: str) -> dict:
+    return {"type": "system", "subtype": "turn_duration", "uuid": uuid}
+
+
+async def test_mirror_does_not_repost_history_on_resume_rewrite(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    # Two completed turns of HISTORY, delivered by a previous mirror lifetime.
+    # Padded so the later resume-rewrite shrinks the file (trips offset reset).
+    _write_event(jsonl, _assistant_text_uuid("old answer 1", "u1", pad=400))
+    _write_event(jsonl, _turn_end("t1"))
+    _write_event(jsonl, _assistant_text_uuid("old answer 2", "u2", pad=400))
+    _write_event(jsonl, _turn_end("t2"))
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    reply_sink_calls: list[str] = []
+
+    async def sink(text: str) -> None:
+        pass
+
+    async def reply_sink(text: str) -> None:
+        reply_sink_calls.append(text)
+
+    mirror = TranscriptMirror(
+        thread_id=1,
+        project_dir=project,
+        sink=sink,
+        reply_sink=reply_sink,
+        verbosity="minimal",
+        poll_interval=0.05,
+    )
+    mirror.start()  # tails from EOF — history must stay un-posted
+    try:
+        await asyncio.sleep(0.2)
+        # Resume rewrite: history preserved verbatim + a NEW turn, no padding.
+        lines = [
+            _assistant_text_uuid("old answer 1", "u1"),
+            _turn_end("t1"),
+            _assistant_text_uuid("old answer 2", "u2"),
+            _turn_end("t2"),
+            _assistant_text_uuid("brand new answer", "u3"),
+            _turn_end("t3"),
+        ]
+        jsonl.write_text("".join(json.dumps(x) + "\n" for x in lines))
+        os.utime(jsonl, (50, 50))
+        await asyncio.sleep(0.4)
+    finally:
+        await mirror.stop()
+
+    # Only the genuinely new turn reaches Discord; no history re-post (the burst).
+    assert any("brand new answer" in s for s in reply_sink_calls), reply_sink_calls
+    assert not any("old answer 1" in s for s in reply_sink_calls), reply_sink_calls
+    assert not any("old answer 2" in s for s in reply_sink_calls), reply_sink_calls

--- a/tests/transcript/test_tail.py
+++ b/tests/transcript/test_tail.py
@@ -28,6 +28,21 @@ async def _drain(agen, n: int, timeout: float = 2.0) -> list:
     return collected
 
 
+async def _collect_for(agen, duration: float) -> list:
+    """Collect every event yielded within *duration* seconds (then stop)."""
+    collected: list = []
+
+    async def pull() -> None:
+        async for ev in agen:
+            collected.append(ev)
+
+    task = asyncio.create_task(pull())
+    await asyncio.sleep(duration)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    return collected
+
+
 async def test_tail_yields_lines_appended_after_start(tmp_path: Path) -> None:
     project = tmp_path / "proj"
     project.mkdir()
@@ -168,3 +183,84 @@ async def test_tail_handles_truncation_or_rewrite(tmp_path: Path) -> None:
         await asyncio.gather(prod, return_exceptions=True)
 
     assert events[0]["n"] == 99
+
+
+async def test_tail_does_not_replay_history_on_resume_rewrite(tmp_path: Path) -> None:
+    # Issue #433: the real production trigger. A ``--resume`` (after a host crash
+    # killed the tmux Claude) makes Claude Code rewrite the active jsonl IN PLACE,
+    # PRESERVING the whole history and appending the new turn. The rewrite is
+    # smaller than the padded original, so ``size < offset`` fires and tail resets
+    # offset to 0 — re-reading the entire history. Tail must NOT re-yield events
+    # (by uuid) that already existed when it started: only the genuinely new
+    # ``u3`` may be emitted. Without the dedup this yields u1, u2, u3 (the burst).
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    # Existing history (delivered by a previous tail lifetime) with padding so the
+    # later rewrite shrinks the file and trips the truncation-reset path.
+    _write_event(jsonl, {"type": "assistant", "uuid": "u1", "pad": "x" * 400})
+    _write_event(jsonl, {"type": "assistant", "uuid": "u2", "pad": "x" * 400})
+    os.utime(jsonl, (1, 1))
+
+    agen = tail_events(project, poll_interval=0.05).__aiter__()
+
+    async def producer() -> None:
+        await asyncio.sleep(0.15)
+        # Resume rewrite: history preserved verbatim + new u3, no padding (smaller).
+        jsonl.write_text(
+            json.dumps({"type": "assistant", "uuid": "u1"})
+            + "\n"
+            + json.dumps({"type": "assistant", "uuid": "u2"})
+            + "\n"
+            + json.dumps({"type": "assistant", "uuid": "u3"})
+            + "\n"
+        )
+        os.utime(jsonl, (50, 50))
+
+    prod = asyncio.create_task(producer())
+    try:
+        events = await _collect_for(agen, 0.5)
+    finally:
+        prod.cancel()
+        await asyncio.gather(prod, return_exceptions=True)
+
+    assert [e["uuid"] for e in events] == ["u3"]
+
+
+async def test_tail_does_not_re_yield_already_followed_event_on_rewrite(tmp_path: Path) -> None:
+    # A uuid appended *after* tail started (already delivered live) must also not
+    # be re-emitted when a subsequent rewrite resets the offset to 0.
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    _write_event(jsonl, {"type": "assistant", "uuid": "base", "pad": "x" * 400})
+    os.utime(jsonl, (1, 1))
+
+    agen = tail_events(project, poll_interval=0.05).__aiter__()
+
+    async def producer() -> None:
+        await asyncio.sleep(0.15)
+        # Live append — delivered now.
+        _write_event(jsonl, {"type": "assistant", "uuid": "live"})
+        os.utime(jsonl, (40, 40))
+        await asyncio.sleep(0.2)
+        # Rewrite preserving everything (shrinks → reset to 0).
+        jsonl.write_text(
+            json.dumps({"type": "assistant", "uuid": "base"})
+            + "\n"
+            + json.dumps({"type": "assistant", "uuid": "live"})
+            + "\n"
+            + json.dumps({"type": "assistant", "uuid": "fresh"})
+            + "\n"
+        )
+        os.utime(jsonl, (80, 80))
+
+    prod = asyncio.create_task(producer())
+    try:
+        events = await _collect_for(agen, 0.7)
+    finally:
+        prod.cancel()
+        await asyncio.gather(prod, return_exceptions=True)
+
+    # "live" is yielded once (when appended), "fresh" once; "base" never; no dup.
+    assert [e["uuid"] for e in events] == ["live", "fresh"]


### PR DESCRIPTION
## What does this PR do?

`CLORD_BRIDGE_MODE=jsonl` の transcript ミラーが、bot/ホスト再起動後に古いスレッドの
**会話履歴を Discord に大量再投稿**してしまう不具合を修正する。

## Why?

ホスト/bot 再起動はいつでも起こりうる。再起動後に古いスレッドへ一言話しかけただけで、
そのスレッドの過去ログ（数十件の旧 assistant 応答）が一気に再投稿されると、チャンネルが
過去ログで埋まり、通知爆撃・レート制限・「壊れている」という不信につながる。再起動/resume を
またいでも「過去ログ再送なし・新着応答のみ」であるべき。

## 利用者から見た before/after（1行・必須）

Before: 再起動後に古いスレッドへ話しかけると過去ログ全体が再送される / After: 新しいターンの応答だけが届く。

Closes #433

## 根本原因と修正

`c_lord/transcript/tail.py` はアクティブ jsonl を **EOF から** tail するが、truncation
(`size < offset`) / in-place rewrite / 新 active file を検知すると **offset を 0 にリセットして
全行を再 yield** する。クラッシュで死んだ tmux Claude を `--resume` すると Claude Code が jsonl を
**履歴ごと書き換える**ためこのリセットが誘発され、ミラーが dedup 無しに全 assistant 履歴を
再投稿していた。

修正: `tail_events` を「1 回の追従中、同じイベントを二度 yield しない」に変更。dedup キーは安定した
`uuid`、起動時に既存 uuid を baseline として seen に投入 → offset リセットが起きても起動前の履歴は
二度と流れない。uuid 無しメタデータ（mode 等）は `render_event` が None＝非投稿なので対象外。

**本番で実際に起きた事象（production RED）**: channel `1510995056876847237` で 2026-06-18
02:34:57〜02:35:41 UTC に 6/1〜6/17 の旧 assistant 応答が大量再投稿（該当 jsonl は 1 ファイル・
1.4MB・assistant text 98件、02:34:12 の resume 直後にバースト）。

## Acceptance Criteria (copied from the issue)

- [x] `TranscriptMirror` が同一 assistant イベント `uuid` を 2 回 Discord に投稿しない（tail が offset=0 で全再読しても）。RED→GREEN テスト追加。
- [x] `tail_events` が truncation / in-place rewrite を検知して offset=0 にリセットし旧行を再 yield することを固定するテストを追加。
- [x] ステージングで、長い履歴の jsonl を resume / rewrite した際に Discord へ過去ログ再投稿が起きないことを RED→GREEN で確認（下記 Staging Evidence、実画面スクショ）。
- [x] 「あるべき動き」を `docs/specs/transcript-mirror-replay-safety.md` に明文化。
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` 全 green（CI `test` 3 バージョン pass）。

## Staging Evidence (証跡)

staging-1 の E2E スレッド `1514085380666691664` に履歴3件(OLD)を持つ検証用 jsonl を最新ファイルとして
置き、mirror が EOF から tail 開始後にその jsonl を**縮小 rewrite（履歴保持 + 新1件）= `size<offset`
リセットを誘発**して本番の resume-rewrite と同じ機構を再現。

**RED (`main` = 修正前)** — 再読で履歴 OLD 1/2/3 まで再投稿（バースト）:
```
03:28:18 C-lord-staging | 【#433-staging検証】OLD message 1（再送NG）
03:28:18 C-lord-staging | 【#433-staging検証】OLD message 2（再送NG）
03:28:18 C-lord-staging | 【#433-staging検証】OLD message 3（再送NG）
03:28:19 C-lord-staging | 【#433-staging検証】NEW message（これだけ届くのが正しい）
```
![red](https://github.com/yousan/c-lord/releases/download/evidence/i433-red-20260618T033837Z-00.png)

**GREEN (`fix/433…` = 修正後)** — 再読しても履歴は再送されず新規 1 件のみ:
```
03:35:37 C-lord-staging | 【#433検証·GREEN】NEW-CLEAN（修正後はこれだけ届くのが正しい）
--- count: 1   (OLD-A/B/C は再投稿されない)
```
![green](https://github.com/yousan/c-lord/releases/download/evidence/i433-green-20260618T033837Z-01.png)

検証後 staging-1 は原状復帰（検証用 jsonl 削除・DB cursor 復元・`main` 再起動・lease 返却）。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line: `AssertionError: ['old answer 1', 'old answer 2', 'brand new answer']`
- [x] `uv run pytest tests/ -v` passes — CI `test (3.10/3.11/3.12)` 全 pass（※本番チェックアウトで回すと本番 `.env` 依存テスト17件が落ちるが本変更と無関係＝stash 後のクリーンツリーでも同数失敗・CI クリーンでは緑）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done（差分は tail.py + 2 テスト + 新 spec のみ）
- [x] 動きを変えたので「あるべき動き」のドキュメント（`docs/specs/transcript-mirror-replay-safety.md`）も更新した
- [x] `Closes #433` は 100% AC 充足のため使用（独立行）
