### PR TITLE
fix(bot): guild-sync のみに絞りスラッシュコマンド二重表示を解消

### DIFF
--- a/c_lord/bot.py
+++ b/c_lord/bot.py
@@ -201,16 +201,27 @@ class ClaudeDiscordBot(commands.Bot):
             )
 
         # Sync slash commands to the guild only — instant propagation, no duplicates.
-        # Global sync is intentionally omitted: c-lord is installed per-server, so
-        # guild-scoped commands are sufficient and avoid the double-entry that arises
-        # when the same command exists as both a guild command and a global command.
+        #
+        # Previously the bot called both tree.sync(guild=guild) AND tree.sync() (global),
+        # which caused every command to appear twice in Discord's command picker.
+        # The fix has two steps:
+        #   1. Register commands as guild-scoped (instant, sufficient for per-server installs)
+        #   2. Wipe any previously-registered global commands so the duplicates disappear
         try:
             channel = self.get_channel(self.channel_id)
             guild = getattr(channel, "guild", None)
             if guild is not None:
+                # Step 1: guild sync (instant propagation)
                 self.tree.copy_global_to(guild=guild)
                 synced = await self.tree.sync(guild=guild)
                 logger.info("Synced %d slash commands to guild %d (instant)", len(synced), guild.id)
+
+                # Step 2: clear global commands so previously-registered globals are removed.
+                # This is a migration: on first run after the fix it removes the old global
+                # registrations; on subsequent runs it is a cheap no-op (empty list → empty list).
+                self.tree.clear_commands(guild=None)
+                await self.tree.sync()
+                logger.info("Cleared global slash commands (removes legacy duplicates)")
             else:
                 logger.warning(
                     "Could not resolve guild from channel %d; slash commands not synced",

--- a/c_lord/bot.py
+++ b/c_lord/bot.py
@@ -200,17 +200,22 @@ class ClaudeDiscordBot(commands.Bot):
                 self.channel_id,
             )
 
-        # Sync slash commands — guild sync first for instant propagation,
-        # then global sync so commands are available outside the guild too.
+        # Sync slash commands to the guild only — instant propagation, no duplicates.
+        # Global sync is intentionally omitted: c-lord is installed per-server, so
+        # guild-scoped commands are sufficient and avoid the double-entry that arises
+        # when the same command exists as both a guild command and a global command.
         try:
             channel = self.get_channel(self.channel_id)
             guild = getattr(channel, "guild", None)
             if guild is not None:
                 self.tree.copy_global_to(guild=guild)
-                await self.tree.sync(guild=guild)
-                logger.info("Synced slash commands to guild %d (instant)", guild.id)
-            synced = await self.tree.sync()
-            logger.info("Synced %d slash commands (global)", len(synced))
+                synced = await self.tree.sync(guild=guild)
+                logger.info("Synced %d slash commands to guild %d (instant)", len(synced), guild.id)
+            else:
+                logger.warning(
+                    "Could not resolve guild from channel %d; slash commands not synced",
+                    self.channel_id,
+                )
         except Exception:
             logger.exception("Failed to sync slash commands")
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -225,51 +225,34 @@ class TestOnError:
 
 
 class TestSlashCommandSync:
-    """Slash command sync must use guild-only sync to avoid duplicate entries.
+    """Slash command sync must register guild-only and wipe global commands.
 
     Before the fix, the bot called both tree.sync(guild=guild) AND tree.sync()
     (global), causing the same command to appear twice in Discord's command list.
+    The fix has two parts:
+      1. Register as guild commands (instant)
+      2. Explicitly clear global commands so previously-registered globals disappear
     """
 
-    @pytest.mark.asyncio
-    async def test_global_sync_not_called(self) -> None:
-        """tree.sync() without a guild argument must NOT be called."""
-        from unittest.mock import AsyncMock, MagicMock, patch
+    def _make_bot_with_mocks(self) -> tuple:
+        from unittest.mock import AsyncMock, MagicMock
 
         bot = ClaudeDiscordBot(channel_id=123)
-
         guild = MagicMock()
         channel = MagicMock()
         channel.guild = guild
-
         bot.tree.copy_global_to = MagicMock()
+        bot.tree.clear_commands = MagicMock()
         bot.tree.sync = AsyncMock(return_value=[])
         bot.get_channel = MagicMock(return_value=channel)
-
-        with (
-            patch.object(bot, "_assert_expected_identity"),
-            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
-            patch("c_lord.bot.isinstance", return_value=False),
-        ):
-            await bot.on_ready()
-
-        # sync must have been called exactly once, with guild= kwarg
-        bot.tree.sync.assert_called_once_with(guild=guild)
+        return bot, guild
 
     @pytest.mark.asyncio
     async def test_guild_sync_called(self) -> None:
         """tree.copy_global_to and tree.sync(guild=...) must be called."""
-        from unittest.mock import AsyncMock, MagicMock, patch
+        from unittest.mock import AsyncMock, patch
 
-        bot = ClaudeDiscordBot(channel_id=123)
-
-        guild = MagicMock()
-        channel = MagicMock()
-        channel.guild = guild
-
-        bot.tree.copy_global_to = MagicMock()
-        bot.tree.sync = AsyncMock(return_value=[])
-        bot.get_channel = MagicMock(return_value=channel)
+        bot, guild = self._make_bot_with_mocks()
 
         with (
             patch.object(bot, "_assert_expected_identity"),
@@ -279,4 +262,52 @@ class TestSlashCommandSync:
             await bot.on_ready()
 
         bot.tree.copy_global_to.assert_called_once_with(guild=guild)
-        bot.tree.sync.assert_called_once_with(guild=guild)
+        # First sync call must be the guild sync
+        first_call = bot.tree.sync.call_args_list[0]
+        assert first_call.kwargs.get("guild") == guild
+
+    @pytest.mark.asyncio
+    async def test_global_commands_cleared(self) -> None:
+        """clear_commands(guild=None) + tree.sync() must be called to wipe legacy globals."""
+        from unittest.mock import AsyncMock, call, patch
+
+        bot, guild = self._make_bot_with_mocks()
+
+        with (
+            patch.object(bot, "_assert_expected_identity"),
+            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
+            patch("c_lord.bot.isinstance", return_value=False),
+        ):
+            await bot.on_ready()
+
+        bot.tree.clear_commands.assert_called_once_with(guild=None)
+        # Second sync call must be the global clear (no guild kwarg)
+        assert call() in bot.tree.sync.call_args_list
+
+    @pytest.mark.asyncio
+    async def test_sync_order_guild_before_global_clear(self) -> None:
+        """Guild sync must happen before the global clear."""
+        from unittest.mock import AsyncMock, patch
+
+        bot, guild = self._make_bot_with_mocks()
+        call_order: list[str] = []
+
+        orig_sync = bot.tree.sync.side_effect
+
+        async def tracking_sync(**kwargs: object) -> list:
+            if "guild" in kwargs:
+                call_order.append("guild")
+            else:
+                call_order.append("global_clear")
+            return []
+
+        bot.tree.sync.side_effect = tracking_sync
+
+        with (
+            patch.object(bot, "_assert_expected_identity"),
+            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
+            patch("c_lord.bot.isinstance", return_value=False),
+        ):
+            await bot.on_ready()
+
+        assert call_order == ["guild", "global_clear"]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -222,3 +222,61 @@ class TestOnError:
 
         assert any(r.levelno >= logging.ERROR for r in caplog.records)
         assert any("zombie" in r.message.lower() for r in caplog.records)
+
+
+class TestSlashCommandSync:
+    """Slash command sync must use guild-only sync to avoid duplicate entries.
+
+    Before the fix, the bot called both tree.sync(guild=guild) AND tree.sync()
+    (global), causing the same command to appear twice in Discord's command list.
+    """
+
+    @pytest.mark.asyncio
+    async def test_global_sync_not_called(self) -> None:
+        """tree.sync() without a guild argument must NOT be called."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        bot = ClaudeDiscordBot(channel_id=123)
+
+        guild = MagicMock()
+        channel = MagicMock()
+        channel.guild = guild
+
+        bot.tree.copy_global_to = MagicMock()
+        bot.tree.sync = AsyncMock(return_value=[])
+        bot.get_channel = MagicMock(return_value=channel)
+
+        with (
+            patch.object(bot, "_assert_expected_identity"),
+            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
+            patch("c_lord.bot.isinstance", return_value=False),
+        ):
+            await bot.on_ready()
+
+        # sync must have been called exactly once, with guild= kwarg
+        bot.tree.sync.assert_called_once_with(guild=guild)
+
+    @pytest.mark.asyncio
+    async def test_guild_sync_called(self) -> None:
+        """tree.copy_global_to and tree.sync(guild=...) must be called."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        bot = ClaudeDiscordBot(channel_id=123)
+
+        guild = MagicMock()
+        channel = MagicMock()
+        channel.guild = guild
+
+        bot.tree.copy_global_to = MagicMock()
+        bot.tree.sync = AsyncMock(return_value=[])
+        bot.get_channel = MagicMock(return_value=channel)
+
+        with (
+            patch.object(bot, "_assert_expected_identity"),
+            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
+            patch("c_lord.bot.isinstance", return_value=False),
+        ):
+            await bot.on_ready()
+
+        bot.tree.copy_global_to.assert_called_once_with(guild=guild)
+        bot.tree.sync.assert_called_once_with(guild=guild)


### PR DESCRIPTION
## What does this PR do?

Discord でスラッシュコマンドが二重表示されていた問題を修正する。`on_ready` で同じコマンドをグローバルとギルドの両方に登録していたのをやめ、ギルドのみに登録 + 既存グローバルコマンドを明示削除する。

## Why?

ユーザーが Discord で `/` を打つと、同名コマンド（`/skill` `/tmux-list` 等）が 2 つずつ並んで表示され、どちらを選べばよいか分からない・リストが冗長になる、という不便があった。

Refs #460

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: Discord で `/` を打つと各コマンドが 2 つずつダブって出る → 各コマンドが 1 つだけ表示される

## 修正内容 (2 ステップ)

1. ギルドコマンドとして登録（今まで通り、即時反映）
2. `clear_commands(guild=None)` + `tree.sync()` で過去に登録したグローバルコマンドを**明示削除**（migration）

```
# Before (バグ)
tree.sync(guild=guild)  # ギルドに登録
tree.sync()             # さらにグローバルにも登録 → 2 つ見える
```

## Acceptance Criteria (copied from the issue)

- [ ] Discord の `/` メニューで各スラッシュコマンドが1つだけ表示される ← **本番デプロイ後に目視確認**（グローバル削除の Discord 反映に最大1時間）。staging では bot 4 台同居で `/` 目視が判別不能のため API 数値で代替検証済み（下記）
- [x] `tree.sync()` (引数なし/global sync) が登録目的で `on_ready` で呼ばれない
- [x] `tree.sync(guild=guild)` は引き続き呼ばれる (即時反映のため)
- [x] `pytest` + `ruff check` + `ruff format --check` が全グリーン（既存失敗は pre-existing）

最後の1件は本番反映後にしか確認できないため `Refs #460` に留め、Issue は開いたままにする。

## Staging Evidence (証跡)

### RED — 本番で `/tmux` を打つと同名コマンドが重複表示（yousan 撮影の実画面）

![before - duplicated commands](https://github.com/yousan/c-lord/releases/download/evidence/i460-i460-before-real-20260622T051301Z.png)

`/tmux-screenshot` `/tmux-list` がそれぞれ複数回ダブって出ている。

### GREEN — staging-3 で fix ブランチ起動後、Discord API のコマンド登録数を実測

| | グローバル | ギルド |
|---|---|---|
| main (RED) | 20 | 20 |
| fix (GREEN) | **0** | 20 |

確認コマンド（再現可能・staging-3 で実行）:
```bash
TOKEN=$(grep '^DISCORD_BOT_TOKEN=' .env | cut -d= -f2-)
APP_ID=1503234123932635206
curl -s -H "Authorization: Bot $TOKEN" \
  "https://discord.com/api/v10/applications/$APP_ID/commands" \
  | python3 -c "import sys,json; print(len(json.load(sys.stdin)))"
# → main: 20 / fix: 0
```

※ staging サーバには staging-1〜4 の bot が同居しているため `/` リストの目視はコマンドが混ざって判別不能。そのため GREEN は **bot 単位で確実に判定できる API 登録数**で示している。本番（bot 1 台）では目視で確認する。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked（本番目視のみ post-merge、`Refs` で Issue 継続）
- [x] TDD: `test_global_commands_cleared` が修正前 FAIL / 修正後 PASS
- [x] `uv run pytest tests/` passes（今回追加分・既存失敗は pre-existing で本変更と無関係）
- [x] `uv run ruff check c_lord/` + `ruff format --check` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新（コマンド sync は内部挙動・docs 記載なし。利用者向けの見え方変化は本文 before/after に記載）
- [x] `Refs #460` used（本番目視 AC 未達のため `Closes` ではなく `Refs`）