### PR TITLE
fix(claude_chat): セッション復元を可視化して「壊れて見える」を解消 (#464 ②-1)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -1289,6 +1289,17 @@ class ClaudeChatCog(commands.Cog):
                     pane_alive = await asyncio.to_thread(tmux_manager.is_claude_running, thread.id)
                     try_continue = not pane_alive
 
+            # #464 ②: the dead pane is about to be auto-resumed via --continue.
+            # Announce it first, otherwise the resumed turn re-emits the prior
+            # turn's output and reads as the bot replaying garbage / being broken
+            # (exactly what the 2026-06-25 tmux-server-death incident looked like
+            # to the user). A visible notice makes the recovery legible.
+            if try_continue:
+                with contextlib.suppress(discord.HTTPException):
+                    await thread.send(
+                        "🔄 前回のセッションが落ちていたので、これまでの会話を復元して続けます。"
+                    )
+
             # Run as its own task so the per-thread lock is NOT held for the
             # (possibly long, possibly menu-parked) duration of the turn — that
             # held-across-run lock was the #315 deadlock.  Registering the task

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -208,6 +208,12 @@ Send follow-up messages → Claude continues in same session
 Bot restart → tmux session keeps running; observers re-attach and a quiet
               "C-lord を再起動しました" notice is posted. Claude is NOT
               re-prompted (#406) — send a new message to continue.
+    ↓
+tmux session gone (killed together with the bot / tmux-server death):
+              the next message recreates the window and resumes the prior
+              conversation from the on-disk transcript (claude --continue),
+              announced with "🔄 …会話を復元して続けます" so the replayed
+              context reads as a restore, not a broken bot (#464).
 ```
 
 ### What Happens Under the Hood

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -919,6 +919,40 @@ class TestResumeAfterPaneDeath:
         assert kwargs.get("try_continue") is True
 
     @pytest.mark.asyncio
+    async def test_recovery_is_announced_to_user(self) -> None:
+        """#464 ②: when the dead pane is auto-resumed, tell the user.
+
+        During the 2026-06-25 incident the tmux server was gone and the reply
+        path silently re-emitted the prior turn's output via ``--continue``,
+        which looked like the bot was broken / replaying garbage.  A visible
+        notice makes the recovery legible instead of confusing.
+        """
+        cog = self._cog_with_pane(running=False)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        cog.repo.get = AsyncMock(return_value=record)
+        msg = self._make_thread_message()
+
+        await cog._handle_thread_reply(msg)
+
+        sent = [c.args[0] for c in msg.channel.send.call_args_list if c.args]
+        assert any("復元" in s for s in sent), f"no recovery notice sent; got {sent}"
+
+    @pytest.mark.asyncio
+    async def test_no_recovery_notice_when_pane_alive(self) -> None:
+        """Pane alive → normal live continuation; must NOT post a recovery notice."""
+        cog = self._cog_with_pane(running=True)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        cog.repo.get = AsyncMock(return_value=record)
+        msg = self._make_thread_message()
+
+        await cog._handle_thread_reply(msg)
+
+        sent = [c.args[0] for c in msg.channel.send.call_args_list if c.args]
+        assert not any("復元" in s for s in sent), f"unexpected recovery notice: {sent}"
+
+    @pytest.mark.asyncio
     async def test_no_continue_when_session_cleared(self) -> None:
         """/clear invariant (#123 Part 1): session was reset → stay fresh, never --continue."""
         cog = self._cog_with_pane(running=False)


### PR DESCRIPTION
## 概要（利用者目線・先頭）

スレッドで返信したとき、**前回の作業セッション(tmux)が落ちていた場合**でも、これまで c-lord は黙って `claude --continue` で会話を復元していました。その結果、復元時に再表示される過去の出力が「**壊れている／古い返事が再生された**」ように見えていました(2026-06-25 に tmux サーバーごと消えたインシデントで、ユーザーが実際にそう感じた)。

このPRで、復元が走るときに先に **「🔄 前回のセッションが落ちていたので、これまでの会話を復元して続けます。」** と表示し、**再開だと一目で分かる**ようにします。復元の仕組み自体は既存(#270)で、本PRは**その可視化のみ**を追加します。

Refs #464

> これは #464 ②(「消えても会話を自動で復活させる／『見つからない』で詰まらせない」)の **1/2**。②-2(`/resync` 等の行き止まり解消)は PR #470。`Closes` ではなく `Refs`。

## 変更点

- `c_lord/cogs/claude_chat.py::_handle_thread_reply` — `try_continue`(=死んだ pane を `--continue` で復元)が立ったとき、復元通知をスレッドへ post。送信失敗は `contextlib.suppress(discord.HTTPException)`(既存規約どおり)。
- `docs/USER_GUIDE.md` — 「あるべき動き」を更新(tmux セッション消失時に次メッセージで window を作り直し `--continue` で復元、通知を出す旨)。
- `tests/test_claude_chat.py` — RED→GREEN テスト2件。

## TDD evidence (RED → GREEN)

- **RED**(実装前): `tests/test_claude_chat.py::TestResumeAfterPaneDeath::test_recovery_is_announced_to_user`
  → `AssertionError: no recovery notice sent; got []`
- **GREEN**(実装後): 当該クラス 5 passed。負例 `test_no_recovery_notice_when_pane_alive`(pane 生存時は通知しない)も green。

## Staging Evidence

- **環境**: staging-3 (`c-lord-staging-3`)、検証ブランチ `verify/464-both`(= `main` + #465 + #470)。
- **手順(GREEN)**: E2E スレッドの tmux window (`w1`) を `tmux kill-window` で落として **dead pane** にした状態で、信頼bot経由でスレッドにメッセージ「続きお願い」を投稿。
- **結果(GREEN)**: bot が `try_continue`(dead pane)を検知し、**「🔄 前回のセッションが落ちていたので、これまでの会話を復元して続けます。」** を post → その後 `⏺ Session running (w1)` で復元・再開。ログ: `run_claude: enter` → `start_claude ... --continue`。

![pr465-green-recovery-notice](https://github.com/yousan/c-lord/releases/download/evidence/i464-pr465-green-recovery-notice-20260709T010333Z.png)

- **RED(対比)**: 同じトリガを `main`(修正前)で実行すると、ログ上は同じく復元は走るが **🔄 通知は一切出ない**(黙って復元 → 過去出力の再表示が「壊れて見える」)。RED ユニットテスト `test_recovery_is_announced_to_user`(実装前に失敗)が示す挙動と同じ。
- 補足: staging の E2E トリガは webhook 未設定(`PENDING`)のため信頼bot経由(prod token 投稿)を使用。証跡 PNG は `evidence` prerelease にアップロード(git には commit していない)。

## Definition of Done checklist

- [x] Refs #464(本PRは ② の 1/2。`Closes` は使わない)
- [x] TDD: RED 失敗行を掲示 → GREEN
- [x] `pytest` 全緑(**2013 passed, 3 skipped**) / `ruff check` / `ruff format --check` / `pyright`(0 errors)
- [x] 動きを変えた → `docs/USER_GUIDE.md` を同PRで更新
- [x] 無関係な変更なし(diff は claude_chat.py / test / USER_GUIDE.md のみ)
- [x] Staging behavior verified(上記 Staging Evidence・実画面スクショ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)