### PR TITLE
fix(staging): restart <branch> を origin に ff してから起動する (#436)

### DIFF
--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -82,11 +82,18 @@ cd /home/yousan/c-lord-staging-1
 bash scripts/staging.sh status             # identity / branch / pid / instances / log
 bash scripts/staging.sh stop               # この clone の bot を安全停止
 bash scripts/staging.sh restart            # 現在のブランチで安全再起動
-bash scripts/staging.sh restart <branch>   # branch に切り替えて再起動 (PR 検証用)
+bash scripts/staging.sh restart <branch>   # branch を origin の最新に同期して再起動 (PR 検証用)
 ```
 
 `restart` は: /proc/cwd で自分の bot だけを同定 → PID 直 kill → setsid + venv python で起動 →
 per-run ログ → `Logged in as` を待って identity を検証(mismatch なら非0で失敗)→ 単一インスタンス確認、まで自動で行う。
+
+`restart <branch>` は起動前に **`git fetch origin <branch>` → checkout → `git merge --ff-only origin/<branch>`** まで行い、
+ローカルブランチを **origin の最新に確実に同期**する(#436)。単なる `checkout` は fetch 済みでも
+ローカルブランチを古い HEAD のまま切り替えるだけなので、これが無いと「最新の fix を回したつもりで
+**古いコードを検証**」して偽の RED/GREEN を得る(#399 検証中に実害)。ローカルが origin と分岐していて
+ff できない場合は、**黙って古いコードを起動せず明示エラーで停止**する(`git reset --hard origin/<branch>` で
+破棄するか push してから再実行)。起動ログには回しているコミットが `checked out <branch> @ <short-sha>` と出る。
 
 **禁止事項(全て実害のあった事故パターン — #322 根因D)**:
 - `pgrep -f "c_lord.main" | xargs kill` 系の**パターン kill**(本番・自分のシェルに当たる/相対パス起動を取り逃す)

--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -270,13 +270,32 @@ check_log_identity() {
 
 cmd_restart() {
   local branch_arg="${1:-}"
-  [ -x "$VENV_PY" ] || die "no .venv in $CLONE_DIR ($VENV_PY がない)。uv sync --dev を先に実行。"
 
+  # ブランチ同期は venv チェックより前に行う (#436)。理由 2 つ:
+  #  1) 単なる `git checkout <branch>` はローカルブランチを古い HEAD のまま
+  #     切り替えるだけで、fetch 済みでも origin に追従しない。検証者は
+  #     「最新の fix を回したつもりで古いコード」を起動し偽 RED/GREEN を得る
+  #     (#399 検証中に実害: d09fd57 を push・fetch 済みなのに 1 つ前の
+  #     47c3f02 を起動していた)。fetch → checkout → origin/<branch> へ
+  #     fast-forward まで行って初めて「最新を回している」と言える。
+  #  2) launch 前に確実に同期させ、回しているコミットを起動ログに出すため。
+  # ff 不能 (ローカルが分岐) なら黙って古いコードを起動せず明示エラーで止める。
   if [ -n "$branch_arg" ]; then
-    git -C "$CLONE_DIR" fetch origin "$branch_arg" -q 2>/dev/null || true
-    git -C "$CLONE_DIR" checkout "$branch_arg" -q || die "branch '$branch_arg' に checkout できない"
-    echo "checked out: $(git -C "$CLONE_DIR" log --oneline -1)"
+    git -C "$CLONE_DIR" fetch origin "$branch_arg" -q \
+      || die "git fetch origin '$branch_arg' に失敗 (ブランチ名 / ネットワークを確認)。restart は origin に push 済みのブランチを対象にする。"
+    git -C "$CLONE_DIR" checkout "$branch_arg" -q \
+      || die "branch '$branch_arg' に checkout できない"
+    if ! git -C "$CLONE_DIR" merge --ff-only "origin/$branch_arg" -q; then
+      die "branch '$branch_arg' を origin/$branch_arg に fast-forward できない (local=$(git -C "$CLONE_DIR" rev-parse --short HEAD) origin=$(git -C "$CLONE_DIR" rev-parse --short "origin/$branch_arg" 2>/dev/null))。ローカルに origin へ無いコミットがある — 'git -C $CLONE_DIR reset --hard origin/$branch_arg' で破棄するか push してから再実行。"
+    fi
   fi
+  # 起動するコミットを必ず明示する (#436 AC: 検証者が回している HEAD を一目で)。
+  local head_branch head_sha
+  head_branch="$(git -C "$CLONE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  head_sha="$(git -C "$CLONE_DIR" rev-parse --short HEAD 2>/dev/null || true)"
+  [ -n "$head_sha" ] && echo "checked out $head_branch @ $head_sha"
+
+  [ -x "$VENV_PY" ] || die "no .venv in $CLONE_DIR ($VENV_PY がない)。uv sync --dev を先に実行。"
 
   cmd_stop
 

--- a/tests/test_staging_script.py
+++ b/tests/test_staging_script.py
@@ -25,6 +25,15 @@ def run_script(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 class TestScriptGuards:
     def test_script_exists_and_is_executable(self) -> None:
         assert SCRIPT.is_file()
@@ -228,3 +237,89 @@ class TestLease:
         result = run_script(["stop", "--owner", "sess-B"], cwd=clone)
         assert result.returncode != 0
         assert "sess-A" in result.stdout + result.stderr
+
+
+class TestRestartBranchSync:
+    """restart <branch> は origin/<branch> へ確実に同期してから起動する (#436).
+
+    単なる `git checkout <branch>` はローカルブランチを古い HEAD のまま切り替える
+    だけで、`git fetch` 済みでも origin に追従しない。検証者は「最新の fix を回した
+    つもりで古いコード」を起動し、偽の RED/GREEN を得る (#399 検証中に実害)。
+    """
+
+    def _origin_and_clone(self, tmp_path: Path) -> tuple[Path, str, str]:
+        """origin/feature を 2 コミット先 (c2) に進め、clone は feature@c1 で stale。
+
+        戻り値: (clone, c1, c2) — c1=stale ローカル HEAD, c2=origin/feature。
+        """
+        origin = tmp_path / "origin"
+        origin.mkdir()
+        _git(origin, "init", "-q", "-b", "main")
+        _git(origin, "config", "user.email", "t@example.com")
+        _git(origin, "config", "user.name", "t")
+        (origin / "VERSION").write_text("c1\n", encoding="utf-8")
+        _git(origin, "add", "-A")
+        _git(origin, "commit", "-qm", "c1")
+        _git(origin, "branch", "feature")  # feature@c1
+
+        clone = tmp_path / "clone"
+        subprocess.run(
+            ["git", "clone", "-q", str(origin), str(clone)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(clone, "config", "user.email", "t@example.com")
+        _git(clone, "config", "user.name", "t")
+        _git(clone, "checkout", "-q", "feature")  # ローカル feature@c1 (stale)
+        c1 = _git(clone, "rev-parse", "HEAD")
+
+        # origin/feature を c2 に進める (clone はまだ知らない)
+        _git(origin, "checkout", "-q", "feature")
+        (origin / "VERSION").write_text("c2\n", encoding="utf-8")
+        _git(origin, "commit", "-aqm", "c2")
+        c2 = _git(origin, "rev-parse", "HEAD")
+        _git(origin, "checkout", "-q", "main")  # fetch 専用にしておく
+
+        (clone / ".env").write_text(
+            "DISCORD_BOT_TOKEN=dummy\nDISCORD_CHANNEL_ID=1\nEXPECTED_BOT_USER_ID=42\n",
+            encoding="utf-8",
+        )
+        return clone, c1, c2
+
+    def test_restart_fast_forwards_branch_to_origin(self, tmp_path: Path) -> None:
+        """AC1/AC2: restart <branch> は HEAD を origin/<branch> に ff し、回す sha を出す。
+
+        .venv が無いので launch 自体は後段で落ちるが、ブランチ同期はそれより前に
+        完了していなければならない (古いコードを起動させない)。
+        """
+        clone, c1, c2 = self._origin_and_clone(tmp_path)
+        run_script(["borrow", "--owner", "sess-S", "--purpose", "sync test"], cwd=clone)
+        assert _git(clone, "rev-parse", "HEAD") == c1  # 前提: stale
+
+        result = run_script(["restart", "feature", "--owner", "sess-S"], cwd=clone)
+
+        after = _git(clone, "rev-parse", "HEAD")
+        assert after == c2, (
+            f"branch not fast-forwarded to origin (after={after[:7]} want={c2[:7]})\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+        # AC2: 回しているコミットを一目で確認できる行
+        assert f"checked out feature @ {c2[:7]}" in result.stdout
+
+    def test_restart_refuses_when_local_diverges(self, tmp_path: Path) -> None:
+        """AC1: ff 不能 (ローカルが分岐) なら黙って古いコードを起動せず明示エラーで止まる。"""
+        clone, _, _ = self._origin_and_clone(tmp_path)
+        run_script(["borrow", "--owner", "sess-S", "--purpose", "diverge test"], cwd=clone)
+        # ローカル feature に origin に無いコミットを積む → origin/feature と分岐
+        (clone / "LOCAL").write_text("local only\n", encoding="utf-8")
+        _git(clone, "add", "-A")
+        _git(clone, "commit", "-qm", "local-only")
+        local_head = _git(clone, "rev-parse", "HEAD")
+
+        result = run_script(["restart", "feature", "--owner", "sess-S"], cwd=clone)
+
+        assert result.returncode != 0
+        assert "fast-forward" in (result.stdout + result.stderr).lower()
+        # 黙って origin の c2 に飛んだり起動したりしない (HEAD は触らず止まる)
+        assert _git(clone, "rev-parse", "HEAD") == local_head


### PR DESCRIPTION
## What does this PR do?

`scripts/staging.sh restart <branch>` が、指定ブランチを **origin の最新に確実に同期してから** bot を起動するようにする。

- `git fetch origin <branch>` → `git checkout <branch>` → **`git merge --ff-only origin/<branch>`** まで行う。
- ff 不能（ローカルが origin と分岐）なら **黙って古いコードを起動せず明示エラーで停止**する（`reset --hard` か push を促す）。
- 起動ログに **`checked out <branch> @ <short-sha>`** を出し、回しているコミットを一目で確認できるようにする。
- ブランチ同期を venv チェックより前に移動（launch 前に確実に同期 + ライブ起動なしで単体テスト可能に）。

## Why?

staging 検証の存在意義は「マージ前に実機で直ったことを確認する」こと。従来の `restart <branch>` は `fetch` 後に単なる `checkout` をするだけで `origin/<branch>` に追従せず、**古いコミットのまま bot を起動**していた。検証者は「最新の fix を回したつもりで古いコードを検証」し、偽の RED/GREEN を得る。実際に #399 の検証中にこれを踏み、修正コミット `d09fd57` を push・fetch 済みなのに staging は 1 つ前の `47c3f02` を起動していた。

Closes #436

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: `no-user-visible-change`（operator/開発者ツール `scripts/staging.sh` のみの変更。c-lord bot / Discord の見え方は変わらない）

## Acceptance Criteria (copied from the issue)

- [x] `staging.sh restart <branch>` が起動前に `git fetch origin` し、対象ブランチを `origin/<branch>` へ確実に同期する（ff 不能なら明示エラーで停止し、黙って古いコードを起動しない）
- [x] 起動ログに「checked out `<branch>` @ `<short-sha>`」を出し、検証者が回しているコミットを一目で確認できる
- [x] 既存の lease / identity チェックを壊さない（`pytest` 緑）

## Staging Evidence (証跡)

> このPRは **operator ツール `scripts/staging.sh` のみの変更**で、c-lord bot / Discord のランタイム挙動は一切変えない。シェルスクリプトは UI/レイアウトを持たず出力は全てテキストなので、Discord スクショは原理的に N/A。よって `no-runtime-change` ラベルを付け、証跡は **実 `staging.sh` を本物の git リポジトリに対して回した RED→GREEN**（モックではない）を貼る。`tests/test_staging_script.py::TestRestartBranchSync` が同じことを subprocess で自動検証している。

**RED（修正前 staging.sh）→ GREEN（修正後 staging.sh）を実 CLI で実演**（throwaway clone。origin/feature の真の最新 = `5a8e478`、ローカルは stale `732cc48`）:

```
true latest on origin/feature (the fix) = 5a8e478
local feature is stale at               = 732cc48

######## RED — OLD staging.sh: restart feature ########
  ERROR: no .venv ... (venv で停止)
  RESULT: local HEAD = 732cc48   --> STALE (bug: 古いコードのまま起動していた)

######## GREEN — NEW staging.sh (this PR): restart feature ########
  checked out feature @ 5a8e478
  ERROR: no .venv ... (venv で停止)
  RESULT: local HEAD = 5a8e478   --> LATEST (fixed: origin に ff)
```

（両者とも throwaway clone に `.venv` が無いため最終的に venv で停止するが、**ブランチ同期は launch より前に完了**しているのが要点。実 staging clone では venv があるのでそのまま起動まで進む。）

<details>
<summary>TDD: RED line (修正前コードでの失敗) — tests/test_staging_script.py::TestRestartBranchSync</summary>

```
FAILED test_restart_fast_forwards_branch_to_origin
  assert after == c2  →  42f2aeb (stale c1) != 56a9ab8 (c2)
FAILED test_restart_refuses_when_local_diverges
  assert "fast-forward" in (...)  →  got "ERROR: no .venv ..." (ff 同期に到達していない)
```
GREEN (修正後): `tests/test_staging_script.py` 23 passed（既存 21 + 新規 2）。
</details>

## Definition of Done checklist

> `no-runtime-change` ラベルにより Rule 1（DoD 完了）・証跡画像要件（#391）は免除。`Closes` 規律は常時適用（上の AC は全達成）。operator ツールのみの変更で bot/Discord ランタイム不変のため Discord 証跡は N/A、代わりに実 CLI の RED→GREEN を上に掲載。

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（`test_staging_script.py` 23/23。他 14 件は本PRと無関係の既存失敗で、clean `main` でも同一に失敗＝環境依存。CI のクリーン環境では緑）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass（CI スコープ `c_lord/` は clean、変更ファイルも clean）
- [x] Staging Evidence above is filled in（実 CLI RED→GREEN）
- [x] No unrelated changes in the diff; self-review done（diff = staging.sh / test / docs/STAGING.md の3ファイルのみ）
- [x] docs/STAGING.md の restart 記述を同PRで更新（`restart <branch>` の origin 同期挙動）
- [x] `Closes #436` は AC 100% 達成のため使用（独立行に記載）
