### PR TITLE
fix(bot): スラッシュコマンドをグローバル登録にしてマルチサーバー対応 (#462)

### DIFF
--- a/c_lord/bot.py
+++ b/c_lord/bot.py
@@ -200,33 +200,31 @@ class ClaudeDiscordBot(commands.Bot):
                 self.channel_id,
             )
 
-        # Sync slash commands to the guild only — instant propagation, no duplicates.
+        # Register slash commands GLOBALLY so they are available in every guild the
+        # bot is in. c-lord is one bot instance that can serve multiple servers, and
+        # global registration is Discord's recommended approach for multi-guild bots.
         #
-        # Previously the bot called both tree.sync(guild=guild) AND tree.sync() (global),
-        # which caused every command to appear twice in Discord's command picker.
-        # The fix has two steps:
-        #   1. Register commands as guild-scoped (instant, sufficient for per-server installs)
-        #   2. Wipe any previously-registered global commands so the duplicates disappear
+        # #462: a previous version (#461) registered commands only on the single guild
+        # derived from channel_id (and wiped the globals). That hid the commands from
+        # every OTHER server the bot was in. The trade-off of going global is that
+        # command *definition* changes take up to ~1h to propagate; normal use is
+        # unaffected once registered.
+        #
+        # Migration: before the global sync, clear any legacy guild-scoped commands on
+        # the primary guild — left in place they would duplicate against the global
+        # ones in Discord's command picker (the #460 double-entry bug). Pushing an
+        # empty guild command set removes them. On servers that never had guild
+        # commands this is a no-op.
         try:
             channel = self.get_channel(self.channel_id)
             guild = getattr(channel, "guild", None)
             if guild is not None:
-                # Step 1: guild sync (instant propagation)
-                self.tree.copy_global_to(guild=guild)
-                synced = await self.tree.sync(guild=guild)
-                logger.info("Synced %d slash commands to guild %d (instant)", len(synced), guild.id)
+                self.tree.clear_commands(guild=guild)
+                await self.tree.sync(guild=guild)
+                logger.info("Cleared legacy guild-scoped slash commands on guild %d", guild.id)
 
-                # Step 2: clear global commands so previously-registered globals are removed.
-                # This is a migration: on first run after the fix it removes the old global
-                # registrations; on subsequent runs it is a cheap no-op (empty list → empty list).
-                self.tree.clear_commands(guild=None)
-                await self.tree.sync()
-                logger.info("Cleared global slash commands (removes legacy duplicates)")
-            else:
-                logger.warning(
-                    "Could not resolve guild from channel %d; slash commands not synced",
-                    self.channel_id,
-                )
+            synced = await self.tree.sync()
+            logger.info("Synced %d global slash commands (available in all guilds)", len(synced))
         except Exception:
             logger.exception("Failed to sync slash commands")
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -225,13 +225,13 @@ class TestOnError:
 
 
 class TestSlashCommandSync:
-    """Slash command sync must register guild-only and wipe global commands.
+    """Slash command sync must register GLOBALLY so commands work in every guild.
 
-    Before the fix, the bot called both tree.sync(guild=guild) AND tree.sync()
-    (global), causing the same command to appear twice in Discord's command list.
-    The fix has two parts:
-      1. Register as guild commands (instant)
-      2. Explicitly clear global commands so previously-registered globals disappear
+    #462 regression: #461 registered commands only on the one guild derived from
+    channel_id (and wiped globals), so the bot — which serves multiple servers —
+    lost its slash commands on every OTHER server. The fix registers globally
+    (Discord's multi-guild standard) and clears the legacy guild-scoped commands
+    on the primary guild so they don't duplicate against the global ones.
     """
 
     def _make_bot_with_mocks(self) -> tuple:
@@ -248,27 +248,8 @@ class TestSlashCommandSync:
         return bot, guild
 
     @pytest.mark.asyncio
-    async def test_guild_sync_called(self) -> None:
-        """tree.copy_global_to and tree.sync(guild=...) must be called."""
-        from unittest.mock import AsyncMock, patch
-
-        bot, guild = self._make_bot_with_mocks()
-
-        with (
-            patch.object(bot, "_assert_expected_identity"),
-            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
-            patch("c_lord.bot.isinstance", return_value=False),
-        ):
-            await bot.on_ready()
-
-        bot.tree.copy_global_to.assert_called_once_with(guild=guild)
-        # First sync call must be the guild sync
-        first_call = bot.tree.sync.call_args_list[0]
-        assert first_call.kwargs.get("guild") == guild
-
-    @pytest.mark.asyncio
-    async def test_global_commands_cleared(self) -> None:
-        """clear_commands(guild=None) + tree.sync() must be called to wipe legacy globals."""
+    async def test_global_sync_called(self) -> None:
+        """tree.sync() with NO guild kwarg must be called to register globally."""
         from unittest.mock import AsyncMock, call, patch
 
         bot, guild = self._make_bot_with_mocks()
@@ -280,25 +261,57 @@ class TestSlashCommandSync:
         ):
             await bot.on_ready()
 
-        bot.tree.clear_commands.assert_called_once_with(guild=None)
-        # Second sync call must be the global clear (no guild kwarg)
+        # A global sync (no guild kwarg) must have happened
         assert call() in bot.tree.sync.call_args_list
 
     @pytest.mark.asyncio
-    async def test_sync_order_guild_before_global_clear(self) -> None:
-        """Guild sync must happen before the global clear."""
+    async def test_copy_global_to_not_called(self) -> None:
+        """copy_global_to must NOT be used — that re-creates the per-guild duplicates."""
+        from unittest.mock import AsyncMock, patch
+
+        bot, guild = self._make_bot_with_mocks()
+
+        with (
+            patch.object(bot, "_assert_expected_identity"),
+            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
+            patch("c_lord.bot.isinstance", return_value=False),
+        ):
+            await bot.on_ready()
+
+        bot.tree.copy_global_to.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_guild_commands_cleared(self) -> None:
+        """clear_commands(guild=guild) + sync(guild=guild) must wipe legacy guild commands."""
+        from unittest.mock import AsyncMock, patch
+
+        bot, guild = self._make_bot_with_mocks()
+
+        with (
+            patch.object(bot, "_assert_expected_identity"),
+            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
+            patch("c_lord.bot.isinstance", return_value=False),
+        ):
+            await bot.on_ready()
+
+        bot.tree.clear_commands.assert_called_once_with(guild=guild)
+        # A guild-scoped sync (to push the now-empty guild command set) must have happened
+        guild_syncs = [c for c in bot.tree.sync.call_args_list if c.kwargs.get("guild") == guild]
+        assert len(guild_syncs) == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_order_guild_clear_before_global(self) -> None:
+        """Legacy guild clear must happen before the global registration."""
         from unittest.mock import AsyncMock, patch
 
         bot, guild = self._make_bot_with_mocks()
         call_order: list[str] = []
 
-        orig_sync = bot.tree.sync.side_effect
-
         async def tracking_sync(**kwargs: object) -> list:
-            if "guild" in kwargs:
-                call_order.append("guild")
+            if kwargs.get("guild") is not None:
+                call_order.append("guild_clear")
             else:
-                call_order.append("global_clear")
+                call_order.append("global")
             return []
 
         bot.tree.sync.side_effect = tracking_sync
@@ -310,4 +323,26 @@ class TestSlashCommandSync:
         ):
             await bot.on_ready()
 
-        assert call_order == ["guild", "global_clear"]
+        assert call_order == ["guild_clear", "global"]
+
+    @pytest.mark.asyncio
+    async def test_global_sync_runs_even_without_guild(self) -> None:
+        """If the channel's guild can't be resolved, global sync must still run."""
+        from unittest.mock import AsyncMock, MagicMock, call, patch
+
+        bot = ClaudeDiscordBot(channel_id=123)
+        channel = MagicMock()
+        channel.guild = None  # cannot resolve guild
+        bot.tree.clear_commands = MagicMock()
+        bot.tree.sync = AsyncMock(return_value=[])
+        bot.get_channel = MagicMock(return_value=channel)
+
+        with (
+            patch.object(bot, "_assert_expected_identity"),
+            patch.object(bot, "_restore_pending_ask_views", new_callable=AsyncMock),
+            patch("c_lord.bot.isinstance", return_value=False),
+        ):
+            await bot.on_ready()
+
+        # Global sync still happened so commands are registered everywhere
+        assert call() in bot.tree.sync.call_args_list


### PR DESCRIPTION
## What does this PR do?

C-lord のスラッシュコマンド登録を **グローバル登録のみ** に統一し、bot が参加する全サーバーでコマンドが使えるようにする。

## Why?

#461 はコマンドを `channel_id` 由来の1つのサーバーだけにギルド登録し、グローバルコマンドを全削除していた。C-lord は1 bot インスタンスで複数サーバーに参加するため、**メインサーバー以外の全サーバーでスラッシュコマンドが消える**リグレッションになっていた（ばべるんサーバーで `/clord` が出ない、と報告）。

グローバル登録は Discord 公式が複数サーバー bot 向けに推奨する標準方式。参加サーバーが増えても自動で全部に行き渡る。元の二重表示 (#460) も、起動時に primary guild の旧ギルドコマンドを削除することで再発を防ぐ。

Refs #462

## 利用者から見た before/after（1行・必須）

- before → after: メインサーバー以外で C-lord のスラッシュコマンドが一切出ない → 全サーバーでコマンドが出る（重複なし）

## 修正内容

`on_ready` のコマンド同期を変更:
1. primary guild の旧ギルドコマンドを削除（`clear_commands(guild=guild)` + `sync(guild=guild)`）→ グローバルとの二重表示を防ぐ
2. グローバル登録（`tree.sync()` 引数なし）→ 全ギルドでコマンドが使える

トレードオフ: コマンド定義の変更は Discord 反映に最大1時間。登録済みコマンドの通常利用は即座に動く。

## Acceptance Criteria (copied from the issue)

- [x] `on_ready` はグローバル登録 (`tree.sync()` 引数なし) のみを行う
- [x] 起動時に既存のギルドコマンドを削除する（メインサーバーの二重化防止）
- [x] API 実測で、メインサーバー・他サーバー両方でコマンドが見える状態になる（global=20 が全ギルドに行き渡る）
- [x] `pytest` + `ruff check` + `ruff format --check` が全グリーン（既存失敗は pre-existing で本変更と無関係）
- [ ] 別サーバー（ばべるん）の Discord 実画面で `/clord` 系コマンドが表示される ← **本番反映後に目視**（グローバル反映に最大1時間）

最後の AC は本番反映後にしか確認できないため `Refs #462` に留め、Issue は開いたままにする。

## Staging Evidence (証跡)

staging-2 bot は2ギルド（Kater = primary / C-lordのサーバー = other）に参加しているのでマルチサーバー検証に使った。

### RED — 他サーバーでコマンドが消える

本番のばべるんサーバーで `/clo` を打っても C-lord のコマンドが出ない（yousan 撮影の実画面）:

![before - no C-lord commands on other server](https://github.com/yousan/c-lord/releases/download/evidence/i462-i462-before-other-server-20260625T014402Z.png)

staging-2 (main) の API 実測も同じ症状:
```
グローバル:               0 件
Kater (primary):          20 件
C-lordのサーバー (other): 0 件  ← 他サーバーでコマンド消滅
```

### GREEN — fix ブランチ起動後、staging-2 の API 実測

```
グローバル:               20 件  ← 全ギルドに行き渡る
Kater (primary):          0 件   ← ギルド重複なし
C-lordのサーバー (other): 0 件   ← グローバル20件で網羅される
```

グローバルコマンドは Discord 仕様上 bot が参加する全ギルドに表示されるため、他サーバーでもコマンドが復活する。本番（ばべるん含む）の実画面確認はデプロイ後に行う。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked（本番目視のみ post-merge、`Refs` で Issue 継続）
- [x] TDD: `TestSlashCommandSync` を新仕様に書き換え、修正前 RED（3件 fail）→ 修正後 GREEN（5件 pass）
- [x] `uv run pytest tests/` passes（bot 関連は全 green。既存失敗は pre-existing）
- [x] `uv run ruff check c_lord/` + `ruff format --check` pass
- [x] Staging Evidence above is filled in
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメントも更新（コマンド sync は内部挙動・利用者向け変化は本文 before/after に記載）
- [x] `Refs #462` used（本番目視 AC 未達のため `Closes` ではなく `Refs`）