### PR TITLE
feat: コマンド/ボタンの未捕捉例外をユーザーに返す安全網 (#444)

### DIFF
--- a/c_lord/bot.py
+++ b/c_lord/bot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import sys
 from typing import TYPE_CHECKING
@@ -15,6 +16,7 @@ from .concurrency import SessionRegistry
 from .coordination.service import CoordinationService
 from .discord_ui.ask_bus import ask_bus
 from .discord_ui.ask_view import AskView
+from .discord_ui.permission_help import command_error_help
 
 if TYPE_CHECKING:
     from .database.ask_repo import PendingAskRepository
@@ -112,8 +114,41 @@ class ClaudeDiscordBot(commands.Bot):
     async def on_app_command_error(
         self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
-        """Log slash command errors that would otherwise be silently swallowed."""
+        """Log slash command errors AND surface an actionable reply (#444).
+
+        Logging alone (the pre-#444 behavior) left the user staring at Discord's
+        generic "アプリが応答しませんでした" with no idea what went wrong.  We now also
+        reply ephemerally with a sanitized message (no raw traceback): a
+        permission hint for ``discord.Forbidden``, otherwise a generic
+        "unexpected error" notice.  The reply itself is best-effort — if it also
+        fails (e.g. the interaction expired) we swallow that, since this is the
+        last-resort net.
+        """
         logger.error("Slash command error: %s", error, exc_info=error)
+        message = command_error_help(error)
+        with contextlib.suppress(discord.HTTPException):
+            if interaction.response.is_done():
+                await interaction.followup.send(message, ephemeral=True)
+            else:
+                await interaction.response.send_message(message, ephemeral=True)
+
+    async def on_command_error(
+        self, context: commands.Context, error: commands.CommandError
+    ) -> None:
+        """Surface text-command (``!cmd``) errors to the user (#444).
+
+        discord.py's default handler only prints a traceback to stderr (invisible
+        on bot hosts), so before #444 a failing ``!clord``/``!stop`` looked like a
+        silent hang.  ``CommandNotFound`` is ignored (mentions and unrelated ``!``
+        text are not errors); everything else is logged and answered with a
+        sanitized message via ``ctx.send``.
+        """
+        if isinstance(error, commands.CommandNotFound):
+            return
+        logger.error("Text command error: %s", error, exc_info=error)
+        message = command_error_help(error)
+        with contextlib.suppress(discord.HTTPException):
+            await context.send(message)
 
     def _assert_expected_identity(self) -> None:
         """Fail fast when the logged-in identity is not the expected one.

--- a/c_lord/discord_ui/ask_view.py
+++ b/c_lord/discord_ui/ask_view.py
@@ -29,6 +29,7 @@ import discord
 
 from .ask_bus import AskAnswerBus
 from .ask_bus import ask_bus as _default_ask_bus
+from .error_reporting import ErrorReportingViewMixin
 
 if TYPE_CHECKING:
     from ..claude.types import AskQuestion
@@ -42,7 +43,7 @@ _RESTART_MSG = (
 )
 
 
-class AskView(discord.ui.View):
+class AskView(ErrorReportingViewMixin, discord.ui.View):
     """Renders buttons or a select menu for a single AskUserQuestion prompt.
 
     This is a **persistent** view — ``timeout=None``.  Register it with the

--- a/c_lord/discord_ui/elicitation_view.py
+++ b/c_lord/discord_ui/elicitation_view.py
@@ -18,13 +18,14 @@ from typing import Any
 import discord
 
 from ..claude.types import ElicitationRequest
+from .error_reporting import ErrorReportingViewMixin
 
 logger = logging.getLogger(__name__)
 
 ELICITATION_TIMEOUT = 300  # 5 minutes
 
 
-class ElicitationUrlView(discord.ui.View):
+class ElicitationUrlView(ErrorReportingViewMixin, discord.ui.View):
     """Single button opening a URL for url-mode elicitation."""
 
     def __init__(self, runner, request: ElicitationRequest) -> None:
@@ -129,7 +130,7 @@ class ElicitationFormModal(discord.ui.Modal):
         )
 
 
-class ElicitationFormView(discord.ui.View):
+class ElicitationFormView(ErrorReportingViewMixin, discord.ui.View):
     """Single button that opens the form Modal for form-mode elicitation."""
 
     def __init__(self, runner, request: ElicitationRequest) -> None:

--- a/c_lord/discord_ui/error_reporting.py
+++ b/c_lord/discord_ui/error_reporting.py
@@ -1,0 +1,48 @@
+"""Shared ``on_error`` for Discord UI Views (#444 safety net).
+
+By default, an unhandled exception in a ``discord.ui.View`` button/modal callback
+shows the user a generic "This interaction failed" and prints a traceback to
+stderr (invisible on bot hosts).  ``ErrorReportingViewMixin`` overrides
+``on_error`` so every View instead logs the exception AND replies to the user
+with a sanitized, actionable message.
+
+Usage: list the mixin *before* ``discord.ui.View`` in the bases so its
+``on_error`` takes precedence::
+
+    class StopView(ErrorReportingViewMixin, discord.ui.View): ...
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+import discord
+
+from .permission_help import command_error_help
+
+logger = logging.getLogger(__name__)
+
+
+class ErrorReportingViewMixin:
+    """Mixin that turns an unhandled View callback error into a user reply."""
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,
+    ) -> None:
+        logger.error(
+            "Unhandled error in %s view callback (item=%r): %s",
+            type(self).__name__,
+            getattr(item, "custom_id", item),
+            error,
+            exc_info=error,
+        )
+        message = command_error_help(error)
+        with contextlib.suppress(discord.HTTPException):
+            if interaction.response.is_done():
+                await interaction.followup.send(message, ephemeral=True)
+            else:
+                await interaction.response.send_message(message, ephemeral=True)

--- a/c_lord/discord_ui/permission_help.py
+++ b/c_lord/discord_ui/permission_help.py
@@ -9,6 +9,8 @@ hitting a silent failure or a generic "interaction failed".
 
 from __future__ import annotations
 
+import discord
+
 
 class ThreadCreateForbiddenError(Exception):
     """Signals that ``channel.create_thread()`` failed with ``discord.Forbidden``.
@@ -39,3 +41,35 @@ def create_thread_permission_help() -> str:
     Create Public Threads on the channel).
     """
     return _CREATE_THREAD_PERMISSION_HELP
+
+
+# --- Generic last-resort messages (#444 safety net) ----------------------------
+# Shown when an *unhandled* exception reaches a global error handler (slash/text
+# command, or a View button/modal callback). They must be actionable but must
+# NOT leak the raw exception text or a traceback to the user.
+
+PERMISSION_DENIED_HELP = (
+    "❌ Bot に必要な権限が無い可能性があります。対象チャンネルで Bot（またはそのロール）に "
+    "「チャンネルを見る」「メッセージの送信」「公開スレッドの作成」"
+    "「スレッドでメッセージを送信」などが付与されているか確認してください。"
+)
+
+UNEXPECTED_ERROR_HELP = (
+    "⚠️ 処理中に予期せぬエラーが発生しました。少し待ってもう一度試してください。"
+    "繰り返す場合は bot のログを確認してください。"
+)
+
+
+def command_error_help(error: BaseException) -> str:
+    """Map a command/interaction exception to a sanitized, user-facing message.
+
+    discord.py wraps callback exceptions in ``CommandInvokeError`` (both the
+    app-command and text-command variants expose the cause as ``.original``), so
+    we unwrap one level before classifying.  A ``discord.Forbidden`` becomes a
+    permission hint; anything else becomes a generic "unexpected error" message
+    so the user never sees a raw traceback.
+    """
+    original = getattr(error, "original", error)
+    if isinstance(original, discord.Forbidden):
+        return PERMISSION_DENIED_HELP
+    return UNEXPECTED_ERROR_HELP

--- a/c_lord/discord_ui/permission_view.py
+++ b/c_lord/discord_ui/permission_view.py
@@ -12,13 +12,14 @@ import logging
 import discord
 
 from ..claude.types import PermissionRequest
+from .error_reporting import ErrorReportingViewMixin
 
 logger = logging.getLogger(__name__)
 
 PERMISSION_TIMEOUT = 120  # 2 minutes to approve/deny
 
 
-class PermissionView(discord.ui.View):
+class PermissionView(ErrorReportingViewMixin, discord.ui.View):
     """Allow / Deny buttons for tool permission requests."""
 
     def __init__(self, runner, request: PermissionRequest) -> None:

--- a/c_lord/discord_ui/plan_view.py
+++ b/c_lord/discord_ui/plan_view.py
@@ -11,13 +11,15 @@ import logging
 
 import discord
 
+from .error_reporting import ErrorReportingViewMixin
+
 logger = logging.getLogger(__name__)
 
 # Timeout for plan approval — if no response in 5 minutes, cancel.
 PLAN_APPROVAL_TIMEOUT = 300
 
 
-class PlanApprovalView(discord.ui.View):
+class PlanApprovalView(ErrorReportingViewMixin, discord.ui.View):
     """Two-button view: ✅ Approve | ❌ Cancel for plan mode."""
 
     def __init__(self, runner, request_id: str) -> None:

--- a/c_lord/discord_ui/views.py
+++ b/c_lord/discord_ui/views.py
@@ -9,6 +9,7 @@ from typing import Protocol, runtime_checkable
 import discord
 
 from .embeds import stopped_embed
+from .error_reporting import ErrorReportingViewMixin
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ class Interruptable(Protocol):
     async def interrupt(self) -> None: ...
 
 
-class StopView(discord.ui.View):
+class StopView(ErrorReportingViewMixin, discord.ui.View):
     """A ⏹ Stop button attached to the session status message.
 
     Clicking it sends SIGINT to the active Claude runner (graceful interrupt,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -72,9 +72,17 @@ class TestOnAppCommandError:
 
     @pytest.mark.asyncio
     async def test_handler_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
-        """on_app_command_error should log the error at ERROR level."""
+        """on_app_command_error should log the error at ERROR level.
+
+        #444 also makes it reply to the user, so the interaction's response
+        methods must be awaitable mocks (see test_error_safety_net.py for the
+        reply-behavior assertions).
+        """
         bot = ClaudeDiscordBot(channel_id=123)
         interaction = MagicMock()
+        interaction.response.is_done.return_value = False
+        interaction.response.send_message = AsyncMock()
+        interaction.followup.send = AsyncMock()
         error = app_commands.AppCommandError("test failure")
 
         with caplog.at_level(logging.ERROR, logger="c_lord.bot"):

--- a/tests/test_error_safety_net.py
+++ b/tests/test_error_safety_net.py
@@ -1,0 +1,179 @@
+"""Tests for #444: last-resort error surfacing ("safety net").
+
+Before #444, an unhandled exception in a slash command, text command, or a
+View button callback left the user with nothing actionable: slash commands
+showed "アプリが応答しませんでした", text commands failed silently, and buttons
+showed "インタラクションに失敗しました". These tests assert each path now logs AND
+replies to the user with a sanitized, actionable message.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord import app_commands
+from discord.ext import commands
+
+from c_lord.bot import ClaudeDiscordBot
+from c_lord.discord_ui.error_reporting import ErrorReportingViewMixin
+from c_lord.discord_ui.permission_help import (
+    PERMISSION_DENIED_HELP,
+    UNEXPECTED_ERROR_HELP,
+    command_error_help,
+)
+
+
+def _forbidden() -> discord.Forbidden:
+    resp = MagicMock()
+    resp.status = 403
+    resp.reason = "Forbidden"
+    return discord.Forbidden(resp, "Missing Access")
+
+
+class TestCommandErrorHelp:
+    """command_error_help() maps an exception to a user-facing message."""
+
+    def test_forbidden_maps_to_permission_help(self) -> None:
+        assert command_error_help(_forbidden()) == PERMISSION_DENIED_HELP
+
+    def test_wrapped_forbidden_maps_to_permission_help(self) -> None:
+        # discord.py wraps callback exceptions in CommandInvokeError(.original).
+        wrapped = app_commands.CommandInvokeError(MagicMock(), _forbidden())
+        assert command_error_help(wrapped) == PERMISSION_DENIED_HELP
+
+    def test_generic_error_maps_to_unexpected(self) -> None:
+        msg = command_error_help(RuntimeError("boom"))
+        assert msg == UNEXPECTED_ERROR_HELP
+        # Must not leak the raw exception text / traceback to the user.
+        assert "boom" not in msg
+
+
+class TestOnAppCommandErrorReplies:
+    """on_app_command_error logs AND replies ephemerally (was log-only)."""
+
+    @pytest.mark.asyncio
+    async def test_replies_ephemeral_when_not_yet_responded(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        bot = ClaudeDiscordBot(channel_id=123)
+        interaction = MagicMock()
+        interaction.response.is_done.return_value = False
+        interaction.response.send_message = AsyncMock()
+        interaction.followup.send = AsyncMock()
+
+        error = app_commands.CommandInvokeError(MagicMock(), _forbidden())
+        with caplog.at_level(logging.ERROR, logger="c_lord.bot"):
+            await bot.on_app_command_error(interaction, error)
+
+        interaction.response.send_message.assert_awaited_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+        assert PERMISSION_DENIED_HELP in interaction.response.send_message.call_args.args[0]
+        # Still logged (regression guard for the pre-#444 behavior).
+        assert caplog.records
+
+    @pytest.mark.asyncio
+    async def test_uses_followup_when_already_responded(self) -> None:
+        bot = ClaudeDiscordBot(channel_id=123)
+        interaction = MagicMock()
+        interaction.response.is_done.return_value = True
+        interaction.response.send_message = AsyncMock()
+        interaction.followup.send = AsyncMock()
+
+        await bot.on_app_command_error(
+            interaction, app_commands.CommandInvokeError(MagicMock(), RuntimeError("x"))
+        )
+
+        interaction.followup.send.assert_awaited_once()
+        assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True
+        interaction.response.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reply_failure_is_suppressed(self) -> None:
+        # If even the ephemeral reply fails (e.g. interaction expired), the
+        # handler must not raise (it is the last-resort net).
+        bot = ClaudeDiscordBot(channel_id=123)
+        interaction = MagicMock()
+        interaction.response.is_done.return_value = False
+        interaction.response.send_message = AsyncMock(side_effect=_forbidden())
+        interaction.followup.send = AsyncMock(side_effect=_forbidden())
+        await bot.on_app_command_error(
+            interaction, app_commands.CommandInvokeError(MagicMock(), RuntimeError("x"))
+        )  # must not raise
+
+
+class TestOnCommandError:
+    """on_command_error (text commands) — new in #444."""
+
+    @pytest.mark.asyncio
+    async def test_command_not_found_is_ignored(self) -> None:
+        bot = ClaudeDiscordBot(channel_id=123)
+        ctx = MagicMock()
+        ctx.send = AsyncMock()
+        await bot.on_command_error(ctx, commands.CommandNotFound("nope"))
+        ctx.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_other_error_sends_user_message(self) -> None:
+        bot = ClaudeDiscordBot(channel_id=123)
+        ctx = MagicMock()
+        ctx.send = AsyncMock()
+        await bot.on_command_error(ctx, commands.CommandInvokeError(_forbidden()))
+        ctx.send.assert_awaited_once()
+        assert PERMISSION_DENIED_HELP in ctx.send.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_send_failure_is_suppressed(self) -> None:
+        bot = ClaudeDiscordBot(channel_id=123)
+        ctx = MagicMock()
+        ctx.send = AsyncMock(side_effect=_forbidden())
+        await bot.on_command_error(
+            ctx, commands.CommandInvokeError(RuntimeError("x"))
+        )  # must not raise
+
+
+class TestErrorReportingViewMixin:
+    """Button/modal callbacks surface an actionable message instead of the
+    generic 'This interaction failed'."""
+
+    @pytest.mark.asyncio
+    async def test_on_error_replies_ephemeral_and_logs(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        class _V(ErrorReportingViewMixin, discord.ui.View):
+            pass
+
+        view = _V(timeout=None)
+        interaction = MagicMock()
+        interaction.response.is_done.return_value = False
+        interaction.response.send_message = AsyncMock()
+        interaction.followup.send = AsyncMock()
+
+        with caplog.at_level(logging.ERROR):
+            await view.on_error(interaction, RuntimeError("boom"), MagicMock())
+
+        interaction.response.send_message.assert_awaited_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+        assert caplog.records
+
+    def test_all_real_views_inherit_the_mixin(self) -> None:
+        from c_lord.discord_ui.ask_view import AskView
+        from c_lord.discord_ui.elicitation_view import (
+            ElicitationFormView,
+            ElicitationUrlView,
+        )
+        from c_lord.discord_ui.permission_view import PermissionView
+        from c_lord.discord_ui.plan_view import PlanApprovalView
+        from c_lord.discord_ui.views import StopView
+
+        for cls in (
+            StopView,
+            PermissionView,
+            PlanApprovalView,
+            AskView,
+            ElicitationUrlView,
+            ElicitationFormView,
+        ):
+            assert issubclass(cls, ErrorReportingViewMixin), cls.__name__


### PR DESCRIPTION
## 概要

コマンド／ボタンで**想定外の例外**が出たとき、利用者に何も・あるいは無意味な汎用エラーしか返らなかった「最後の安全網」の欠落を埋める。未捕捉例外を一律でユーザーへ ephemeral 返信し、ログにも残す。

Closes #444

### 利用者から見た変化（これがこうなる）

- **スラッシュコマンド**で予期せぬ例外 → 今まで「アプリが応答しませんでした」だけ → **ephemeral で原因に応じた案内**（権限不足なら付与すべき権限を名指し、それ以外は「予期せぬエラー」の汎用文）。
- **テキストコマンド（`!clord` 等）**で例外 → 今まで無反応（stderr のみ） → **チャンネルに案内**（`CommandNotFound` は無視）。
- **ボタン/モーダル**で例外 → 今まで「インタラクションに失敗しました」 → **ephemeral で同じ案内**（全 View 共通）。
- 生 traceback・例外文言は**ユーザーに出さない**（サニタイズ済みの定数のみ）。ログには `exc_info` で従来どおり残る。

## 変更

- `c_lord/discord_ui/permission_help.py`: `command_error_help(error)`（`CommandInvokeError.original` を1段アンラップし、`discord.Forbidden`→権限ヒント / それ以外→汎用文）と定数 `PERMISSION_DENIED_HELP` / `UNEXPECTED_ERROR_HELP` を追加。
- `c_lord/discord_ui/error_reporting.py`（新規）: `ErrorReportingViewMixin` — View の `on_error` をログ＋ephemeral 返信に。
- `c_lord/bot.py`: `on_app_command_error` を「ログのみ」→「ログ＋ephemeral 返信」に。`on_command_error` を新設。返信失敗は `contextlib.suppress`。
- 全 View（StopView / PermissionView / PlanApprovalView / AskView / ElicitationUrlView / ElicitationFormView）が mixin を継承。

## Acceptance Criteria

- [x] `on_app_command_error` がログ＋interaction へ ephemeral 返信（未応答=`send_message`／応答済=`followup.send`）。サニタイズ文言。Forbidden 由来→権限ヒント、他→汎用文（unit）
- [x] `on_command_error` 新設。`CommandNotFound` 無視。`CommandInvokeError` は `.original` 展開。`ctx.send`（失敗は suppress）（unit）
- [x] 全 View に `on_error` を共有 mixin で追加。`test_all_real_views_inherit_the_mixin` で 6 View すべてを強制（unit）
- [x] `pytest`（新規 11 件 green、フル 1928 passed）+ `ruff check` + `ruff format --check` + `pyright`(0 errors) green
- [x] **Staging behavior verified**（下記）

## TDD Evidence

RED（実装前、`tests/test_error_safety_net.py`）:
```
ModuleNotFoundError: No module named 'c_lord.discord_ui.error_reporting'
```
GREEN（実装後）: `11 passed`。フルスイート `1928 passed, 3 skipped`。

## Staging Evidence

staging-2（`C-lord-staging-2`、独立 bot/channel）で、**同一の入力 `!attach`（必須引数 `window` を省略 → `MissingRequiredArgument`）** を webhook 経由で E2E スレッドに投げ、`main`(RED) と `feature/444-error-safety-net`(GREEN) を比較。

- **RED（`main` = #444 なし）**: `on_command_error` が存在せず、`MissingRequiredArgument` は discord.py 既定で stderr に出るだけ → **Discord 上は無反応**。
  - REST 取得（最新メッセージ）: `[clord-e2e-444] '!attach'` の後に bot 応答なし。
  - ![444-red](https://github.com/yousan/c-lord/releases/download/evidence/i447-444-444-sg2-red-20260619T001913Z-00.png)
- **GREEN（`feature/444-error-safety-net`）**: 新設の `on_command_error` が発火し、サニタイズ文言を in-channel 返信。
  - REST 取得: `[C-lord-staging-2] '⚠️ 処理中に予期せぬエラーが発生しました。少し待ってもう一度試してください。繰り返す場合は bot のログを確認してください。'`
  - ![444-green](https://github.com/yousan/c-lord/releases/download/evidence/i447-444-444-sg2-green-20260619T001913Z-01.png)

<details><summary>検証手順</summary>

```
borrow staging-2 → restart main → webhook POST '!attach' (?thread_id=E2E) → REST 確認(無反応) → スクショ(red)
       → restart feature/444-error-safety-net → 同じ '!attach' → REST 確認(⚠️案内) → スクショ(green)
       → restart main → release。一時 webhook は検証後に削除(204)。
```
</details>

## セキュリティ

`security-audit` 実施。subprocess/shell/eval なし。Discord へ送るのは静的定数（`command_error_help`）のみで、生 traceback・例外文言・secret は出さない（ログには `exc_info`）。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)".

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted（`ModuleNotFoundError: No module named 'c_lord.discord_ui.error_reporting'`）
- [x] `uv run pytest tests/ -v` passes（フル 1928 passed / 3 skipped、新規 11 件 green）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright`(0 errors) pass
- [x] Staging Evidence above is filled in（staging-2 で RED→GREEN・スクショ＋REST 文言）
- [x] No unrelated changes in the diff; self-review done（bot.py / 6 View / permission_help / error_reporting / tests のみ）
- [x] 動きを変えた利用者向け説明は本 PR 本文「利用者から見た変化」に記載（新規のエラー応答挙動。`docs/` の仕様変更は無し）
- [x] `Closes #444` は 100% AC 充足のため使用（独立行）

## 関連

- #443（共通の `permission_help` を導入。本 PR はそれを安全網から再利用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
