### PR TITLE
docs(deploy): systemd --user 常駐手順を同梱（ホスト再起動で自動起動）

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,43 @@ c-lord start --env /path/to/.env   # custom .env location
 
 Send a message in the configured channel — Claude will reply in a new thread.
 
+### Run as a Service (systemd --user — survives reboot)
+
+To keep c-lord running in the background and **start it automatically when the
+host reboots**, install it as a `systemd --user` service. From your clone:
+
+```bash
+bash scripts/install-systemd.sh
+```
+
+This generates `~/.config/systemd/user/c-lord.service` (pointing at this clone
+and your `uv`), enables it, and turns on **linger** so the service starts on
+boot even when no one is logged in. Then manage it with standard systemd:
+
+```bash
+systemctl --user restart c-lord.service     # after a `git pull`
+systemctl --user stop    c-lord.service
+systemctl --user status  c-lord.service
+journalctl --user -u c-lord.service -f      # live logs
+```
+
+Why `--user` instead of a system service: c-lord drives the user's `tmux`,
+`~/.claude` session files, `uv`, and the `claude` CLI, so it runs cleanest as
+**you**, with your environment — a root/system service would have to re-create
+all of that via `User=`/`Environment=`. `loginctl enable-linger "$USER"` is what
+makes a user service survive logout and start at boot; the installer runs it for
+you.
+
+> **Manual install:** copy [`deploy/c-lord.service`](deploy/c-lord.service), fix
+> the two `CHANGE-ME` paths (clone dir + `uv`), then
+> `systemctl --user daemon-reload && systemctl --user enable --now c-lord.service && loginctl enable-linger "$USER"`.
+
+> **WSL note:** if `systemctl --user` reports `Failed to connect to bus`, the
+> user D-Bus session isn't up. Ensure `systemd=true` under `[boot]` in
+> `/etc/wsl.conf` and reboot WSL (`wsl --shutdown`), or restart the bot by
+> killing it and letting `Restart=always` respawn it (`pkill -f c_lord.main` is
+> unsafe with multiple clones — kill by PID).
+
 ---
 
 ### Minimal Bot (Install as a Package)

--- a/deploy/c-lord.service
+++ b/deploy/c-lord.service
@@ -1,0 +1,45 @@
+# c-lord — systemd --user unit (Discord <-> Claude Code bridge)
+#
+# Easiest install (auto-detects your clone path + uv, enables linger):
+#     bash scripts/install-systemd.sh
+#
+# To install by hand instead:
+#   1. Copy this file to ~/.config/systemd/user/c-lord.service
+#   2. Fix the two CHANGE-ME paths below (clone dir + uv path)
+#   3. systemctl --user daemon-reload
+#      systemctl --user enable --now c-lord.service
+#      loginctl enable-linger "$USER"      # start on boot without a login
+#
+# Why --user (not a system service): c-lord drives the user's tmux, ~/.claude
+# session files, uv, and the `claude` CLI, so it runs cleanest as *you* with
+# your environment. linger is what makes a --user service survive logout and
+# start at boot.
+#
+# Paths below assume the clone is at ~/c-lord and uv is at ~/.local/bin/uv.
+# `%h` expands to your home directory.
+
+[Unit]
+Description=c-lord (Discord <-> Claude Code bridge)
+Documentation=https://github.com/yousan/c-lord
+After=network-online.target
+Wants=network-online.target
+# Stop retrying if it crash-loops 5x within 60s (avoid a hot restart loop).
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+# CHANGE-ME: absolute path to your c-lord clone (holds .env, data/, sessions).
+WorkingDirectory=%h/c-lord
+# CHANGE-ME: `command -v uv` (often %h/.local/bin/uv).
+ExecStart=%h/.local/bin/uv run python -m c_lord.main
+Restart=always
+RestartSec=5
+# systemd --user services get a minimal PATH. Include every dir holding a CLI
+# c-lord shells out to — at least uv, the `claude` CLI, tmux and git. Adjust to
+# match your `echo $PATH` (e.g. add %h/.bun/bin if claude was installed via bun).
+# The install-systemd.sh helper captures your live $PATH automatically.
+Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# =============================================================================
+# install-systemd.sh — run c-lord as a systemd --user service (survives reboot)
+# =============================================================================
+# Generates ~/.config/systemd/user/c-lord.service pointing at THIS clone and your
+# `uv`, enables it, and turns on linger so it starts on boot without a login.
+#
+# Idempotent: safe to re-run (regenerates the unit + re-enables). No root needed
+# for the service itself; `loginctl enable-linger` may prompt for sudo on some
+# distros. Requires a user systemd instance (standard on desktop/server Ubuntu).
+#
+# After a code update, restart with:  systemctl --user restart c-lord.service
+# =============================================================================
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT_NAME="c-lord.service"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+UNIT_PATH="$UNIT_DIR/$UNIT_NAME"
+
+UV="$(command -v uv || true)"
+if [ -z "$UV" ]; then
+  echo "ERROR: 'uv' not found on PATH. Install it first: https://docs.astral.sh/uv/" >&2
+  exit 1
+fi
+UV_DIR="$(dirname "$UV")"
+
+# Build the service PATH from the installing shell's $PATH so the service finds
+# claude / uv / tmux / git exactly like your interactive shell does (a systemd
+# --user service otherwise gets a minimal PATH and can't spawn the claude CLI).
+# Sanitize: keep only absolute, existing dirs, de-duplicated — drops relative
+# entries (./node_modules/.bin) and stale/foreign paths that don't exist here.
+SERVICE_PATH=""
+add_dir() {
+  case "$1" in /*) ;; *) return ;; esac          # absolute only
+  [ -d "$1" ] || return                           # existing only
+  case ":$SERVICE_PATH:" in *":$1:"*) return ;; esac  # de-dup
+  SERVICE_PATH="${SERVICE_PATH:+$SERVICE_PATH:}$1"
+}
+add_dir "$UV_DIR"
+add_dir "$HOME/.local/bin"
+IFS=: read -ra _path_parts <<<"$PATH"
+for _d in "${_path_parts[@]}"; do add_dir "$_d"; done
+for _d in /usr/local/bin /usr/bin /bin; do add_dir "$_d"; done
+
+if [ ! -f "$REPO_DIR/.env" ]; then
+  echo "WARNING: $REPO_DIR/.env not found — run 'uv run c-lord setup' first," >&2
+  echo "         otherwise the service will start but fail to log in to Discord." >&2
+fi
+
+mkdir -p "$UNIT_DIR"
+cat > "$UNIT_PATH" <<EOF
+[Unit]
+Description=c-lord (Discord <-> Claude Code bridge)
+Documentation=https://github.com/yousan/c-lord
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory=$REPO_DIR
+ExecStart=$UV run python -m c_lord.main
+Restart=always
+RestartSec=5
+Environment=PATH=$SERVICE_PATH
+
+[Install]
+WantedBy=default.target
+EOF
+echo "wrote $UNIT_PATH"
+echo "  WorkingDirectory=$REPO_DIR"
+echo "  ExecStart=$UV run python -m c_lord.main"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$UNIT_NAME"
+
+# Linger: keep the user manager (and thus this service) running after logout and
+# start it on boot without a login session.
+if loginctl show-user "$USER" 2>/dev/null | grep -q '^Linger=yes'; then
+  echo "linger already enabled for $USER"
+else
+  echo "enabling linger for $USER (start on boot without login)…"
+  loginctl enable-linger "$USER" 2>/dev/null || sudo loginctl enable-linger "$USER"
+fi
+
+echo
+systemctl --user status "$UNIT_NAME" --no-pager || true
+echo
+echo "Done. Manage the service with:"
+echo "  systemctl --user restart c-lord.service    # after a git pull"
+echo "  systemctl --user stop    c-lord.service"
+echo "  systemctl --user status  c-lord.service"
+echo "  journalctl --user -u c-lord.service -f     # live logs"


### PR DESCRIPTION
## What does this PR do?

c-lord を「**ホスト再起動後も自動起動する常駐サービス**」として動かす方法を、ホスト固有の未追跡ファイル頼みではなく **リポジトリ同梱 + README 化**する。

## Why?

これまで本番(tachikoma)は `~/.config/systemd/user/c-lord.service`（リポジトリ外）と未追跡の `start-clord.sh` で常駐しており、他の利用者・将来の自分が再現できなかった。c-lord はフレームワーク（"useful to anyone → add here"）なので、標準の常駐手順を本体に持たせる。

## 利用者から見た before/after（1行・必須）

Before: 常駐/自動起動の手順が無く各自で野良設定 / After: `bash scripts/install-systemd.sh` で systemd --user 常駐＋boot 自動起動を再現でき、README に手順がある。

## 方式（合意済み）

**systemd --user + `loginctl enable-linger`**。root 不要で、bot が依存するユーザ環境(tmux/~/.claude/uv/PATH)をそのまま継承できるため。system 全体の service は root と `User=`/`Environment=` 再現が必要で本 bot には不向き、という判断。

## 同梱物

- `deploy/c-lord.service` — user unit 雛形（`Restart=always` / `WantedBy=default.target` / CHANGE-ME パス）
- `scripts/install-systemd.sh` — このクローンと検出した uv を指す unit を生成、**インストール実行シェルの $PATH をサニタイズ（絶対・実在・重複除去）して焼き込み**（service が claude/uv/tmux/git を見つけられるように）、enable + `enable-linger`
- `README.md` — "Run as a Service (systemd --user — survives reboot)" セクション

## 検証

- `systemd-analyze verify`：雛形・生成 unit ともにエラー0（無関係な ntopng の警告のみ）
- `bash -n scripts/install-systemd.sh`：OK
- 生成される `Environment=PATH=` を bash で確認：`~/.local/bin`(= `claude` の場所)等を含むクリーンな絶対パス列になることを確認
- 本方式の有効性は本番ホストで実証済み（`Linger=yes` + enabled user unit により、今朝のホスト再起動 02:15 直後に C-lord が自動起動していた）
- ※ `systemctl --user` 系はこの WSL のセッションバス欠落で実行不可のため、install スクリプトの enable 部分の現地 E2E は未実施（unit 生成・構文・PATH は検証済み、手順自体は通常 Ubuntu 向け）

## Acceptance Criteria (copied from the issue)

(Issue 無し — 会話起点の依頼。`Refs` なし)

- [x] ホスト再起動で c-lord が自動起動する（本番で linger 有効・実証済み）
- [x] その常駐方法を README に記載
- [x] 一般化（リポジトリ同梱の unit 雛形 + install スクリプト）

## Definition of Done checklist

- [x] `no-runtime-change`（c_lord ランタイム変更なし＝デプロイ用ツール + ドキュメントのみ）につき TDD / Staging Evidence は適用除外
- [x] `ruff`/`pyright`/`pytest` は Python 変更が無いため影響なし（CI で確認）
- [x] No unrelated changes（README + deploy/ + scripts/install-systemd.sh のみ）
- [x] 動きを説明するドキュメント（README）を同 PR で更新
