### PR TITLE
fix(staging): parent+child(uv ラッパ+python) を 1 インスタンスと数える (#437)

### DIFF
--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -101,6 +101,32 @@ ff できない場合は、**黙って古いコードを起動せず明示エラ
 - `nohup uv run ...` での起動(Bash ツール teardown で exit 144 死する)
 - 本番 (`/home/yousan/c-lord`) への手動 kill+nohup(supervised — #195 の二重 bot 事故になる)
 
+## supervision モデル — 誰が respawn するか (#437)
+
+「prod に c_lord.main が **2 プロセス**見えるが二重起動か?」「`staging.sh stop` したのに復活するか?」を
+切り分けるための、起動・監視の実態:
+
+| | prod (`/home/yousan/c-lord`) | staging (`/home/yousan/c-lord-staging-N`) |
+|---|---|---|
+| 起動者 | **`systemd --user c-lord.service`**(`Restart=always`, `RestartSec=5`) | **`scripts/staging.sh`**(手動) |
+| 起動コマンド | `start-clord.sh` → `exec uv run python -m c_lord.main` | `setsid <venv>/bin/python -m c_lord.main`(uv ラッパ無し) |
+| プロセス数 | **2 が正常**: `uv` ラッパ(親) + `python` 実体(子) | **1**: `python` のみ |
+| 死んだら | systemd が 5 秒後に respawn | **respawn しない**(stop したら止まったまま) |
+
+- **prod の「2 プロセス」は二重起動ではない**。`uv run python -m c_lord.main` は uv ラッパ(親)を
+  立て、その子として実体の `python` を exec する。`pgrep -f c_lord.main` は cmdline に `c_lord.main` を
+  含む**両方**に当たるので 2 に見えるだけ。親子は `ps -o ppid=` で確認できる(子の ppid = 親の pid)。
+  `staging.sh status` / `restart` は**この parent+child を 1 インスタンスと数える**(`instance_leaders`:
+  親が同一 clone の matched pid である pid = 子 を代表から除く)。本物の二重起動(独立した 2 起動)は
+  ちゃんと `instances: 2` + 終了コード 2 で検出する。
+- **staging には systemd ユニットも guard も無い**。`staging.sh` は `setsid` で venv python を直起動する
+  だけなので、`stop` 後に勝手に復活する経路は無い。staging で churn(pid が数秒おきに変わる)を見たら、
+  それは respawn ではなく**手動 `restart` の競合**を疑う。
+- **`start-clord.sh --guard`**(ログインフックモード)は存在するが、**prod しか起動しない**
+  (`cd $HOME/c-lord`)。二重起動防止に global な `pgrep -f c_lord.main` を使うため、staging bot が
+  動いていると「既に起動済み」と判断して prod を起こさない、という相互作用がある。現状 `~/.zprofile`
+  等のシェルプロファイルには未配線。
+
 ## 占有(借用)プロトコル (#328)
 
 staging は**共有リソース**。複数セッションが同時に使うと kill / checkout の踏み合いになる(2026-05-29 実害)。

--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -189,10 +189,35 @@ find_pids() {
   done
 }
 
+instance_leaders() {
+  # find_pids のうち「親が同じ clone の c_lord.main プロセスでない」pid =
+  # 論理インスタンスの代表 (プロセスツリーの根) だけを返す (#437)。
+  #
+  # なぜ必要か: `uv run python -m c_lord.main` は uv ラッパ(親)+python(子) の
+  # 2 プロセスになり、どちらの cmdline にも c_lord.main が入るので pgrep は
+  # 両方に当たる。これは「正常な 1 インスタンス」であって二重起動ではない
+  # (prod は systemd → start-clord.sh → uv run … でこの形。docs/STAGING.md
+  # 参照)。子 (親が同 clone の matched pid である pid) を除けば、本当に独立
+  # した起動だけが代表として残り、parent+child は 1 と数えられる。
+  local pids pid ppid
+  pids="$(find_pids)"
+  [ -z "$pids" ] && return 0
+  for pid in $pids; do
+    ppid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+    # 親が matched 集合に居れば、この pid は子 → 代表ではない (出力しない)。
+    printf '%s\n' "$pids" | /usr/bin/grep -qx "$ppid" || echo "$pid"
+  done
+}
+
+count_instances() {
+  # 論理インスタンス数 (parent+child を 1 と数える)。0 なら 0 を返す。
+  instance_leaders | /usr/bin/grep -c . || true
+}
+
 cmd_status() {
   local pids count branch expected channel
   pids="$(find_pids)"
-  count=$(echo "$pids" | /usr/bin/grep -c . || true)
+  count="$(count_instances)" # 論理インスタンス数 (uv ラッパ+子 = 1, #437)
   branch="$(git -C "$CLONE_DIR" branch --show-current 2>/dev/null || echo '(not a git repo)')"
   expected="$(env_get EXPECTED_BOT_USER_ID)"
   channel="$(env_get DISCORD_CHANNEL_ID)"
@@ -342,10 +367,21 @@ cmd_restart() {
         done
         die "誤った identity で起動したため停止した (ログ: $log)"
       fi
-      local count
-      count="$(find_pids | /usr/bin/grep -c . || true)"
-      echo "instances: $count"
-      [ "$count" = "1" ] || die "単一インスタンスでない (count=$count)"
+      # 論理インスタンスが 1 に収束するのを待つ (#437)。parent+child(uv ラッパ
+      # +python) は 1 と数える。staging は venv python 直起動で即 1 になるが、
+      # 万一 churn しても収束を待ってから単一を保証する。
+      local inst tries=0
+      while :; do
+        inst="$(count_instances)"
+        [ "$inst" = "1" ] && break
+        tries=$((tries + 1))
+        if [ "$tries" -ge 5 ]; then
+          echo "instances: $inst"
+          die "単一インスタンスに収束しない (instances=$inst)"
+        fi
+        sleep 1
+      done
+      echo "instances: $inst"
       echo "OK"
       return 0
     fi
@@ -395,7 +431,11 @@ BRANCH="$POSITIONAL"
 
 case "$COMMAND" in
 status)
+  # cmd_status の終了コード (二重起動疑い = 2) を後続の lease 出力で潰さず
+  # スクリプトの終了コードに伝播させる (#437): 機械からは exit code で単一性を
+  # 判定できる必要がある。
   cmd_status
+  status_rc=$?
   if [ -f "$LEASE_FILE" ]; then
     if lease_is_valid; then
       echo "lease:     $(lease_describe)"
@@ -405,6 +445,7 @@ status)
   else
     echo "lease:     (none)"
   fi
+  exit "$status_rc"
   ;;
 borrow) cmd_borrow "$OWNER" "$PURPOSE" "$TTL_HOURS" ;;
 release) cmd_release "$OWNER" ;;

--- a/tests/test_staging_script.py
+++ b/tests/test_staging_script.py
@@ -9,7 +9,11 @@ Evidence).
 
 from __future__ import annotations
 
+import contextlib
+import os
+import signal
 import subprocess
+import time
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "staging.sh"
@@ -323,3 +327,101 @@ class TestRestartBranchSync:
         assert "fast-forward" in (result.stdout + result.stderr).lower()
         # 黙って origin の c2 に飛んだり起動したりしない (HEAD は触らず止まる)
         assert _git(clone, "rev-parse", "HEAD") == local_head
+
+
+class TestInstanceCounting:
+    """status / restart は parent+child（uv ラッパ + python 子）を 1 インスタンスと数える (#437).
+
+    `uv run python -m c_lord.main` は uv ラッパ（親）+ python（実体・子）の 2 プロセスになり、
+    `pgrep -f c_lord.main` は両方に当たる。これを 2 と誤カウントすると、検証者は「正常な
+    parent+child」を「二重起動」と誤検出してしまう。論理インスタンス = 親が同一 clone の
+    c_lord.main でない pid（= プロセスツリーの代表）だけを数える。
+
+    テストは実プロセス（cwd=clone・cmdline に c_lord.main を含む sleep）を spawn して検証する。
+    本物の bot や Discord 接続は不要。find_pids は cwd 一致で絞るので、この clone(tmp) の
+    fake だけが対象になり、ホスト上の実 bot とは混ざらない。
+    """
+
+    def _clone_env(self, tmp_path: Path) -> Path:
+        (tmp_path / ".env").write_text(
+            "DISCORD_BOT_TOKEN=dummy\nDISCORD_CHANNEL_ID=1\nEXPECTED_BOT_USER_ID=42\n",
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    @staticmethod
+    def _spawn_single(clone: Path) -> subprocess.Popen[bytes]:
+        """staging 起動形: 単一 python プロセス（cmdline ~ c_lord.main, cwd=clone）。"""
+        return subprocess.Popen(
+            ["bash", "-c", 'exec -a "python -m c_lord.main" sleep 300'],
+            cwd=str(clone),
+            start_new_session=True,
+        )
+
+    @staticmethod
+    def _spawn_uv_style(clone: Path) -> subprocess.Popen[bytes]:
+        """prod 起動形: uv ラッパ（親）+ python（子）。子の ppid は親。両方 cmdline 一致。"""
+        script = (
+            'exec -a "uv run python -m c_lord.main" '
+            "bash -c 'exec -a \"python -m c_lord.main child\" sleep 300 & wait'"
+        )
+        return subprocess.Popen(
+            ["bash", "-c", script],
+            cwd=str(clone),
+            start_new_session=True,
+        )
+
+    @staticmethod
+    def _count_procs(clone: Path) -> int:
+        """staging.sh とは独立に、cwd=clone かつ cmdline ~ c_lord.main のプロセス数を数える。"""
+        out = subprocess.run(
+            ["pgrep", "-f", r"c_lord\.main"], capture_output=True, text=True
+        ).stdout.split()
+        n = 0
+        for pid in out:
+            with contextlib.suppress(OSError):
+                if os.readlink(f"/proc/{pid}/cwd") == str(clone):
+                    n += 1
+        return n
+
+    def _wait_procs(self, clone: Path, n: int, timeout: float = 6.0) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self._count_procs(clone) >= n:
+                return
+            time.sleep(0.1)
+        raise AssertionError(f"fake procs (cwd={clone}) が {n} に到達しない")
+
+    @staticmethod
+    def _kill(proc: subprocess.Popen[bytes]) -> None:
+        with contextlib.suppress(ProcessLookupError, OSError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        with contextlib.suppress(Exception):
+            proc.wait(timeout=5)
+
+    def test_status_counts_uv_wrapper_and_child_as_one(self, tmp_path: Path) -> None:
+        """AC1: uv ラッパ(親)+python(子) は instances: 1（二重起動の誤検出をしない）。"""
+        clone = self._clone_env(tmp_path)
+        proc = self._spawn_uv_style(clone)
+        try:
+            self._wait_procs(clone, 2)  # 親+子の両方が上がるのを待つ
+            result = run_script(["status"], cwd=clone)
+            assert "instances: 1" in result.stdout, result.stdout
+            assert "二重起動" not in result.stdout, result.stdout
+            assert result.returncode == 0, result.stdout
+        finally:
+            self._kill(proc)
+
+    def test_status_counts_two_independent_bots_as_two(self, tmp_path: Path) -> None:
+        """本物の二重起動（独立した 2 プロセス）はちゃんと instances: 2 で検出する。"""
+        clone = self._clone_env(tmp_path)
+        p1 = self._spawn_single(clone)
+        p2 = self._spawn_single(clone)
+        try:
+            self._wait_procs(clone, 2)
+            result = run_script(["status"], cwd=clone)
+            assert "instances: 2" in result.stdout, result.stdout
+            assert result.returncode == 2, result.stdout  # WARNING: 二重起動の疑い
+        finally:
+            self._kill(p1)
+            self._kill(p2)


### PR DESCRIPTION
## What does this PR do?

`scripts/staging.sh` の instance カウントが、`uv run python -m c_lord.main` の **uv ラッパ（親）+ python（子）を 1 インスタンスと数える**ようにする（従来は 2 と誤カウントし、正常な parent+child を「二重起動」と誤検出していた）。あわせて prod/staging の supervision モデルを `docs/STAGING.md` に明記する。

- `instance_leaders` / `count_instances` を追加：親が同一 clone の `c_lord.main` である pid（= 子）を代表から除き、プロセスツリーの**根だけ**を数える。
- `status` / `restart` の単一性チェックを論理インスタンス数ベースに変更。`restart` は厳密に 1 へ収束するのを待ってから OK を返す。
- `status` の終了コード（二重起動疑い = 2）を後続の lease 出力で潰さず**伝播**する（機械から exit code で単一性を判定できるように）。
- supervision モデルを `docs/STAGING.md` に明記。

## Why?

検証者が「クリーンな単一インスタンス」を前提にできること。prod は `systemd → start-clord.sh → uv run python -m c_lord.main` で起動し、`uv` ラッパ（親）+ `python`（子）の **2 プロセスが正常**だが、`pgrep -f c_lord.main` は両方に当たる。これを 2 と数えると「正常な parent+child」を「二重起動」と誤検出し、検証の A/B が成立しない。

> **⚠️ 前提訂正（重要）**: この Issue は当初「staging bot が guard 配下で respawn して 2 重化する」が前提でしたが、**実機調査でその経路が現環境に無いことが判明**し、@yousan と相談のうえ Issue を再スコープしました（[#437 のコメント](https://github.com/yousan/c-lord/issues/437#issuecomment-4738597479)）。実機の事実: prod の 2 プロセスは正常な parent+child（`ppid` で確認）／prod の respawn は systemd `c-lord.service`（`Restart=always`）の 1 本のみ／staging には systemd ユニットも guard も無く respawn しない。

Closes #437

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: `no-user-visible-change`（operator/開発者ツール `scripts/staging.sh` のみの変更。c-lord bot / Discord の見え方は変わらない）

## Acceptance Criteria (copied from the issue)

- [x] `staging.sh` の instance カウントが、uv ラッパ（親）+ python（子）を **1 インスタンス**と数える（`/proc/<pid>/cwd` 一致 **かつ** ppid 関係を考慮し、親が同一 clone の c_lord.main である pid は代表に数えない）。`status` / `restart` の単一性チェックが parent+child を 2 と誤検出しない
- [x] prod/staging の supervision モデルを `docs/STAGING.md` に明記（prod=systemd `c-lord.service` `Restart=always`・uv で 2 プロセスが正常 / staging=手動 `setsid` venv python・respawn 無し / `--guard` ログインモードと global pgrep の癖）
- [x] `restart` 完了後、論理インスタンスが厳密に 1 へ収束する（短い収束待ちを含む）。`pytest` 緑

## Staging Evidence (証跡)

> operator ツール `scripts/staging.sh` のみの変更で、c-lord bot / Discord のランタイム挙動は変えない。シェルスクリプトは UI を持たず出力は全てテキストなので Discord スクショは N/A → `no-runtime-change` ラベル。証跡は**実プロセス（prod 起動形の uv ラッパ親 + python 子）を spawn して実 `staging.sh status` を回した RED→GREEN**（モックではない）。`tests/test_staging_script.py::TestInstanceCounting` が同じことを subprocess で自動検証。

**実 CLI 実演**（prod 起動形のツリーを 1 つだけ spawn し、`status` のカウントを比較）:

```
one tree spawned (uv-wrapper parent + python child)
OLD staging.sh (main):     exit=0  ['instances: 2', 'WARNING: 二重起動の疑い...']   ← 誤検出
NEW staging.sh (this PR):  exit=0  ['instances: 1']                                ← 正しい
```

プロセスツリー（`ppid` で親子確認）:
```
pid=1153303 ppid=356(systemd)   cmd=[uv run python -m c_lord.main ...]   ← 親(代表) = 1 instance
pid=1153304 ppid=1153303        cmd=[python -m c_lord.main child ...]    ← 子(除外)
```

<details>
<summary>TDD: RED line（修正前コードでの失敗）</summary>

```
FAILED TestInstanceCounting::test_status_counts_uv_wrapper_and_child_as_one
  assert "instances: 1" in result.stdout  →  実際は "instances: 2"（uv ラッパ+子を 2 と誤カウント）
FAILED TestInstanceCounting::test_status_counts_two_independent_bots_as_two
  assert result.returncode == 2  →  実際は 0（status の return 2 が lease 出力で潰されていた）
```
GREEN（修正後）: `tests/test_staging_script.py` 25 passed（既存 23 + 新規 2）。本物の独立 2 起動は `instances: 2` + exit 2 で正しく検出することも検証済み。
</details>

## Definition of Done checklist

> `no-runtime-change` ラベルにより Rule 1（DoD 完了）・証跡画像要件（#391）は免除。`Closes` 規律は常時適用（上の AC は全達成）。operator ツールのみで bot/Discord ランタイム不変のため Discord 証跡 N/A、代わりに実 CLI RED→GREEN を掲載。

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（`test_staging_script.py` 25/25。他の既存失敗 14 件は本PRと無関係で clean `main` でも同一に失敗＝環境依存。CI クリーン環境では緑）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass（変更ファイル clean、bash -n も OK）
- [x] Staging Evidence above is filled in（実 CLI RED→GREEN + プロセスツリー）
- [x] No unrelated changes in the diff; self-review done（diff = staging.sh / test / docs/STAGING.md の3ファイル）
- [x] docs/STAGING.md に supervision モデルを追記（動きの説明を実態に更新）
- [x] `Closes #437` は AC 100% 達成のため使用（独立行に記載）
