### PR TITLE
fix: DISCORD_OWNER_ID に非数値を入れると起動時に明示的なエラーを出す

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,11 @@ CLAUDE_PERMISSION_MODE=acceptEdits
 CLAUDE_WORKING_DIR=
 
 # Access Control
-# DISCORD_OWNER_ID=123456789          # Bot owner (always allowed)
+# DISCORD_OWNER_ID must be your numeric Discord user ID (snowflake) — NOT your
+# username. To find it: enable Developer Mode (User Settings → Advanced →
+# Developer Mode), then right-click your username in Discord → Copy User ID.
+# Example: DISCORD_OWNER_ID=123456789012345678
+# DISCORD_OWNER_ID=                   # Bot owner (always allowed); leave blank to allow everyone
 # CLORD_ALLOWED_ROLE=claude-operator  # Discord role name (members with this role can use bot)
 
 # Limits

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -168,6 +168,17 @@ def load_config(env_path: Path | None = None) -> dict[str, str]:
         )
         sys.exit(1)
 
+    # Issue #451: DISCORD_OWNER_ID must be a numeric Discord snowflake.
+    # Fail loudly so users don't enter their username by mistake.
+    owner_id_raw = os.getenv("DISCORD_OWNER_ID", "")
+    if owner_id_raw and not owner_id_raw.isdigit():
+        logger.error(
+            "DISCORD_OWNER_ID must be a numeric Discord user ID (snowflake), got %r."
+            " Enable Developer Mode in Discord, then right-click your username → Copy User ID.",
+            owner_id_raw,
+        )
+        sys.exit(1)
+
     return {
         "token": token,
         "channel_id": channel_id,
@@ -179,7 +190,7 @@ def load_config(env_path: Path | None = None) -> dict[str, str]:
         "claude_working_dir": os.getenv("CLAUDE_WORKING_DIR", ""),
         "max_concurrent": os.getenv("MAX_CONCURRENT_SESSIONS", "3"),
         "timeout": os.getenv("SESSION_TIMEOUT_SECONDS", "300"),
-        "owner_id": os.getenv("DISCORD_OWNER_ID", ""),
+        "owner_id": owner_id_raw,
         "coordination_channel_id": os.getenv("COORDINATION_CHANNEL_ID", ""),
     }
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -139,6 +139,56 @@ class TestExpectedBotUserId:
         mock_exit.assert_called_with(1)
 
 
+class TestDiscordOwnerId:
+    """Issue #451: DISCORD_OWNER_ID must be a numeric snowflake or absent."""
+
+    def _base_env(self, monkeypatch: object) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")  # type: ignore[attr-defined]
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "999")  # type: ignore[attr-defined]
+
+    def test_non_numeric_value_exits(self, monkeypatch: object) -> None:
+        """'yousan' instead of a snowflake must fail loudly at startup."""
+        import sys
+        from unittest.mock import patch
+
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("DISCORD_OWNER_ID", "yousan")  # type: ignore[attr-defined]
+        with patch.object(sys, "exit") as mock_exit:
+            load_config()
+        mock_exit.assert_called_with(1)
+
+    def test_non_numeric_error_message(
+        self, monkeypatch: object, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Error message must mention snowflake and the bad value."""
+        import logging
+        import sys
+        from unittest.mock import patch
+
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("DISCORD_OWNER_ID", "yousan")  # type: ignore[attr-defined]
+        with (
+            caplog.at_level(logging.ERROR, logger="c_lord.main"),
+            patch.object(sys, "exit"),
+        ):
+            load_config()
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "DISCORD_OWNER_ID" in joined
+        assert "yousan" in joined
+
+    def test_valid_snowflake_accepted(self, monkeypatch: object) -> None:
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("DISCORD_OWNER_ID", "123456789012345678")  # type: ignore[attr-defined]
+        config = load_config()
+        assert config["owner_id"] == "123456789012345678"
+
+    def test_empty_when_unset(self, monkeypatch: object) -> None:
+        self._base_env(monkeypatch)
+        monkeypatch.delenv("DISCORD_OWNER_ID", raising=False)  # type: ignore[attr-defined]
+        config = load_config()
+        assert config["owner_id"] == ""
+
+
 class TestDotenvOverride:
     """Issue #324: keys present in the .env file must beat inherited process env.
 


### PR DESCRIPTION
## What does this PR do?

`DISCORD_OWNER_ID` に非数値（例: ユーザー名 `yousan`）を設定した場合、起動時に明示的なエラーメッセージを出して終了するようにする。

Closes #451

## Why?

新規ユーザーが `.env` の `DISCORD_OWNER_ID` に Discord ユーザー名を入れてしまうと、従来は内部的な `ValueError: invalid literal for int() with base 10: 'yousan'` が出るだけで原因が分からなかった。

## 利用者から見た before/after（1行・必須）

- before → `.env` に `DISCORD_OWNER_ID=yousan` を入れると、起動時に `ValueError: invalid literal for int() with base 10: 'yousan'` という不可解なエラーが出る
- after → 起動直後に `DISCORD_OWNER_ID must be a numeric Discord user ID (snowflake), got 'yousan'. Enable Developer Mode in Discord, then right-click your username → Copy User ID.` という分かりやすいエラーが出て終了する

## Acceptance Criteria (copied from the issue)

- [x] AC 1: `DISCORD_OWNER_ID` が数値でなければ起動時に明示的なエラーメッセージを出して exit(1)
- [x] AC 2: `.env.example` に「ユーザー名ではなく数値ID」「取得方法（開発者モード → 右クリック → ID をコピー）」を明記
- [x] AC 3: 空欄（オプション未設定）は従来通りエラーなし

（複数オーナー対応は別 Issue に切り出し予定のため本 PR スコープ外）

## Staging Evidence (証跡)

![evidence_451](https://github.com/yousan/c-lord/releases/download/evidence/i451-evidence_451-20260619T011132Z.png)

<details>
<summary>RED (before) — reproduced</summary>

```
$ DISCORD_OWNER_ID=yousan c-lord start
Traceback (most recent call last):
  File "…/main.py", line 219, in main
    owner_id = int(config["owner_id"]) if config["owner_id"] else None
ValueError: invalid literal for int() with base 10: 'yousan'
```
</details>

<details>
<summary>GREEN (after) — fixed</summary>

```
$ DISCORD_OWNER_ID=yousan python3 -c "from c_lord.main import load_config; load_config()"
ERROR c_lord.main: DISCORD_OWNER_ID must be a numeric Discord user ID (snowflake), got 'yousan'. Enable Developer Mode in Discord, then right-click your username → Copy User ID.
Process exited with code 1.
```
</details>

スタートアップ設定検証のみの変更。有効な snowflake では挙動変化なし。`pytest tests/test_main.py` 18 passed で担保。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

> **Label exemptions** (`no-runtime-change` or `documentation` label): the DoD-completion checklist below is waived (notably **TDD evidence**, **Staging Evidence**, and the **evidence-link requirement** #391).
> **`Closes` discipline is always enforced**, regardless of label: if you use `Closes`/`Resolves #N`, the Acceptance Criteria above must still be fully checked (else use `Refs #N`).

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED: `test_non_numeric_value_exits` `test_non_numeric_error_message` FAILED) and passes after (GREEN: 全4テスト PASSED)
- [x] `uv run pytest tests/ -v` passes (既存失敗 2件は main ブランチ由来、本 PR と無関係)
- [x] `uv run ruff check c_lord/` + `ruff format --check` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメント（仕様 / README / docs）も更新した → `.env.example` に取得方法を追記
- [x] `Closes #451` written on its own line; 100% of ACs met