### PR TITLE
fix(watchdog): menu watchdog は自 bot 所有のウィンドウだけをブリッジする (#438)

### DIFF
--- a/c_lord/cogs/channel_repo.py
+++ b/c_lord/cogs/channel_repo.py
@@ -15,6 +15,7 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -129,6 +130,22 @@ class ChannelRepoCog(commands.Cog):
         manager = TmuxSessionManager(session_name=session_name)
         self._tmux_cache[channel_id] = manager
         return manager
+
+    async def managed_session_names(self) -> set[str]:
+        """tmux session names this bot manages (#438).
+
+        Used by the menu watchdog to ignore other bots' sessions on a shared
+        tmux server. Derived from this bot's channel bindings, plus the global
+        default session (``clord``) so that windows for an unbound channel
+        (#420) are still recognised as ours.
+        """
+        from ..tmux import SESSION_NAME
+
+        names: set[str] = {SESSION_NAME}
+        for binding in await self._repo.list_all():
+            with contextlib.suppress(Exception):
+                names.add(derive_session_name(binding["source_repo"]))
+        return names
 
     def evict_cache(self, channel_id: int) -> None:
         """Remove a cached channel manager (called on bind/unbind)."""

--- a/c_lord/setup.py
+++ b/c_lord/setup.py
@@ -305,7 +305,11 @@ async def setup_bridge(
     if os.getenv("CLORD_MENU_WATCHDOG", "1") not in ("0", "false", "no"):
         from .thread_state_sync import MenuWatchdogLoop
 
-        menu_watchdog = MenuWatchdogLoop(bot, is_processing=chat_cog.is_processing)
+        # repo wired so the sweep only bridges windows THIS bot owns on a shared
+        # tmux server — never another bot's menu (#438).
+        menu_watchdog = MenuWatchdogLoop(
+            bot, is_processing=chat_cog.is_processing, repo=session_repo
+        )
         menu_watchdog.start()
         bot.menu_watchdog = menu_watchdog  # type: ignore[attr-defined]
 

--- a/c_lord/thread_state_sync.py
+++ b/c_lord/thread_state_sync.py
@@ -456,8 +456,19 @@ class MenuWatchdogLoop:
     Independent of the thread-name lamp (which is off by default, #329): the
     user's ability to see and answer AskUserQuestion/plan menus must not depend
     on an opt-in cosmetic feature.  Iterates every tmux window that carries an
-    ``@thread_id`` — no DB dependency — so it also recovers menus opened before
-    the bot (re)started.
+    ``@thread_id`` so it also recovers menus opened before the bot (re)started.
+
+    Ownership filter (#438): ``tmux list-windows -a`` returns every session on
+    the (shared) tmux server, including OTHER bots' sessions on the same host.
+    Bridging a foreign window would post another bot's menu into a thread we do
+    not own.  Each sweep is therefore restricted to windows this bot owns:
+      * AC2 — ``@thread_id`` must be a session in our own ``sessions.db``
+        (each bot has its own DB, so a foreign thread_id is absent), and
+      * AC1 — the window must live in a tmux session this bot manages
+        (binding-derived names + the global default).
+    ``repo`` defaults to ``None`` for backward compatibility (consumers that
+    do not wire it keep the old, unfiltered behaviour); ``setup.py`` always
+    passes it so the filter is on by default (zero-config).
     """
 
     def __init__(
@@ -466,10 +477,12 @@ class MenuWatchdogLoop:
         *,
         interval_seconds: float = _DEFAULT_INTERVAL_SECONDS,
         is_processing: Callable[[int], bool] | None = None,
+        repo: SessionRepository | None = None,
     ) -> None:
         self._bot = bot
         self._interval = interval_seconds
         self._is_processing: Callable[[int], bool] = is_processing or (lambda _tid: False)
+        self._repo = repo
         self._task: asyncio.Task[None] | None = None
         # Per-thread background bridge task — one at a time per thread.
         self._ask_bridges: dict[int, asyncio.Task[None]] = {}
@@ -506,17 +519,59 @@ class MenuWatchdogLoop:
     async def tick(self) -> None:
         """One sweep over every tmux window bound to a thread. Public for tests."""
         windows = await asyncio.to_thread(_list_all_windows)
+        managed = await self._managed_session_names()
         for w in windows:
             tid = w.get("thread_id") or ""
             if not tid.isdigit():
                 continue
+            thread_id = int(tid)
             session_name = w.get("session_name", "")
+            # #438: skip windows this bot does not own BEFORE capturing the pane
+            # (a foreign bot's window on the shared tmux server). This is the
+            # whole guard against cross-bot menu bridging.
+            if not await self._owns_window(thread_id, session_name, managed):
+                continue
             window_name = w.get("window_name", "")
             pane_text = await asyncio.to_thread(_capture_pane_text, session_name, window_name)
             try:
-                await self._maybe_bridge_open_menu(int(tid), session_name, window_name, pane_text)
+                await self._maybe_bridge_open_menu(thread_id, session_name, window_name, pane_text)
             except Exception:
                 logger.exception("menu watchdog failed for thread=%s", tid)
+
+    async def _managed_session_names(self) -> set[str] | None:
+        """tmux session names this bot manages, for the #438 ownership filter.
+
+        Returns ``None`` when undeterminable (no ChannelRepoCog) — in that case
+        the session-name guard (AC1) is skipped and ownership rests on the DB
+        guard (AC2) alone.
+        """
+        from .cogs.channel_repo import ChannelRepoCog
+
+        cog = self._bot.get_cog("ChannelRepoCog")
+        if not isinstance(cog, ChannelRepoCog):
+            return None
+        with contextlib.suppress(Exception):
+            return await cog.managed_session_names()
+        return None
+
+    async def _owns_window(
+        self, thread_id: int, session_name: str, managed: set[str] | None
+    ) -> bool:
+        """#438: does this tmux window belong to THIS bot? See class docstring.
+
+        AC2 (DB) is authoritative; AC1 (managed session set) is the second guard.
+        Both must hold. A window in a session we do not manage, or for a thread
+        absent from our ``sessions.db``, is another bot's — never bridge it.
+        """
+        # AC2 — the thread must be one of our own sessions.
+        if self._repo is not None and await self._repo.get(thread_id) is None:
+            return False
+        # AC1 — the window must live in a tmux session we manage. ``managed``
+        # includes the default session, so unbound-channel windows (#420) for an
+        # owned thread still pass. Skip the guard when undeterminable / no name.
+        if managed is None or not session_name:
+            return True
+        return session_name in managed
 
     async def _maybe_bridge_open_menu(
         self, thread_id: int, session_name: str, window_name: str, pane_text: str

--- a/tests/test_thread_state_sync.py
+++ b/tests/test_thread_state_sync.py
@@ -1068,3 +1068,111 @@ async def test_watchdog_still_gives_up_when_session_name_empty():
         await asyncio.sleep(0)
     bridge.assert_not_awaited()
     assert 223 not in loop._ask_bridges
+
+
+# ── #438: menu watchdog must only act on windows THIS bot owns ────────────────
+# `tmux list-windows -a` returns every session on a shared tmux server, including
+# other bots'. The watchdog must ignore foreign windows (else bot B bridges bot
+# A's menu). Ownership = thread_id ∈ my sessions.db (AC2) AND session ∈ my
+# managed tmux sessions (AC1).
+
+
+def _make_owned_watchdog(known_thread_ids, managed_sessions):
+    """Build a watchdog whose repo knows `known_thread_ids` and whose
+    ChannelRepoCog manages `managed_sessions`."""
+    from c_lord.cogs.channel_repo import ChannelRepoCog
+
+    bot = MagicMock()
+    cog = MagicMock(spec=ChannelRepoCog)
+    cog.managed_session_names = AsyncMock(return_value=set(managed_sessions))
+    bot.get_cog.return_value = cog
+
+    repo = MagicMock()
+    known = set(known_thread_ids)
+    repo.get = AsyncMock(side_effect=lambda tid: object() if tid in known else None)
+
+    loop = thread_state_sync.MenuWatchdogLoop(bot, interval_seconds=60, repo=repo)
+    return loop, bot, repo
+
+
+@pytest.mark.asyncio
+async def test_watchdog_skips_window_for_thread_not_in_db():
+    """AC2: a window whose @thread_id is not in this bot's sessions.db (another
+    bot's session on the shared tmux server) is never bridged."""
+    loop, _bot, repo = _make_owned_watchdog(known_thread_ids={100}, managed_sessions={"clord"})
+    windows = [{"thread_id": "999", "session_name": "other-bot", "window_name": "w1"}]
+    with (
+        patch.object(thread_state_sync, "_list_all_windows", return_value=windows),
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="menu") as cap,
+        patch.object(loop, "_maybe_bridge_open_menu", new=AsyncMock()) as bridge,
+    ):
+        await loop.tick()
+    bridge.assert_not_awaited()
+    cap.assert_not_called()  # foreign window: don't even capture its pane
+    repo.get.assert_awaited_with(999)
+
+
+@pytest.mark.asyncio
+async def test_watchdog_processes_window_for_own_thread():
+    """An owned thread (in my DB) in a managed session is processed normally."""
+    loop, _bot, _repo = _make_owned_watchdog(
+        known_thread_ids={100}, managed_sessions={"clord", "myrepo"}
+    )
+    windows = [{"thread_id": "100", "session_name": "myrepo", "window_name": "w1"}]
+    with (
+        patch.object(thread_state_sync, "_list_all_windows", return_value=windows),
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="menu"),
+        patch.object(loop, "_maybe_bridge_open_menu", new=AsyncMock()) as bridge,
+    ):
+        await loop.tick()
+    bridge.assert_awaited_once()
+    assert bridge.await_args is not None
+    assert bridge.await_args.args[0] == 100
+
+
+@pytest.mark.asyncio
+async def test_watchdog_skips_foreign_session_even_if_thread_id_collides():
+    """AC1: a window in a tmux session this bot does NOT manage is skipped, even
+    if its @thread_id happens to match one of ours (二重ガード)."""
+    loop, _bot, _repo = _make_owned_watchdog(known_thread_ids={100}, managed_sessions={"clord"})
+    windows = [{"thread_id": "100", "session_name": "someone-elses-session", "window_name": "w1"}]
+    with (
+        patch.object(thread_state_sync, "_list_all_windows", return_value=windows),
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="menu"),
+        patch.object(loop, "_maybe_bridge_open_menu", new=AsyncMock()) as bridge,
+    ):
+        await loop.tick()
+    bridge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_processes_owned_thread_in_default_clord_session():
+    """#420 regression: an owned thread whose window is in the default `clord`
+    session (unbound channel) is still bridged — the managed set includes the
+    default session, so the ownership filter does not strand it."""
+    loop, _bot, _repo = _make_owned_watchdog(known_thread_ids={100}, managed_sessions={"clord"})
+    windows = [{"thread_id": "100", "session_name": "clord", "window_name": "w94"}]
+    with (
+        patch.object(thread_state_sync, "_list_all_windows", return_value=windows),
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="menu"),
+        patch.object(loop, "_maybe_bridge_open_menu", new=AsyncMock()) as bridge,
+    ):
+        await loop.tick()
+    bridge.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_without_repo_is_backward_compatible():
+    """Zero-config / legacy: a loop built without a repo (and no ChannelRepoCog)
+    keeps the old behaviour — it does not filter and still processes windows."""
+    bot = MagicMock()
+    bot.get_cog.return_value = None
+    loop = thread_state_sync.MenuWatchdogLoop(bot, interval_seconds=60)  # no repo
+    windows = [{"thread_id": "100", "session_name": "clord", "window_name": "w1"}]
+    with (
+        patch.object(thread_state_sync, "_list_all_windows", return_value=windows),
+        patch.object(thread_state_sync, "_capture_pane_text", return_value="menu"),
+        patch.object(loop, "_maybe_bridge_open_menu", new=AsyncMock()) as bridge,
+    ):
+        await loop.tick()
+    bridge.assert_awaited_once()


### PR DESCRIPTION
## What does this PR do?

menu watchdog (#359) を「**自 bot が所有するウィンドウだけ**をブリッジする」よう絞る。共有 tmux サーバ上で `tmux list-windows -a` が他 bot のセッションのウィンドウも返すため、ある bot のメニューを別 bot が拾って投稿していた（越境ブリッジ）。

二重ガード（`tick()` で pane capture より前に判定）:
- **AC2（authoritative）**: `@thread_id` が自 bot の `sessions.db` に存在すること（各 bot は独立 DB なので他 bot の thread_id は不在）。
- **AC1**: ウィンドウの tmux セッションが自 bot の管理セッション群（channel binding 由来 + 既定 `clord`）に属すること。

`MenuWatchdogLoop(repo=...)` は後方互換のため既定 `None`、`setup.py` は常に `session_repo` を渡すので既定で有効（zero-config）。既定 `clord` を管理集合に含めるので未バインドチャンネル（#420）の所有ウィンドウは従来どおりブリッジされる。

## Why?

検証中、staging-2 の thread のメニューを **prod (C-lord) / staging-1 / staging-4 が投稿**しているのを観測（いずれも当該 thread を自分の `sessions.db` に持たない）。prod も同一ホストの staging と tmux サーバを共有するため越境しうる（実際に prod が staging-2 のメニューを投稿していた）。共有ホストでの検証も汚染される。

Closes #438

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: 共有ホストで複数 bot が動いているとき、いままでは1つのスレッドのメニュー（Plan承認ボタン等）を**複数の bot が二重・三重に投稿**していた → この PR 後は**所有している bot 1つだけ**が投稿する（単一 bot の本番では見え方は変わらない）

## Acceptance Criteria (copied from the issue)

- [x] menu watchdog が、**自 bot が管理する tmux セッション**のウィンドウのみを対象にする（他 bot のセッションは無視） — AC1（`managed_session_names` = binding 由来 + 既定 `clord`）
- [x] `@thread_id` が自 DB の `sessions` に存在するウィンドウのみブリッジする（二重ガード） — AC2（`session_repo.get(thread_id)`）
- [x] 共有ホストで複数 bot を起動しても、各 thread のメニューを投稿するのは所有 bot 1 つだけ、を **staging で確認** — 下記 Staging Evidence（軽量版: 1 bot + 偽ウィンドウで RED→GREEN、yousan と合意のうえ）

## Staging Evidence (証跡)

![438 staging RED to GREEN](https://github.com/yousan/c-lord/releases/download/evidence/i438-438-watchdog-ownership-red-green-20260618T071028Z.png)

**手法（軽量版・合意済み）**: staging-2 で bot を1つ起動し、「他 bot のセッション」を模した **FOREIGN セッション**（`other-bot-session`、bot の管理外）に `@thread_id`=E2E(自 DB 内) + ASK メニュー pane を植え、watchdog がそれをブリッジするかを bot ログで観測。

- **RED（`main` 1069a92・旧 watchdog）**: FOREIGN セッションのメニューを `bridging unwatched TUI menu (thread=1514545583459926117 header='Deploy')` で**投稿してしまう**（越境ブリッジ＝バグ再現）。
- **GREEN（`fix/438` bfc6b76・所有フィルタ ON）**: 同じ FOREIGN ウィンドウは **bridging 0 件**（AC1 でスキップ）。
- **対照（liveness）**: 管理セッション `clord`（既定・管理集合内）に同一メニューを足すと**ブリッジが復活**。FOREIGN との唯一の差は tmux セッションなので、watchdog は生きており**所有判定で選択的にフィルタ**していることが分かる。

> 注: 軽量版なので staging 実機で踏むのは **AC1（セッション所有）** ガード。**AC2（thread_id 所有）** は別途ユニットテストで担保（`test_watchdog_skips_window_for_thread_not_in_db`）。検証後にフリートは原状復帰（main / 1 instance）+ lease 解放済み。

<details>
<summary>TDD: RED→GREEN（ユニット）</summary>

RED（修正前、`repo` 引数なし）: `TypeError: MenuWatchdogLoop.__init__() got an unexpected keyword argument 'repo'`（4 tests）
GREEN（修正後）: watchdog テスト 11/11、ファイル全体 49/49 passed。新規 5 ケース（cross-bot skip / own-thread / foreign-session / default-clord regression / backward-compat）。
</details>

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（thread_state_sync 49/49。他の既存失敗 14 件は本PRと無関係で clean `main` でも同一に失敗＝環境依存。CI クリーン環境では緑）
- [x] `uv run ruff check c_lord/` + `ruff format --check c_lord/` + `pyright c_lord/` pass
- [x] Staging Evidence above is filled in（実機 RED→GREEN + liveness 対照、証跡画像あり）
- [x] No unrelated changes in the diff; self-review done
- [x] 動きの説明はコード docstring + 本文の before/after に記載
- [x] `Closes #438` は AC 100% 達成のため使用（独立行に記載）
