### PR TITLE
feat(skills): discord-read skill — read via curl + bot token, not MCP (#259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,8 @@ c-lord のクローン (parallel worktree, 別ディレクトリの clone 等) �
 **前提と制約**:
 - `c_lord/cogs/_run_helper.py` は **bot が spawn する子 Claude の env から `DISCORD_BOT_TOKEN` を strip する** (security audit に記載)。bot 経由で立った Claude は環境変数からは token を読めない
 - 手動で `claude` コマンドを叩いて立ち上げた tmux window 内 Claude には strip が掛からないので、**bot の `.env` ファイル**を直接読めばよい
-- Discord MCP plugin (`plugin:discord:discord`) は別チャンネルへ `Missing Access` で失敗することが多い。**メッセージの読み取りは MCP に頼らず、`.env` の bot token を読んで Discord REST API を `curl` で叩く**のが確実 — MCP が `Missing Access` を返しても**そこで諦めず curl にフォールバックすること**。MCP は c-lord のスタック外（利用者環境にある保証もない）なので読み取りの基盤にしない。読み取り経路を skill + API として c-lord 内に正式実装する作業は #259、設計方針は #234 を参照
+- Discord MCP plugin (`plugin:discord:discord`) は別チャンネルへ `Missing Access` で失敗することが多い。**メッセージの読み取りは MCP に頼らず、`.env` の bot token を読んで Discord REST API を `curl` で叩く**のが確実 — MCP が `Missing Access` を返しても**そこで諦めず curl にフォールバックすること**。MCP は c-lord のスタック外（利用者環境にある保証もない）なので読み取りの基盤にしない。
+- **bot が spawn する子 Claude には `discord-read` skill が自動注入される (#259)**。この skill が上記の「MCP は使わない / `Missing Access` でも curl にフォールバック / token は c-lord の `.env` から実行時に変数へ読む」手順を、**cwd が利用者リポジトリ（c-lord 外）のセッションにも**届ける。token は SKILL.md に焼き込まず `.env` の絶対パスだけを渡す（`c_lord/skills/discord_read.py`、accepted risk は `docs/SECURITY.md`）。設計方針は #234。
 
 **Token 取得**: **本番 `.env` を絶対パスで直接読む** (`/home/yousan/c-lord/.env`。パスは運用に合わせて)。
 

--- a/c_lord/main.py
+++ b/c_lord/main.py
@@ -136,8 +136,10 @@ def load_config(env_path: Path | None = None) -> dict[str, str]:
     single source of truth for every key it defines. Keys absent from the
     file still fall back to the process env (env-var-only setups keep working).
     """
+    resolved_env_path: str | None = None
     if env_path is not None:
         load_dotenv(env_path, override=True)
+        resolved_env_path = str(Path(env_path).resolve())
     else:
         # find_dotenv(usecwd=True): search from the CURRENT DIRECTORY upward,
         # not from this package's location. README documents the bare launch as
@@ -147,6 +149,14 @@ def load_config(env_path: Path | None = None) -> dict[str, str]:
         found = find_dotenv(usecwd=True)
         if found:
             load_dotenv(found, override=True)
+            resolved_env_path = str(Path(found).resolve())
+
+    # Issue #259: expose the resolved .env path so the injected discord-read
+    # skill can tell Claude where to read DISCORD_BOT_TOKEN from at runtime.
+    # Only the path is shared — never the token. Skip if no .env file was used
+    # (env-var-only setups); the read skill then renders its path-less variant.
+    if resolved_env_path:
+        os.environ.setdefault("CLORD_ENV_PATH", resolved_env_path)
 
     token = os.getenv("DISCORD_BOT_TOKEN", "")
     if not token:

--- a/c_lord/session_dir.py
+++ b/c_lord/session_dir.py
@@ -152,7 +152,12 @@ class SessionDirManager:
         # final answers via REST API instead of relying on capture-pane
         # scraping. Gated by USE_SKILL_REPLY env so old path stays default.
         # Runs on every call to keep api_url / api_secret in sync.
-        from .skills.injector import inject_skills, remove_injected_skills, skills_enabled
+        from .skills.injector import (
+            inject_read_skill,
+            inject_skills,
+            remove_injected_skills,
+            skills_enabled,
+        )
 
         if skills_enabled():
             try:
@@ -161,12 +166,22 @@ class SessionDirManager:
                 # Don't fail session creation on a skill write error.
                 logger.warning("Failed to inject skills for thread %d: %s", thread_id, exc)
         else:
-            # jsonl bridge mode etc.: scrub any stale skill left by a prior
-            # skill-mode session so Claude isn't pointed at a dead REST API.
+            # jsonl bridge mode etc.: scrub any stale REST-API output skill left
+            # by a prior skill-mode session so Claude isn't pointed at a dead
+            # REST API.
             try:
                 remove_injected_skills(target)
             except OSError as exc:
                 logger.warning("Failed to remove stale skills for thread %d: %s", thread_id, exc)
+
+        # Issue #259: discord-read is bridge-independent (it curls the Discord
+        # REST API directly, not c-lord's API), so inject it in every mode —
+        # including jsonl, where the output skills above are scrubbed. This is
+        # what lets Claude read other channels regardless of cwd or #71 state.
+        try:
+            inject_read_skill(target)
+        except OSError as exc:
+            logger.warning("Failed to inject discord-read for thread %d: %s", thread_id, exc)
 
         return target
 

--- a/c_lord/skills/__init__.py
+++ b/c_lord/skills/__init__.py
@@ -10,13 +10,16 @@ Discord by curl-ing the c-lord REST API, replacing the legacy
 from __future__ import annotations
 
 from .discord_prompt_choice import render_discord_prompt_choice_skill
+from .discord_read import render_discord_read_skill
 from .discord_reply import DISCORD_REPLY_SKILL, render_discord_reply_skill
-from .injector import inject_skills, remove_injected_skills
+from .injector import inject_read_skill, inject_skills, remove_injected_skills
 
 __all__ = [
     "DISCORD_REPLY_SKILL",
+    "inject_read_skill",
     "inject_skills",
     "remove_injected_skills",
     "render_discord_prompt_choice_skill",
+    "render_discord_read_skill",
     "render_discord_reply_skill",
 ]

--- a/c_lord/skills/discord_read.py
+++ b/c_lord/skills/discord_read.py
@@ -1,0 +1,168 @@
+"""``discord-read`` skill template (Issue #259).
+
+Lets the Claude session **read** messages from any Discord channel / thread /
+guild the c-lord bot participates in, using the bot's own token via a plain
+``curl`` against the Discord REST API — **not** the ``plugin:discord:discord``
+MCP tool.
+
+Why this exists (#454): when Claude tries to read another channel it tends to
+reach for the MCP ``fetch_messages`` tool, which is gated by the plugin's own
+``access.json`` allowlist and fails with ``Missing Access`` / ``not
+allowlisted`` on channels the bot is otherwise a member of. The documented
+curl fallback only lived in c-lord's own ``CLAUDE.md``, so it never reached
+sessions whose cwd is a *different* project. Injecting this skill puts the
+fallback in front of Claude regardless of cwd.
+
+Design (spawn-read, see #259 comment 2026-06-22):
+- The skill does **not** stand up or call a c-lord REST endpoint — reading is
+  stateless, so a one-shot curl is enough and avoids the multi-tenant pitfall
+  of an always-on localhost API (loopback TCP is not UID-scoped).
+- The bot **token is never baked into this file**. SKILL.md is written inside
+  the cloned user repo working tree, so a literal token could be committed and
+  pushed. Instead the skill tells Claude to read the token at runtime from
+  c-lord's ``.env`` (``{env_path}``) into a shell variable — file permissions
+  (same Unix user) are the isolation boundary, matching #234's stance that the
+  same-UID Claude can read ``.env`` anyway. The token therefore never appears
+  as a literal in the command text that the #71 transcript mirror would echo
+  to Discord.
+"""
+
+from __future__ import annotations
+
+# NOTE: keep the curl examples aligned with the documented fallback in the
+# project ``CLAUDE.md`` ("Debugging Discord from a Claude session"). The token
+# is always read into a shell variable first; never interpolate it as a
+# literal.
+
+_DISCORD_READ_SKILL_WITH_PATH = """\
+---
+name: discord-read
+description: |
+  Read messages from any Discord channel, thread, or guild the c-lord bot is
+  in. Use this whenever you need to look at Discord history that is NOT the
+  current thread's incoming message — e.g. "check what the error said in that
+  other channel", "read the linked message", "what was posted in #ops". Do
+  NOT use the `plugin:discord:discord` MCP tool for this; it is gated by a
+  separate allowlist and fails with `Missing Access` on channels the bot can
+  otherwise see. This skill reads via the bot's own token over plain HTTPS.
+---
+
+# discord-read
+
+Read Discord messages using the **c-lord bot token** and the Discord REST API.
+
+## Do NOT use the MCP plugin
+
+`plugin:discord:discord` (`fetch_messages`) is gated by its own `access.json`
+allowlist and returns `Missing Access` / `not allowlisted` for channels the
+c-lord bot is nonetheless a member of. **If you already tried MCP and it was
+rejected, do not give up — fall back to the curl below.** Prefer this curl
+from the start.
+
+## Read the token (runtime, into a variable — never print it)
+
+The bot token lives in c-lord's `.env`. Read it into a shell variable; never
+echo, log, write it to a file, or commit it:
+
+```bash
+TOKEN=$(grep '^DISCORD_BOT_TOKEN=' {env_path} | cut -d= -f2-)
+```
+
+## Fetch the last N messages of a channel / thread
+
+```bash
+curl -s -H "Authorization: Bot $TOKEN" \\
+  -H "User-Agent: DiscordBot (https://github.com/yousan/c-lord, 1.0)" \\
+  "https://discord.com/api/v10/channels/<CHANNEL_OR_THREAD_ID>/messages?limit=20"
+```
+
+Returns a JSON array (newest first). Pipe through `jq` or `python3 -m json.tool`
+to read it; each element has `.author.username` and `.content`.
+
+## Fetch a single message
+
+```bash
+curl -s -H "Authorization: Bot $TOKEN" \\
+  -H "User-Agent: DiscordBot/1.0" \\
+  "https://discord.com/api/v10/channels/<CHANNEL_ID>/messages/<MESSAGE_ID>"
+```
+
+## Rules
+
+1. Always read the token into a variable first; use `$TOKEN` in the curl.
+   Never put the literal token in a command, a file, or your reply.
+2. A Discord thread ID works as a channel ID — `/channels/<THREAD_ID>/messages`
+   reads a thread.
+3. Scope: you can read any channel/guild the **bot** is a member of (the bot
+   token is cross-guild within its memberships). This is intentional.
+4. This skill is for **reading**. To post your answer, use `discord-reply`.
+"""
+
+_DISCORD_READ_SKILL_NO_PATH = """\
+---
+name: discord-read
+description: |
+  Read messages from any Discord channel, thread, or guild the c-lord bot is
+  in. Use this whenever you need to look at Discord history that is NOT the
+  current thread's incoming message. Do NOT use the `plugin:discord:discord`
+  MCP tool for this; it is gated by a separate allowlist and fails with
+  `Missing Access`. This skill reads via the bot's own token over plain HTTPS.
+---
+
+# discord-read
+
+Read Discord messages using the **c-lord bot token** and the Discord REST API.
+
+## Do NOT use the MCP plugin
+
+`plugin:discord:discord` (`fetch_messages`) is gated by its own `access.json`
+allowlist and returns `Missing Access` / `not allowlisted` for channels the
+c-lord bot is nonetheless a member of. **If you already tried MCP and it was
+rejected, do not give up — fall back to the curl below.**
+
+## Read the token (runtime, into a variable — never print it)
+
+The bot token is in c-lord's `.env` file (the same `.env` the bot was started
+with — search upward from the c-lord working directory if unsure). Read
+`DISCORD_BOT_TOKEN` into a shell variable; never echo, log, write it to a
+file, or commit it:
+
+```bash
+TOKEN=$(grep '^DISCORD_BOT_TOKEN=' /path/to/c-lord/.env | cut -d= -f2-)
+```
+
+## Fetch the last N messages of a channel / thread
+
+```bash
+curl -s -H "Authorization: Bot $TOKEN" \\
+  -H "User-Agent: DiscordBot (https://github.com/yousan/c-lord, 1.0)" \\
+  "https://discord.com/api/v10/channels/<CHANNEL_OR_THREAD_ID>/messages?limit=20"
+```
+
+## Rules
+
+1. Always read the token into a variable first; use `$TOKEN` in the curl.
+   Never put the literal token in a command, a file, or your reply.
+2. A Discord thread ID works as a channel ID.
+3. Scope: any channel/guild the **bot** is a member of (cross-guild within its
+   memberships). This is intentional.
+4. This skill is for **reading**. To post your answer, use `discord-reply`.
+"""
+
+
+def render_discord_read_skill(env_path: str | None = None) -> str:
+    """Render the discord-read SKILL.md body.
+
+    Args:
+        env_path: Absolute path to c-lord's ``.env`` file, from which Claude
+            reads ``DISCORD_BOT_TOKEN`` at runtime. When known, it is baked
+            into the curl example so the fallback is copy-pasteable. When
+            ``None``, a generic variant is rendered that still instructs
+            Claude to read the token from c-lord's ``.env``.
+
+    The token value itself is **never** substituted into the body — only the
+    path. Claude reads the token into a shell variable at runtime.
+    """
+    if env_path:
+        return _DISCORD_READ_SKILL_WITH_PATH.format(env_path=env_path)
+    return _DISCORD_READ_SKILL_NO_PATH

--- a/c_lord/skills/injector.py
+++ b/c_lord/skills/injector.py
@@ -8,15 +8,21 @@ import shutil
 from pathlib import Path
 
 from .discord_prompt_choice import render_discord_prompt_choice_skill
+from .discord_read import render_discord_read_skill
 from .discord_reply import render_discord_reply_skill
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_URL = "http://127.0.0.1:8080"
 
-# Skill directories inject_skills writes. Kept here so remove_injected_skills
-# stays symmetric with what we create.
+# Output-path skills that depend on the c-lord REST API. inject_skills writes
+# them and remove_injected_skills scrubs them; their lifecycle is tied to
+# skills_enabled() (skill-reply mode). discord-read is intentionally NOT here —
+# it curls the Discord REST API directly (no c-lord API), so it is injected in
+# every bridge mode by inject_read_skill() and never scrubbed. See #259.
 INJECTED_SKILL_NAMES: tuple[str, ...] = ("discord-reply", "discord-prompt-choice")
+
+READ_SKILL_NAME = "discord-read"
 
 
 def inject_skills(
@@ -24,6 +30,7 @@ def inject_skills(
     thread_id: int,
     api_url: str | None = None,
     api_secret: str | None = None,
+    env_path: str | None = None,
 ) -> list[str]:
     """Write the c-lord skill bundle into ``<session_dir>/.claude/skills/``.
 
@@ -38,6 +45,11 @@ def inject_skills(
         api_secret: Bearer token the API server requires. When omitted,
             falls back to the ``CLORD_API_SECRET`` env var. If neither is
             set, the auth-less template is rendered.
+        env_path: Absolute path to c-lord's ``.env`` file, baked into the
+            ``discord-read`` skill so Claude can read ``DISCORD_BOT_TOKEN`` at
+            runtime (#259). When omitted, falls back to the ``CLORD_ENV_PATH``
+            env var; if still unset, the path-less read template is rendered.
+            Only the path is ever written — never the token value.
 
     Returns:
         Absolute paths to the SKILL.md files written.
@@ -48,6 +60,9 @@ def inject_skills(
 
     if api_secret is None:
         api_secret = os.getenv("CLORD_API_SECRET") or None
+
+    if env_path is None:
+        env_path = os.getenv("CLORD_ENV_PATH") or None
 
     skills_root = Path(session_dir) / ".claude" / "skills"
 
@@ -85,7 +100,54 @@ def inject_skills(
         thread_id,
         choice_path,
     )
+
+    # Issue #259: discord-read is bridge-independent, so inject it here too for
+    # convenience (skill mode) — but the authoritative, always-on injection is
+    # inject_read_skill(), called by session_dir regardless of bridge mode.
+    written.append(inject_read_skill(session_dir, env_path=env_path))
     return written
+
+
+def inject_read_skill(
+    session_dir: str | os.PathLike[str],
+    env_path: str | None = None,
+) -> str:
+    """Write the ``discord-read`` skill into ``<session_dir>/.claude/skills/``.
+
+    Unlike :func:`inject_skills`, this is injected in **every** bridge mode
+    (skill-reply *and* jsonl mirror): reading other Discord channels via curl
+    is independent of how Claude's *output* reaches Discord, and it does not
+    touch the c-lord REST API. So it is never scrubbed by
+    :func:`remove_injected_skills`. See #259.
+
+    Idempotent (overwrites). Only the ``.env`` *path* is baked in — never the
+    token value.
+
+    Args:
+        session_dir: Path to the per-thread session directory.
+        env_path: Absolute path to c-lord's ``.env``. Defaults to the
+            ``CLORD_ENV_PATH`` env var; if unset, the path-less read template
+            is rendered.
+
+    Returns:
+        Absolute path to the SKILL.md written.
+    """
+    if env_path is None:
+        env_path = os.getenv("CLORD_ENV_PATH") or None
+
+    read_dir = Path(session_dir) / ".claude" / "skills" / READ_SKILL_NAME
+    read_dir.mkdir(parents=True, exist_ok=True)
+    read_path = read_dir / "SKILL.md"
+    read_path.write_text(
+        render_discord_read_skill(env_path=env_path),
+        encoding="utf-8",
+    )
+    logger.info(
+        "Injected discord-read skill at %s (env_path=%s)",
+        read_path,
+        env_path or "(none)",
+    )
+    return str(read_path)
 
 
 def remove_injected_skills(session_dir: str | os.PathLike[str]) -> list[str]:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -30,8 +30,36 @@ The bridge's security goal is:
 | Claude Code modifying its own config | This is expected behavior (CLAUDE.md, memory files, etc.) |
 | Discord server admin abuse | If someone has admin on your Discord server, they already have control |
 | Physical access to the host | Out of scope — standard server security applies |
+| Claude reading the bot token from c-lord's `.env` | Accepted (#259). Same-UID processes can already read `.env`; the spawn-read skill relies on that. See below. |
 
 **The security boundary is at the Discord layer, not the CLI layer.** Once a session starts, Claude Code has full CLI-level access. The bridge's job is to ensure only the right person can start sessions.
+
+### Accepted risk: `discord-read` skill exposes the bot token to the session (#259)
+
+The injected `discord-read` skill (`c_lord/skills/discord_read.py`) tells Claude
+to read other Discord channels by reading `DISCORD_BOT_TOKEN` from c-lord's
+`.env` at runtime and `curl`-ing the Discord REST API (instead of the MCP
+plugin, which fails with `Missing Access` on channels the bot can otherwise
+see — #454).
+
+This means the bot token is **readable by the Claude session** (it `grep`s the
+`.env` file). We accept this:
+
+- It exposes nothing new: any process running as the same Unix user can already
+  `cat` the `.env` file. Hiding the token from a same-UID Claude is security
+  theater (see #234) — the real isolation boundary is the OS file permissions
+  on `.env`, which separate different Unix users.
+- The skill **never bakes the literal token into a file**. Only the `.env`
+  *path* is written into `SKILL.md` (which lives inside the cloned user repo
+  working tree, where a literal token could be `git commit`-ed and pushed). The
+  token is read into a shell variable at runtime, so it does not appear in the
+  command text that the transcript mirror (#71) echoes to Discord.
+
+> Note: the env-var stripping described under "Environment Isolation" below
+> (`_STRIPPED_ENV_KEYS`) is **not currently implemented** in the tmux-based
+> architecture — see #458. Regardless of that, the spawn-read path reads the
+> token from the `.env` *file*, not from an environment variable, so the
+> accepted-risk reasoning above does not depend on it.
 
 ## Input Validation
 

--- a/tests/test_session_dir.py
+++ b/tests/test_session_dir.py
@@ -223,6 +223,30 @@ class TestCreateSessionDir:
 
         assert not skill_dir.exists(), "stale skill must be removed when skills disabled"
 
+    def test_injects_discord_read_even_when_output_skills_disabled(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Issue #259: discord-read is bridge-independent. Even with output
+        skills disabled (jsonl mode), the read skill must still be injected so
+        Claude can read other channels regardless of cwd or #71 state."""
+        monkeypatch.setenv("USE_SKILL_REPLY", "0")
+        base = str(tmp_path / "sessions")
+
+        def fake_run(args, cwd=None):  # noqa: ANN001 — test helper
+            if "clone" in args:
+                Path(args[-1]).mkdir(parents=True, exist_ok=True)
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        with patch("c_lord.session_dir._run", side_effect=fake_run):
+            mgr = SessionDirManager(base_dir=base, source_repo="/repo")
+            Path(base).mkdir(parents=True)
+            target = mgr.create_session_dir(777)
+
+        reply = Path(target) / ".claude" / "skills" / "discord-reply" / "SKILL.md"
+        read = Path(target) / ".claude" / "skills" / "discord-read" / "SKILL.md"
+        assert not reply.exists(), "output skill must stay disabled"
+        assert read.exists(), "discord-read must be injected regardless of bridge mode"
+
     def test_injects_skills_by_default(self, tmp_path: Path, monkeypatch) -> None:
         """Issue #53: with the env unset, skill injection is on by default."""
         monkeypatch.delenv("USE_SKILL_REPLY", raising=False)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -7,9 +7,11 @@ from pathlib import Path
 import pytest
 
 from c_lord.skills import (
+    inject_read_skill,
     inject_skills,
     remove_injected_skills,
     render_discord_prompt_choice_skill,
+    render_discord_read_skill,
     render_discord_reply_skill,
 )
 from c_lord.skills.injector import skills_enabled
@@ -101,6 +103,63 @@ class TestRenderDiscordPromptChoiceSkill:
         assert "Authorization" not in body
 
 
+class TestRenderDiscordReadSkill:
+    """Issue #259: spawn-read skill — tells Claude to read other Discord
+    channels/threads via curl + the c-lord bot token (read at runtime from
+    the c-lord .env), NOT via the MCP plugin. The token is never baked into
+    the SKILL.md (it lives in the user repo working tree → git-leak risk);
+    Claude reads it into a shell variable at runtime."""
+
+    def test_frontmatter_name(self) -> None:
+        body = render_discord_read_skill(env_path="/srv/c-lord/.env")
+        assert body.startswith("---\nname: discord-read")
+
+    def test_includes_env_path_when_given(self) -> None:
+        body = render_discord_read_skill(env_path="/srv/c-lord/.env")
+        assert "/srv/c-lord/.env" in body
+        assert "{env_path}" not in body
+
+    def test_reads_token_into_variable_not_literal(self) -> None:
+        """The token must be read at runtime via a shell var, never printed
+        as a literal — otherwise it leaks into the (#71-mirrored) transcript."""
+        body = render_discord_read_skill(env_path="/srv/c-lord/.env")
+        # token is pulled from .env into a variable then used as $VAR
+        assert "DISCORD_BOT_TOKEN" in body
+        assert "grep" in body
+        # curl uses the bot auth scheme via a variable expansion ($...)
+        assert "Authorization: Bot $" in body
+
+    def test_points_at_discord_rest_api(self) -> None:
+        body = render_discord_read_skill(env_path="/x/.env")
+        assert "discord.com/api/" in body
+        assert "/messages" in body
+
+    def test_forbids_mcp_and_mandates_fallback(self) -> None:
+        """The whole point of #454: don't use the MCP plugin; if it returns
+        Missing Access / not allowlisted, fall back to curl instead of giving
+        up."""
+        low = render_discord_read_skill(env_path="/x/.env").lower()
+        assert "mcp" in low
+        # must reference the give-up trigger and a fallback instruction
+        assert "missing access" in low or "allowlist" in low
+        assert "fall back" in low or "fallback" in low
+
+    def test_does_not_leak_a_literal_token(self) -> None:
+        """No raw token value is ever substituted into the body."""
+        body = render_discord_read_skill(env_path="/x/.env")
+        # A real bot token never appears because we only know the .env path.
+        assert "Bot " in body  # the scheme word is fine
+        # but there must be a variable expansion, proving runtime read
+        assert "$" in body
+
+    def test_usable_without_env_path(self) -> None:
+        """When the .env path is unknown, the skill still instructs Claude to
+        read DISCORD_BOT_TOKEN from c-lord's .env — no unfilled placeholder."""
+        body = render_discord_read_skill()
+        assert "{env_path}" not in body
+        assert "DISCORD_BOT_TOKEN" in body
+
+
 class TestInjectSkills:
     def test_writes_discord_reply_skill_md(self, tmp_path: Path) -> None:
         session_dir = tmp_path / "12345"
@@ -186,6 +245,75 @@ class TestInjectSkills:
         assert "http://x:2222" in body
         assert "/api/prompt-choice" in body
 
+    def test_also_writes_discord_read_skill_md(self, tmp_path: Path) -> None:
+        """Issue #259: discord-read skill is injected alongside the others."""
+        session_dir = tmp_path / "thr"
+        session_dir.mkdir()
+        paths = inject_skills(session_dir, thread_id=88, api_url="http://x:2222")
+
+        read_md = session_dir / ".claude" / "skills" / "discord-read" / "SKILL.md"
+        assert read_md.exists()
+        assert str(read_md) in paths
+        body = read_md.read_text()
+        assert "discord.com/api/" in body
+        assert "mcp" in body.lower()
+
+    def test_inject_read_uses_env_path_arg(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x", env_path="/opt/clord/.env")
+        body = (session_dir / ".claude" / "skills" / "discord-read" / "SKILL.md").read_text()
+        assert "/opt/clord/.env" in body
+
+    def test_inject_read_falls_back_to_env_var(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("CLORD_ENV_PATH", "/from/env/.env")
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_skills(session_dir, thread_id=1, api_url="http://x")
+        body = (session_dir / ".claude" / "skills" / "discord-read" / "SKILL.md").read_text()
+        assert "/from/env/.env" in body
+
+
+class TestInjectReadSkill:
+    """Issue #259: discord-read has an independent, bridge-mode-agnostic
+    lifecycle — it is injected in both skill-reply and jsonl modes."""
+
+    def test_writes_read_skill_md(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        path = inject_read_skill(session_dir, env_path="/opt/clord/.env")
+        read_md = session_dir / ".claude" / "skills" / "discord-read" / "SKILL.md"
+        assert read_md.exists()
+        assert str(read_md) == path
+        body = read_md.read_text()
+        assert "/opt/clord/.env" in body
+        assert "discord.com/api/" in body
+
+    def test_falls_back_to_env_var(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("CLORD_ENV_PATH", "/from/env/.env")
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_read_skill(session_dir)
+        body = (session_dir / ".claude" / "skills" / "discord-read" / "SKILL.md").read_text()
+        assert "/from/env/.env" in body
+
+    def test_idempotent_overwrites(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_read_skill(session_dir, env_path="/a/.env")
+        inject_read_skill(session_dir, env_path="/b/.env")
+        body = (session_dir / ".claude" / "skills" / "discord-read" / "SKILL.md").read_text()
+        assert "/b/.env" in body
+        assert "/a/.env" not in body
+
+    def test_survives_remove_injected_skills(self, tmp_path: Path) -> None:
+        """The jsonl-mode path: output skills are scrubbed but read stays."""
+        session_dir = tmp_path / "1"
+        session_dir.mkdir()
+        inject_read_skill(session_dir, env_path="/x/.env")
+        remove_injected_skills(session_dir)
+        assert (session_dir / ".claude" / "skills" / "discord-read" / "SKILL.md").exists()
+
 
 class TestRemoveInjectedSkills:
     """When skill reply is disabled (e.g. CLORD_BRIDGE_MODE=jsonl) a stale skill
@@ -198,7 +326,8 @@ class TestRemoveInjectedSkills:
         inject_skills(session_dir, thread_id=1, api_url="http://x")
         reply = session_dir / ".claude" / "skills" / "discord-reply"
         choice = session_dir / ".claude" / "skills" / "discord-prompt-choice"
-        assert reply.exists() and choice.exists()
+        read = session_dir / ".claude" / "skills" / "discord-read"
+        assert reply.exists() and choice.exists() and read.exists()
 
         removed = remove_injected_skills(session_dir)
 
@@ -206,6 +335,10 @@ class TestRemoveInjectedSkills:
         assert not choice.exists()
         assert str(reply) in removed
         assert str(choice) in removed
+        # #259: discord-read is bridge-independent (curls Discord directly, not
+        # the c-lord REST API), so it is NOT scrubbed by remove_injected_skills.
+        assert read.exists()
+        assert str(read) not in removed
 
     def test_idempotent_when_absent(self, tmp_path: Path) -> None:
         session_dir = tmp_path / "1"


### PR DESCRIPTION
## What does this PR do?

Injects a **`discord-read`** skill into every Claude session so Claude reads
other Discord channels/threads via the **c-lord bot token + Discord REST API
(curl)** instead of the MCP plugin — and falls back to curl even when MCP
returns `Missing Access`.

- New `c_lord/skills/discord_read.py` (template, like `discord_reply.py`).
- New `inject_read_skill()` in `injector.py`; called by `session_dir.py` in
  **every bridge mode** (skill-reply *and* jsonl). It is not in
  `INJECTED_SKILL_NAMES`, so `remove_injected_skills()` never scrubs it.
- `main.py` exposes the resolved `.env` path as `CLORD_ENV_PATH` so the skill
  can tell Claude where to read `DISCORD_BOT_TOKEN` at runtime. **Only the path
  is propagated — never the token.**
- `docs/SECURITY.md` records the accepted risk; `CLAUDE.md` documents the new
  delivery path.

## Why?

When Claude needs to read another channel it reaches for the MCP plugin, which
is gated by its own allowlist and fails with `Missing Access` on channels the
c-lord bot is otherwise in (#454). The reliable curl fallback only lived in
c-lord's own `CLAUDE.md`, so it never reached sessions whose cwd is a different
project — exactly the #454 case.

Design rationale (spawn-read, not a server-side read API) and the security
analysis (multi-tenant loopback, token exposure) are recorded in the
[#259 decision comment (2026-06-22)](https://github.com/yousan/c-lord/issues/259#issuecomment-4763879034).

Refs #259
Refs #454
Refs #234
Refs #71

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: 別チャンネルの内容を聞くと「MCP で Missing Access、読めませんでした」と諦めることがある → 別プロジェクトのセッションでも c-lord bot 経由で確実に読んで答える。

## Acceptance Criteria (copied from the issue)

- [x] `discord-read` skill が各セッションに注入される（`tests/test_skills.py::TestInjectReadSkill`, `tests/test_session_dir.py::...test_injects_discord_read_even_when_output_skills_disabled`）。bridge-mode 非依存に `inject_read_skill()` で注入。
- [x] skill は c-lord の `.env` の bot token を使い Discord REST を curl する手順を含み、**MCP を使うな／Missing Access でも curl にフォールバックせよ**を明記（`TestRenderDiscordReadSkill::test_forbids_mcp_and_mandates_fallback`）。
- [x] セッション cwd に依存せず注入され、Claude がそれに従って別チャンネルを読める（staging E2E + unit test。詳細は下記 Staging Evidence。※ staging のセッション cwd は c-lord clone だが、注入経路は cwd 非依存＝任意 session_dir で動くことを unit test で担保）。
- [x] SECURITY.md に spawn-read の accepted risk（token 露出 = ファイルパーミッションに委ねる）が明記（本 PR）。
- [x] CLAUDE.md に「読み取りは discord-read / curl、MCP は使わない・Missing Access でも curl にフォールバック」が明記（本 PR）。
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` all green（変更ファイルについて）。
- [x] TDD: 新規テストが RED → GREEN（下記）。
- [x] Staging 検証: 修正前=スキル無し／修正後=skill 経由で別チャンネルを読める を確認（下記）。
- [x] `Refs #234` / `Refs #71` / `Refs #454`。

## TDD Evidence (RED → GREEN)

**RED**（実装前・import が存在しない）:
```
tests/test_skills.py:9: in <module>
    from c_lord.skills import (
E   ImportError: cannot import name 'render_discord_read_skill' from 'c_lord.skills'
```
**GREEN**（実装後・クリーン env で全スイート）: `1971 passed, 3 skipped, 23 deselected`。
変更ファイルの `ruff check` / `ruff format --check` / `pyright`: all green。

## Staging Evidence (証跡)

環境: staging-2（`C-lord-staging-2`, `CLORD_BRIDGE_MODE=jsonl`）/ E2E thread `1514545583459926117` / 信頼bot方式トリガー。
検証内容: Claude に「**別チャンネル `1503245597841559623`（#c-lord-staging-3）の最新メッセージを discord-read skill で読め**」と指示。jsonl モードなので、main では skill 自体が注入されない（= RED が決定論的）。

### RED — `main`（discord-read skill 無し）

Claude は「**discord-read スキルが見つかりません**」と回答。session dir にも `discord-read/SKILL.md` は無し（`ls .../.claude/skills` → discord-read 不在）。

![RED main](https://github.com/yousan/c-lord/releases/download/evidence/i459-259-259-red-20260622T045409Z-00.png)

### GREEN — `feature/259-discord-read-skill @ f3b69ca`

別チャンネルに既知マーカー `GREENPROOF-9911 別チャンネルから discord-read で読めたら成功` を投下 → Claude は **discord-read skill を起動 → curl で当該チャンネルを読み**、本文をそのまま回答:

> 最新メッセージの本文:
> **GREENPROOF-9911 別チャンネルから discord-read で読めたら成功**

![GREEN fix](https://github.com/yousan/c-lord/releases/download/evidence/i459-259-259-green-20260622T045409Z-01.png)

<details>
<summary>transcript 証跡 — discord-read skill 起動 + curl（token は変数経由・MCP 不使用）</summary>

JSONL transcript（`tool_use`）抜粋:
```
TOOL: Skill   {"skill": "discord-read", "args": "channel_id=1503245597841559623 limit=1"}
TOOL: Bash    TOKEN=$(grep '^DISCORD_BOT_TOKEN=' /home/yousan/c-lord-staging-2/.env | cut -d= -f2-)
              curl -s -H "Authorization: Bot $TOKEN" \
                -H "User-Agent: DiscordBot (https://github.com/yousan/c-lord, 1.0)" \
                "https://discord.com/api/v10/channels/1503245597841559623/messages?limit=1"
```
- `discord-read` skill が discovery され起動 ✓
- token は **per-instance の `.env`**（`/home/yousan/c-lord-staging-2/.env`）から `$TOKEN` 変数へ（**literal で出ない** → #71 ミラーにも漏れない）✓
- MCP ではなく **curl で別チャンネル**を読了 ✓
- 補足: skill 注入直後の同一 Claude プロセスは起動時に skill 一覧を読むため未反映 → 新規 Claude 起動（新 thread / 再起動）で反映。production でも「更新後の新規セッション」で有効＝Zero-Config として正しい挙動。
</details>

## Scope

- セキュリティ監査（`security-audit` skill）実施済み: token 値はどこにも書き込み／ログ
  出力しない。`main.py` は `.env` の**パス**だけを `CLORD_ENV_PATH` に出す。
- スコープ外: 無認証 API サーバの cross-UID 露出（#457）、`DISCORD_BOT_TOKEN`
  env-strip のドキュメント drift（#458）。本 PR では触らない。


## Definition of Done checklist

- [x] Every Acceptance Criterion of the linked issue is copied into the PR body and checked (上記 Acceptance Criteria 参照)。
- [x] TDD evidence: 新規テストが変更前に RED（`ImportError: cannot import name 'render_discord_read_skill'`）→ 変更後 GREEN。
- [x] Detection bug fixture rule: 該当なし（TUI prompt 検出関数の変更ではない）。
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` all green（変更ファイル / CI: test 3.10/3.11/3.12 green）。
- [x] Staging behavior verified: RED（main = discord-read skill 無し→「見つかりません」）→ GREEN（fix = skill 起動 + curl で別チャンネルの `GREENPROOF-9911` を読了）を staging-2 で確認。スクショ + transcript を上の Staging Evidence に掲載。
- [x] 動きを変えたら「あるべき動き」も更新: `CLAUDE.md`（読み取り経路）+ `docs/SECURITY.md`（accepted risk）を本 PR で更新。
- [x] No unrelated changes; self-review 済み（`git diff main` は discord-read 関連のみ）。
- [x] Closes gating: `Refs #259`（auto-close しない。AC は満たしているが、レビュー後に手動クローズ判断とする）。
