### PR TITLE
fix(context-footer): progress.txt の後ろに独立メッセージとして送る

### DIFF
--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -44,13 +44,6 @@ from .run_config import RunConfig  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
-# How long to wait for transcript_mirror.reply_sink to register the assistant
-# reply before falling back to a fresh send.  jsonl bridge mode polls the
-# JSONL on a separate loop, so reply_sink may fire slightly after run_claude
-# returns; the line should ride on the same bubble in the common case.
-_REPLY_WAIT_ATTEMPTS = 8
-_REPLY_WAIT_INTERVAL = 0.2  # 8 × 200ms = up to 1.6 s
-
 # Context-window total per session_id, learned via TmuxClaudeRunner's /context
 # probe (or a per-model fallback) and reused for the rest of the session.  The
 # value is ``(model, total)``: when the model in the transcript changes (e.g.
@@ -358,33 +351,11 @@ async def _post_context_usage(config: RunConfig, session_id: str | None) -> None
         cost_usd=cost_usd,
     )
 
-    # Prefer appending to Claude's last reply message — keeps the addendum
-    # inside the same bubble (no fresh avatar/timestamp chrome).  In jsonl
-    # bridge mode the transcript_mirror.reply_sink races with run_claude's
-    # loop end, so the message may not be registered yet — poll briefly
-    # before falling back to a fresh send.
-    from ..skills.reply_tracker import get_last_reply_message
-
-    last_reply = None
-    for _ in range(_REPLY_WAIT_ATTEMPTS):
-        last_reply = get_last_reply_message(config.thread.id)
-        if last_reply is not None:
-            break
-        await asyncio.sleep(_REPLY_WAIT_INTERVAL)
-    # #372: discord.py's Message.edit defaults suppress=False (NOT MISSING), so
-    # an edit that omits suppress explicitly *un*-suppresses embeds — which would
-    # re-enable the URL OGP card that reply_sink suppressed at send-time. Pass
-    # suppress explicitly so appending the context line preserves the setting.
+    # #455: send footer as a standalone new message so it appears AFTER
+    # progress.txt and BEFORE the 🟡 mention — not appended to the reply.
     from ..transcript.mirror import show_url_embeds_enabled
 
     suppress_embeds = not show_url_embeds_enabled()
-    if last_reply is not None:
-        existing = last_reply.content or ""
-        combined = f"{existing}\n{line}" if existing else line
-        if len(combined) <= 2000:
-            with contextlib.suppress(discord.HTTPException):
-                await last_reply.edit(content=combined, suppress=suppress_embeds)
-            return
     with contextlib.suppress(discord.HTTPException):
         await config.thread.send(line, suppress_embeds=suppress_embeds)
 

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -226,12 +226,12 @@ class TestPostContextUsage:
         asyncio.run(rh._post_context_usage(cfg, "sess-4"))
         cfg.thread.send.assert_not_called()
 
-    def test_edits_last_reply_when_available(self, monkeypatch) -> None:
-        """The context line must be appended to the last reply (no new bubble).
+    def test_sends_new_message_ignoring_reply_tracker(self, monkeypatch) -> None:
+        """#455: footer is always a new message, never appended to the reply.
 
-        UX feedback: a separate bot message adds avatar/timestamp chrome that
-        feels obtrusive.  Editing the reply keeps the line inside the same
-        bubble as Claude's answer.
+        Even when reply_tracker has recorded the assistant reply message, the
+        footer must be sent as a standalone message so it appears AFTER
+        progress.txt and before the 🟡 mention.
         """
         from pathlib import Path
         from unittest.mock import MagicMock
@@ -243,9 +243,9 @@ class TestPostContextUsage:
         _run_helper._context_window_cache.clear()
         reply_tracker.reset_tracker()
 
-        # Simulate the api_server having recorded the assistant reply message.
+        # Even if the reply message is tracked, footer must NOT edit it.
         last_msg = MagicMock()
-        last_msg.content = "2"
+        last_msg.content = "Claude's answer"
         last_msg.edit = AsyncMock()
         reply_tracker.record_reply_message(12345, last_msg)
 
@@ -257,41 +257,24 @@ class TestPostContextUsage:
         monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
 
         cfg = self._config(probe_total=1_000_000)
-        asyncio.run(_run_helper._post_context_usage(cfg, "sess-edit"))
+        asyncio.run(_run_helper._post_context_usage(cfg, "sess-new-msg"))
 
-        # Edited the reply (no new send).
-        last_msg.edit.assert_awaited_once()
-        new_content = last_msg.edit.await_args.kwargs.get("content") or (
-            last_msg.edit.await_args.args[0] if last_msg.edit.await_args.args else ""
-        )
-        assert new_content.startswith("2\n")
-        assert "6%" in new_content
-        assert "1.0M" in new_content
-        cfg.thread.send.assert_not_called()
+        # Must send a new message, must NOT edit the reply.
+        cfg.thread.send.assert_awaited_once()
+        last_msg.edit.assert_not_called()
+        sent = cfg.thread.send.await_args.args[0]
+        assert "6%" in sent
+        assert "1.0M" in sent
 
-    def test_context_edit_preserves_embed_suppression_by_default(self, monkeypatch) -> None:
-        """#372: the context-line edit() must keep URL OGP cards suppressed.
-
-        discord.py's ``Message.edit`` defaults ``suppress=False`` (not MISSING),
-        so an edit that omits ``suppress`` explicitly *un*-suppresses embeds —
-        re-enabling the OGP card that reply_sink had suppressed at send-time.
-        ``_post_context_usage`` must pass ``suppress=True`` by default.
-        """
+    def test_send_suppresses_embeds_by_default(self, monkeypatch) -> None:
+        """#455/#372: new-message footer must suppress URL OGP embeds by default."""
         from pathlib import Path
-        from unittest.mock import MagicMock
 
         from c_lord.claude.context_usage import ContextUsage
         from c_lord.cogs import _run_helper
-        from c_lord.skills import reply_tracker
 
         monkeypatch.delenv("CLORD_SHOW_URL_EMBEDS", raising=False)
         _run_helper._context_window_cache.clear()
-        reply_tracker.reset_tracker()
-
-        last_msg = MagicMock()
-        last_msg.content = "see https://github.com/yousan/c-lord/issues"
-        last_msg.edit = AsyncMock()
-        reply_tracker.record_reply_message(12345, last_msg)
 
         monkeypatch.setattr(
             _run_helper, "read_latest_usage", lambda _p: ContextUsage(input_tokens=60_000)
@@ -301,26 +284,18 @@ class TestPostContextUsage:
         cfg = self._config(probe_total=1_000_000)
         asyncio.run(_run_helper._post_context_usage(cfg, "sess-suppress"))
 
-        last_msg.edit.assert_awaited_once()
-        assert last_msg.edit.await_args.kwargs.get("suppress") is True
+        cfg.thread.send.assert_awaited_once()
+        assert cfg.thread.send.await_args.kwargs.get("suppress_embeds") is True
 
-    def test_context_edit_respects_show_url_embeds_optin(self, monkeypatch) -> None:
-        """#372: CLORD_SHOW_URL_EMBEDS=true keeps embeds enabled on the edit too."""
+    def test_send_respects_show_url_embeds_optin(self, monkeypatch) -> None:
+        """#455/#372: CLORD_SHOW_URL_EMBEDS=true keeps embeds enabled on send."""
         from pathlib import Path
-        from unittest.mock import MagicMock
 
         from c_lord.claude.context_usage import ContextUsage
         from c_lord.cogs import _run_helper
-        from c_lord.skills import reply_tracker
 
         monkeypatch.setenv("CLORD_SHOW_URL_EMBEDS", "true")
         _run_helper._context_window_cache.clear()
-        reply_tracker.reset_tracker()
-
-        last_msg = MagicMock()
-        last_msg.content = "see https://github.com/yousan/c-lord/issues"
-        last_msg.edit = AsyncMock()
-        reply_tracker.record_reply_message(12345, last_msg)
 
         monkeypatch.setattr(
             _run_helper, "read_latest_usage", lambda _p: ContextUsage(input_tokens=60_000)
@@ -330,57 +305,11 @@ class TestPostContextUsage:
         cfg = self._config(probe_total=1_000_000)
         asyncio.run(_run_helper._post_context_usage(cfg, "sess-optin"))
 
-        last_msg.edit.assert_awaited_once()
-        assert last_msg.edit.await_args.kwargs.get("suppress") is False
+        cfg.thread.send.assert_awaited_once()
+        assert cfg.thread.send.await_args.kwargs.get("suppress_embeds") is False
 
-    def test_waits_briefly_for_reply_sink_then_edits(self, monkeypatch) -> None:
-        """In jsonl bridge mode the reply_sink races with the run-loop end.
-
-        Regression: _post_context_usage ran before transcript_mirror.reply_sink
-        finished posting + calling record_reply_message, so get_last_reply_message
-        returned None and the line was sent as a separate bubble. Wait briefly
-        (poll a few times) so the late reply_sink can still register before we
-        fall back.
-        """
-        from pathlib import Path
-        from unittest.mock import MagicMock
-
-        from c_lord.claude.context_usage import ContextUsage
-        from c_lord.cogs import _run_helper
-        from c_lord.skills import reply_tracker
-
-        _run_helper._context_window_cache.clear()
-        reply_tracker.reset_tracker()
-
-        # Schedule a late record_reply_message after a few asyncio ticks,
-        # simulating the transcript_mirror reply_sink firing slightly after
-        # _post_context_usage starts.
-        late_msg = MagicMock()
-        late_msg.content = "5"
-        late_msg.edit = AsyncMock()
-
-        async def runner():
-            async def late_register():
-                await asyncio.sleep(0.15)  # ~150ms after _post_context_usage starts
-                reply_tracker.record_reply_message(12345, late_msg)
-
-            asyncio.create_task(late_register())
-            await _run_helper._post_context_usage(cfg, "sess-race")
-
-        monkeypatch.setattr(
-            _run_helper,
-            "read_latest_usage",
-            lambda _p: ContextUsage(input_tokens=60_000),
-        )
-        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
-        cfg = self._config(probe_total=1_000_000)
-        asyncio.run(runner())
-
-        # Late-arriving reply was edited; no fresh send happened.
-        late_msg.edit.assert_awaited_once()
-        cfg.thread.send.assert_not_called()
-
-    def test_falls_back_to_send_when_no_tracked_message(self, monkeypatch) -> None:
+    def test_always_sends_new_message(self, monkeypatch) -> None:
+        """#455: footer always sent as new message regardless of reply tracker state."""
         from pathlib import Path
 
         from c_lord.claude.context_usage import ContextUsage
@@ -398,33 +327,6 @@ class TestPostContextUsage:
 
         cfg = self._config(probe_total=1_000_000)
         asyncio.run(_run_helper._post_context_usage(cfg, "sess-no-track"))
-        cfg.thread.send.assert_awaited_once()
-
-    def test_falls_back_to_send_when_edit_would_exceed_2000(self, monkeypatch) -> None:
-        from pathlib import Path
-        from unittest.mock import MagicMock
-
-        from c_lord.claude.context_usage import ContextUsage
-        from c_lord.cogs import _run_helper
-        from c_lord.skills import reply_tracker
-
-        _run_helper._context_window_cache.clear()
-        reply_tracker.reset_tracker()
-        last_msg = MagicMock()
-        last_msg.content = "x" * 1990  # leaves <= 10 chars; context line is longer
-        last_msg.edit = AsyncMock()
-        reply_tracker.record_reply_message(12345, last_msg)
-
-        monkeypatch.setattr(
-            _run_helper,
-            "read_latest_usage",
-            lambda _p: ContextUsage(input_tokens=60_000),
-        )
-        monkeypatch.setattr(_run_helper, "latest_session_jsonl", lambda _d: Path("/tmp/fake.jsonl"))
-
-        cfg = self._config(probe_total=1_000_000)
-        asyncio.run(_run_helper._post_context_usage(cfg, "sess-toobig"))
-        last_msg.edit.assert_not_called()
         cfg.thread.send.assert_awaited_once()
 
     def test_skips_when_no_usage_in_transcript(self, monkeypatch) -> None:


### PR DESCRIPTION
Closes #455

## あるべき動き（利用者目線・モックで合意済み）

利用者の発言:
- **現状**: 返答 → フッター(返答に edit 追記) → progress.txt → 🟡
- **ご要望**: 返答 → progress.txt → フッター → 🟡

→ **フッターと progress.txt の順序を入れ替える**。合意したデザインカンプ（After）:

![mockup_desired](https://github.com/yousan/c-lord/releases/download/evidence/i455-mockup_desired-20260622T053044Z-01.png)

## 実装

`_run_helper._post_context_usage()` の edit-reply パスを削除し、常に `thread.send()` で送信。
これによりフッターが progress.txt（RESULT イベント中に送られる）の後、🟡 メンション（`claude_chat` の finally で最後に送られる）の前、という順序になる。
- `_REPLY_WAIT_ATTEMPTS` / `_REPLY_WAIT_INTERVAL` 定数（reply wait ループ）を削除
- `suppress_embeds` (#372) ロジックは `send()` 引数として維持

## Acceptance Criteria

- [x] フッターが progress.txt **の後ろ**に表示される
- [x] 返答メッセージに「編集済み」マークが付かない（フッターは返答に混ざらない）
- [x] メンション 🟡 はフッターより後（最後）に出る
- [x] TDD: `_post_context_usage` のテストを更新・グリーン
- [x] staging で実機確認（progress.txt を挟んだ完全な順序）

## Definition of Done checklist

- [x] TDD evidence: 新テスト群が実装前 RED → 実装後 GREEN
  - RED: `AssertionError: Expected send to have been awaited once. Awaited 0 times.`
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` all green
- [x] Staging verification — 下記 Staging Evidence
- [x] 動きを変えたら「あるべき動き」も更新 — フッター順序はドキュメント未記載のため追記対象なし
- [x] No unrelated changes

## Staging Evidence

**fix ブランチ（ツール実行で progress.txt が出るターン）**: 返答(progress.txt 添付) → フッター(独立・後ろ)
![green-full-order](https://github.com/yousan/c-lord/releases/download/evidence/i455-green-full-order-20260622T053044Z-00.png)

API で確認した順序:
```
C-lord-staging-4 [attach: progress.txt]: 13個あります（…）   ← 返答 + progress.txt
C-lord-staging-4: -# 📊 33% context (66k/200k) · sonnet-4-6 · xhigh · CLI 2.1.185 · $0.18  ← フッター（後ろ・EDITED なし）
```

**比較（main = 旧挙動 / edit 追記で EDITED マーク）**:
![red-footer](https://github.com/yousan/c-lord/releases/download/evidence/i455-red-footer-20260622T044925Z-00.png)

メンション 🟡 は `claude_chat` の finally（run_claude 戻り後）で送られるため常に最後。E2E スレッドは owner 未設定のためこの検証では出ていないが、本番スクショ（#455 本文）では最後に出ている。