### PR TITLE
security: 選択肢ボタンを allowlist で認可（誰でも押せる問題を修正） (#466)

### DIFF
--- a/c_lord/bot.py
+++ b/c_lord/bot.py
@@ -16,6 +16,7 @@ from .concurrency import SessionRegistry
 from .coordination.service import CoordinationService
 from .discord_ui.ask_bus import ask_bus
 from .discord_ui.ask_view import AskView
+from .discord_ui.authorization import Authorizer
 from .discord_ui.permission_help import command_error_help
 
 if TYPE_CHECKING:
@@ -74,6 +75,11 @@ class ClaudeDiscordBot(commands.Bot):
         # kills the process on mismatch (guards against booting with an
         # inherited production token — the #322 env-contamination class).
         self.expected_bot_user_id: int | None = expected_bot_user_id
+        # #466: allowlist predicate, published by ClaudeChatCog on load.  Used
+        # here to re-arm restored persistent AskViews and by AutoUpgradeCog so
+        # button clicks enforce the same allowlist as messages.  None until a
+        # cog sets it (⇒ no allowlist ⇒ everyone may click — zero-config).
+        self.authorizer: Authorizer | None = None
 
     async def process_commands(self, message: discord.Message, /) -> None:
         """Override to allow webhook messages to trigger text commands.
@@ -363,6 +369,7 @@ class ClaudeDiscordBot(commands.Bot):
                     q_idx=q_idx,
                     bus=ask_bus,
                     ask_repo=self.ask_repo,
+                    authorizer=self.authorizer,
                 )
                 self.add_view(view)
                 logger.debug(

--- a/c_lord/cogs/_run_helper.py
+++ b/c_lord/cogs/_run_helper.py
@@ -442,6 +442,7 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
             pending_pane_ask,
             runner,
             ask_repo=config.ask_repo,
+            authorizer=config.authorizer,
         )
     elif not run_errored and not processor.pending_ask and skills_enabled():
         # Issue #67: surface a fallback notice when the skill-reply path was
@@ -471,6 +472,7 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
             processor.pending_ask,
             processor.session_id,
             ask_repo=config.ask_repo,
+            authorizer=config.authorizer,
         )
         if answer_prompt:
             logger.info(

--- a/c_lord/cogs/auto_upgrade.py
+++ b/c_lord/cogs/auto_upgrade.py
@@ -22,6 +22,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from ..discord_ui.authorization import AuthorizedViewMixin, Authorizer
 from ..protocols import DrainAware
 from ..thread_settings import resolve_auto_archive_duration
 
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 _STEP_TIMEOUT = 120
 
 
-class UpgradeApprovalView(discord.ui.View):
+class UpgradeApprovalView(AuthorizedViewMixin, discord.ui.View):
     """A Discord View with a single approval button for upgrade/restart gates.
 
     Posts to the parent channel (not the upgrade thread) so users can approve
@@ -56,10 +57,12 @@ class UpgradeApprovalView(discord.ui.View):
         approved_event: asyncio.Event,
         bot_id: int | None = None,
         label: str = "✅ Approve",
+        authorizer: Authorizer | None = None,
     ) -> None:
         super().__init__(timeout=None)
         self._event = approved_event
         self._bot_id = bot_id
+        self._authorizer = authorizer
         # Override the default label set by the decorator
         for child in self.children:
             if isinstance(child, discord.ui.Button):
@@ -458,7 +461,11 @@ class AutoUpgradeCog(commands.Cog):
         parent = getattr(thread, "parent", None)
         if parent is not None:
             bot_id = self.bot.user.id if self.bot.user else None
-            view = UpgradeApprovalView(approved_event=approved, bot_id=bot_id)
+            view = UpgradeApprovalView(
+                approved_event=approved,
+                bot_id=bot_id,
+                authorizer=getattr(self.bot, "authorizer", None),
+            )
             try:
                 channel_msg = await parent.send(
                     f"🔔 **Approval needed** — {text}\n"

--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -33,6 +33,7 @@ from ..database.repository import SessionRepository
 from ..database.resume_repo import PendingResumeRepository
 from ..database.settings_repo import SettingsRepository
 from ..discord_ref import enrich_discord_references
+from ..discord_ui.authorization import Authorizer
 from ..discord_ui.embeds import stopped_embed
 from ..discord_ui.permission_help import ThreadCreateForbiddenError, create_thread_permission_help
 from ..discord_ui.status import StatusManager
@@ -117,6 +118,13 @@ class ClaudeChatCog(commands.Cog):
         self._thread_retitle = thread_retitle_enabled(thread_retitle)
         self._allowed_user_ids = allowed_user_ids
         self._allowed_role_name = allowed_role_name
+        # #466: one allowlist predicate shared by message gating (_is_allowed)
+        # and button gating (View.interaction_check). Published on the bot so
+        # cross-cog Views (AutoUpgrade) and the persistent-view restore path
+        # (bot.py) enforce the same allowlist without extra wiring.
+        self._authorizer = Authorizer(allowed_user_ids, allowed_role_name)
+        if getattr(bot, "authorizer", None) is None:
+            bot.authorizer = self._authorizer
         self._registry = registry or getattr(bot, "session_registry", None)
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._active_runners: dict[int, TmuxClaudeRunner] = {}
@@ -158,14 +166,11 @@ class ClaudeChatCog(commands.Cog):
 
         OR logic: allowed_user_ids match OR allowed_role_name match.
         When neither is configured, everyone is allowed.
+
+        Delegates to :class:`Authorizer` so message gating and button gating
+        (View.interaction_check, #466) apply the exact same rule.
         """
-        if self._allowed_user_ids is not None and member.id in self._allowed_user_ids:
-            return True
-        if self._allowed_role_name is not None:
-            if isinstance(member, discord.Member):
-                return any(r.name == self._allowed_role_name for r in member.roles)
-            return False  # DM — no role info
-        return self._allowed_user_ids is None
+        return self._authorizer.is_allowed(member)
 
     def _is_message_authorized(self, message: discord.Message) -> bool:
         """Whether *message* is allowed to drive Claude.
@@ -1568,7 +1573,7 @@ class ClaudeChatCog(commands.Cog):
             with contextlib.suppress(Exception):
                 await self.repo.update_trigger_message(thread.id, user_message.id)
 
-            stop_view = StopView(runner)
+            stop_view = StopView(runner, authorizer=self._authorizer)
             if window_name:
                 stop_msg = await thread.send(
                     f"-# ⏺ Session running (`{window_name}`)",
@@ -1596,6 +1601,7 @@ class ClaudeChatCog(commands.Cog):
                         tmux_manager=tmux_manager,
                         image_paths=image_paths,
                         working_dir=working_dir or None,
+                        authorizer=self._authorizer,
                     )
                 )
             finally:

--- a/c_lord/cogs/event_processor.py
+++ b/c_lord/cogs/event_processor.py
@@ -343,7 +343,7 @@ class EventProcessor:
         # ExitPlanMode does not carry a request_id in the current CLI protocol;
         # we use the session_id as a stable identifier for the inject payload.
         request_id = self._state.session_id or "plan"
-        view = PlanApprovalView(self._config.runner, request_id)
+        view = PlanApprovalView(self._config.runner, request_id, authorizer=self._config.authorizer)
         with contextlib.suppress(Exception):
             await self._config.thread.send(embed=embed, view=view)
         logger.info("Plan approval prompt posted (session=%s)", request_id)
@@ -352,7 +352,9 @@ class EventProcessor:
         """Post permission embed with Allow/Deny buttons."""
         assert event.permission_request is not None
         embed = permission_embed(event.permission_request)
-        view = PermissionView(self._config.runner, event.permission_request)
+        view = PermissionView(
+            self._config.runner, event.permission_request, authorizer=self._config.authorizer
+        )
         with contextlib.suppress(Exception):
             await self._config.thread.send(embed=embed, view=view)
         logger.info(
@@ -381,6 +383,7 @@ class EventProcessor:
             event.pane_ask,
             runner,
             ask_repo=self._config.ask_repo,
+            authorizer=self._config.authorizer,
         )
         logger.info(
             "AskUserQuestion bridged and answered for thread %d",
@@ -393,9 +396,9 @@ class EventProcessor:
         req = event.elicitation
         embed = elicitation_embed(req)
         if req.mode == "url-mode":
-            view = ElicitationUrlView(self._config.runner, req)
+            view = ElicitationUrlView(self._config.runner, req, authorizer=self._config.authorizer)
         else:
-            view = ElicitationFormView(self._config.runner, req)
+            view = ElicitationFormView(self._config.runner, req, authorizer=self._config.authorizer)
         with contextlib.suppress(Exception):
             await self._config.thread.send(embed=embed, view=view)
         logger.info(

--- a/c_lord/cogs/run_config.py
+++ b/c_lord/cogs/run_config.py
@@ -19,6 +19,7 @@ from ..database.ask_repo import PendingAskRepository
 from ..database.lounge_repo import LoungeRepository
 from ..database.repository import SessionRepository
 from ..database.settings_repo import SettingsRepository
+from ..discord_ui.authorization import Authorizer
 from ..discord_ui.status import StatusManager
 
 if TYPE_CHECKING:
@@ -82,6 +83,10 @@ class RunConfig:
     # sessions DB so TranscriptMirrorCog can restart mirrors after a bot
     # restart (CLORD_BRIDGE_MODE=jsonl). None when no session_dir_manager.
     working_dir: str | None = None
+    # #466: allowlist predicate forwarded to interactive Views so button
+    # clicks (permission / plan / elicitation / ask) are gated to the same
+    # allowed users as messages. None ⇒ no allowlist ⇒ everyone may click.
+    authorizer: Authorizer | None = None
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/c_lord/discord_ui/ask_handler.py
+++ b/c_lord/discord_ui/ask_handler.py
@@ -25,6 +25,7 @@ from ..claude.types import AskQuestion
 from ..database.ask_repo import PendingAskRepository
 from .ask_bus import ask_bus as _ask_bus
 from .ask_view import AskView
+from .authorization import Authorizer
 from .bridged_context import bridged_context as _bridged_context
 from .embeds import ask_embed
 
@@ -75,6 +76,7 @@ async def bridge_pane_ask(
     question: AskQuestion,
     runner: TmuxClaudeRunner,
     ask_repo: PendingAskRepository | None = None,
+    authorizer: Authorizer | None = None,
 ) -> None:
     """Bridge one in-pane AskUserQuestion menu to Discord buttons (#166).
 
@@ -119,7 +121,7 @@ async def bridge_pane_ask(
             if not truncated:
                 _bridged_context.register(thread.id, question.context, source="pane")
 
-    view = AskView(question, thread_id=thread.id, q_idx=0, ask_repo=ask_repo)
+    view = AskView(question, thread_id=thread.id, q_idx=0, ask_repo=ask_repo, authorizer=authorizer)
     msg = await thread.send(
         embed=ask_embed(
             question.question, question.header, question.options, question.multi_select
@@ -208,6 +210,7 @@ async def collect_ask_answers(
     questions: list[AskQuestion],
     session_id: str,
     ask_repo: PendingAskRepository | None = None,
+    authorizer: Authorizer | None = None,
 ) -> str | None:
     """Show Discord UI for each question and return the formatted answer string.
 
@@ -246,7 +249,9 @@ async def collect_ask_answers(
         # race between the user clicking and the queue being registered.
         answer_queue = _ask_bus.register(thread.id)
 
-        view = AskView(q, thread_id=thread.id, q_idx=q_idx, ask_repo=ask_repo)
+        view = AskView(
+            q, thread_id=thread.id, q_idx=q_idx, ask_repo=ask_repo, authorizer=authorizer
+        )
         msg = await thread.send(
             embed=ask_embed(q.question, q.header, q.options, q.multi_select), view=view
         )

--- a/c_lord/discord_ui/ask_view.py
+++ b/c_lord/discord_ui/ask_view.py
@@ -29,6 +29,7 @@ import discord
 
 from .ask_bus import AskAnswerBus
 from .ask_bus import ask_bus as _default_ask_bus
+from .authorization import AuthorizedViewMixin, Authorizer
 from .error_reporting import ErrorReportingViewMixin
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ _RESTART_MSG = (
 )
 
 
-class AskView(ErrorReportingViewMixin, discord.ui.View):
+class AskView(AuthorizedViewMixin, ErrorReportingViewMixin, discord.ui.View):
     """Renders buttons or a select menu for a single AskUserQuestion prompt.
 
     This is a **persistent** view — ``timeout=None``.  Register it with the
@@ -69,8 +70,10 @@ class AskView(ErrorReportingViewMixin, discord.ui.View):
         q_idx: int,
         bus: AskAnswerBus | None = None,
         ask_repo: PendingAskRepository | None = None,
+        authorizer: Authorizer | None = None,
     ) -> None:
         super().__init__(timeout=None)  # persistent — survives bot restarts
+        self._authorizer = authorizer
         self._thread_id = thread_id
         self._bus = bus if bus is not None else _default_ask_bus
         self._ask_repo = ask_repo

--- a/c_lord/discord_ui/authorization.py
+++ b/c_lord/discord_ui/authorization.py
@@ -1,0 +1,97 @@
+"""Button-level authorization for Discord UI Views (#466).
+
+c-lord restricts who may *drive* a session — ``on_message`` and slash commands
+go through ``ClaudeChatCog._is_allowed`` (``allowed_user_ids`` /
+``allowed_role_name``).  Interactive buttons, however, run their callback for
+anyone who can click them: ``discord.ui.View.interaction_check`` returns ``True``
+by default.  Because c-lord threads are *public*, any server member who can see
+the channel could Approve a plan, Allow a tool permission, or Stop a session —
+bypassing the allowlist entirely.
+
+This module supplies:
+
+* :class:`Authorizer` — the allowlist predicate, extracted from
+  ``ClaudeChatCog._is_allowed`` so the same rule applies to messages and
+  buttons (DRY).
+* :class:`AuthorizedViewMixin` — an ``interaction_check`` that consults the
+  View's ``_authorizer``.  When no authorizer is set (zero-config / no
+  allowlist) it allows everyone, preserving backward-compatible behavior.
+
+Usage: list the mixin *before* ``discord.ui.View`` in the bases and store the
+authorizer on ``self._authorizer`` in ``__init__``::
+
+    class PlanApprovalView(AuthorizedViewMixin, ErrorReportingViewMixin, discord.ui.View):
+        def __init__(self, runner, request_id, authorizer=None):
+            super().__init__(...)
+            self._authorizer = authorizer
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+import discord
+
+logger = logging.getLogger(__name__)
+
+# Shown (ephemeral) to a user who clicks a button they are not allowed to use.
+UNAUTHORIZED_MESSAGE = "⛔ あなたはこの bot を操作する権限がありません。"
+
+
+class Authorizer:
+    """Decides whether a user may interact with the bot.
+
+    Mirrors ``ClaudeChatCog._is_allowed`` exactly so message-trigger gating and
+    button gating share one rule:
+
+    * ``allowed_user_ids`` matches → allowed.
+    * else if ``allowed_role_name`` is configured → allowed iff the member has
+      that role (a plain :class:`discord.User`, e.g. a DM, never matches).
+    * else (no role configured) → allowed iff ``allowed_user_ids`` is ``None``
+      (i.e. no allowlist at all means everyone is allowed — zero-config).
+    """
+
+    def __init__(
+        self,
+        allowed_user_ids: set[int] | None = None,
+        allowed_role_name: str | None = None,
+    ) -> None:
+        self.allowed_user_ids = allowed_user_ids
+        self.allowed_role_name = allowed_role_name
+
+    def is_allowed(self, user: discord.Member | discord.User) -> bool:
+        if self.allowed_user_ids is not None and user.id in self.allowed_user_ids:
+            return True
+        if self.allowed_role_name is not None:
+            if isinstance(user, discord.Member):
+                return any(r.name == self.allowed_role_name for r in user.roles)
+            return False  # DM — no role info
+        return self.allowed_user_ids is None
+
+
+class AuthorizedViewMixin:
+    """Mixin adding allowlist enforcement to a ``discord.ui.View``.
+
+    Reads ``self._authorizer`` (an :class:`Authorizer` or ``None``).  When it is
+    ``None`` every interaction is allowed — this keeps the zero-config default
+    (no allowlist configured ⇒ everyone may click) and makes the mixin safe to
+    add to a View whose construction site has not yet been wired.
+    """
+
+    # Class-level default so a View that forgets to set it still behaves
+    # (allow-all) rather than raising AttributeError.
+    _authorizer: Authorizer | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        authorizer = getattr(self, "_authorizer", None)
+        if authorizer is None or authorizer.is_allowed(interaction.user):
+            return True
+        logger.info(
+            "Rejected unauthorized button interaction from user %s on %s",
+            getattr(interaction.user, "id", "?"),
+            type(self).__name__,
+        )
+        with contextlib.suppress(discord.HTTPException):
+            await interaction.response.send_message(UNAUTHORIZED_MESSAGE, ephemeral=True)
+        return False

--- a/c_lord/discord_ui/elicitation_view.py
+++ b/c_lord/discord_ui/elicitation_view.py
@@ -18,6 +18,7 @@ from typing import Any
 import discord
 
 from ..claude.types import ElicitationRequest
+from .authorization import AuthorizedViewMixin, Authorizer
 from .error_reporting import ErrorReportingViewMixin
 
 logger = logging.getLogger(__name__)
@@ -25,13 +26,16 @@ logger = logging.getLogger(__name__)
 ELICITATION_TIMEOUT = 300  # 5 minutes
 
 
-class ElicitationUrlView(ErrorReportingViewMixin, discord.ui.View):
+class ElicitationUrlView(AuthorizedViewMixin, ErrorReportingViewMixin, discord.ui.View):
     """Single button opening a URL for url-mode elicitation."""
 
-    def __init__(self, runner, request: ElicitationRequest) -> None:
+    def __init__(
+        self, runner, request: ElicitationRequest, authorizer: Authorizer | None = None
+    ) -> None:
         super().__init__(timeout=ELICITATION_TIMEOUT)
         self._runner = runner
         self._request = request
+        self._authorizer = authorizer
         # Add the URL as a link button (no callback needed — Discord opens it).
         if request.url:
             self.add_item(discord.ui.Button(label="🔗 Open link", url=request.url))
@@ -130,13 +134,16 @@ class ElicitationFormModal(discord.ui.Modal):
         )
 
 
-class ElicitationFormView(ErrorReportingViewMixin, discord.ui.View):
+class ElicitationFormView(AuthorizedViewMixin, ErrorReportingViewMixin, discord.ui.View):
     """Single button that opens the form Modal for form-mode elicitation."""
 
-    def __init__(self, runner, request: ElicitationRequest) -> None:
+    def __init__(
+        self, runner, request: ElicitationRequest, authorizer: Authorizer | None = None
+    ) -> None:
         super().__init__(timeout=ELICITATION_TIMEOUT)
         self._runner = runner
         self._request = request
+        self._authorizer = authorizer
 
     @discord.ui.button(label="📝 Fill in form", style=discord.ButtonStyle.primary)
     async def open_form(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:

--- a/c_lord/discord_ui/permission_view.py
+++ b/c_lord/discord_ui/permission_view.py
@@ -12,6 +12,7 @@ import logging
 import discord
 
 from ..claude.types import PermissionRequest
+from .authorization import AuthorizedViewMixin, Authorizer
 from .error_reporting import ErrorReportingViewMixin
 
 logger = logging.getLogger(__name__)
@@ -19,13 +20,16 @@ logger = logging.getLogger(__name__)
 PERMISSION_TIMEOUT = 120  # 2 minutes to approve/deny
 
 
-class PermissionView(ErrorReportingViewMixin, discord.ui.View):
+class PermissionView(AuthorizedViewMixin, ErrorReportingViewMixin, discord.ui.View):
     """Allow / Deny buttons for tool permission requests."""
 
-    def __init__(self, runner, request: PermissionRequest) -> None:
+    def __init__(
+        self, runner, request: PermissionRequest, authorizer: Authorizer | None = None
+    ) -> None:
         super().__init__(timeout=PERMISSION_TIMEOUT)
         self._runner = runner
         self._request = request
+        self._authorizer = authorizer
 
     @discord.ui.button(label="✅ Allow", style=discord.ButtonStyle.success)
     async def allow(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:

--- a/c_lord/discord_ui/plan_view.py
+++ b/c_lord/discord_ui/plan_view.py
@@ -11,6 +11,7 @@ import logging
 
 import discord
 
+from .authorization import AuthorizedViewMixin, Authorizer
 from .error_reporting import ErrorReportingViewMixin
 
 logger = logging.getLogger(__name__)
@@ -19,13 +20,14 @@ logger = logging.getLogger(__name__)
 PLAN_APPROVAL_TIMEOUT = 300
 
 
-class PlanApprovalView(ErrorReportingViewMixin, discord.ui.View):
+class PlanApprovalView(AuthorizedViewMixin, ErrorReportingViewMixin, discord.ui.View):
     """Two-button view: ✅ Approve | ❌ Cancel for plan mode."""
 
-    def __init__(self, runner, request_id: str) -> None:
+    def __init__(self, runner, request_id: str, authorizer: Authorizer | None = None) -> None:
         super().__init__(timeout=PLAN_APPROVAL_TIMEOUT)
         self._runner = runner
         self._request_id = request_id
+        self._authorizer = authorizer
 
     @discord.ui.button(label="✅ Approve", style=discord.ButtonStyle.success)
     async def approve(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:

--- a/c_lord/discord_ui/views.py
+++ b/c_lord/discord_ui/views.py
@@ -8,6 +8,7 @@ from typing import Protocol, runtime_checkable
 
 import discord
 
+from .authorization import AuthorizedViewMixin, Authorizer
 from .embeds import stopped_embed
 from .error_reporting import ErrorReportingViewMixin
 
@@ -22,7 +23,7 @@ class Interruptable(Protocol):
     async def interrupt(self) -> None: ...
 
 
-class StopView(ErrorReportingViewMixin, discord.ui.View):
+class StopView(AuthorizedViewMixin, ErrorReportingViewMixin, discord.ui.View):
     """A ⏹ Stop button attached to the session status message.
 
     Clicking it sends SIGINT to the active Claude runner (graceful interrupt,
@@ -35,9 +36,10 @@ class StopView(ErrorReportingViewMixin, discord.ui.View):
     button at the bottom of the thread (most recently visible position).
     """
 
-    def __init__(self, runner: Interruptable) -> None:
+    def __init__(self, runner: Interruptable, authorizer: Authorizer | None = None) -> None:
         super().__init__(timeout=None)
         self._runner = runner
+        self._authorizer = authorizer
         self._stopped = False
         self._message: discord.Message | None = None
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -13,6 +13,7 @@ The bridge's security goal is:
 | Threat | Mitigation |
 |--------|-----------|
 | Unauthorized users invoking Claude | `allowed_user_ids` allowlist in `ClaudeChatCog` and `SkillCommandCog` |
+| Unauthorized users clicking decision buttons (Allow/Approve/Stop) | Same allowlist enforced in every View via `AuthorizedViewMixin.interaction_check` (#466) |
 | Shell injection via user prompts | `create_subprocess_exec` (no shell), `--` separator before prompt arg |
 | Flag injection via prompts | `--` separator prevents `-p`, `--resume` etc. in prompt text |
 | Session hijacking via crafted IDs | Strict regex validation: `^[a-f0-9\-]+$` |
@@ -143,6 +144,26 @@ class ClaudeChatCog(commands.Cog):
 - When `allowed_user_ids` is set: only listed Discord user IDs can invoke Claude
 - When `allowed_user_ids` is `None`: all users in the channel can invoke Claude (for trusted private servers)
 - The same check applies to `SkillCommandCog`
+
+#### Interactive buttons enforce the same allowlist (#466)
+
+The allowlist gates not only *messages* but every interactive button c-lord
+posts — tool-permission **Allow/Deny**, plan **Approve/Cancel**, MCP
+elicitation, AskUserQuestion choices, the **Stop** button, and the
+auto-upgrade **Approve** button. Because c-lord threads are *public*, any
+server member who can see the channel could otherwise click these and decide
+on the session owner's behalf (e.g. approve a tool permission → let Claude run
+something).
+
+Each `discord.ui.View` mixes in `AuthorizedViewMixin`
+(`c_lord/discord_ui/authorization.py`), whose `interaction_check` consults the
+same `Authorizer` (built from `allowed_user_ids` / `allowed_role_name`). A
+non-allowlisted click runs no callback and gets an ephemeral "権限がありません"
+notice. When no allowlist is configured, everyone may click (zero-config —
+unchanged). The allowlist is built once in `ClaudeChatCog` and shared with the
+in-session Views (via `RunConfig`), the persistent-view restore path
+(`bot.py`), and `AutoUpgradeCog` — so configuring the allowlist alone protects
+every button, no extra wiring.
 
 ### Channel-Level Authorization
 

--- a/tests/test_button_authorization.py
+++ b/tests/test_button_authorization.py
@@ -1,0 +1,203 @@
+"""Tests for button-level authorization (#466).
+
+Discord ``discord.ui.View`` buttons run their callback for *anyone* who can
+click them unless ``interaction_check`` is overridden.  c-lord restricts
+messages / slash commands to an allowlist (``allowed_user_ids`` /
+``allowed_role_name``) but historically left every interactive View wide open,
+so a non-allowlisted user in a public thread could Approve / Allow / Stop.
+
+These tests pin down:
+
+* ``Authorizer.is_allowed`` — the extracted allowlist predicate (same
+  semantics as ``ClaudeChatCog._is_allowed``).
+* ``AuthorizedViewMixin.interaction_check`` — allow when no authorizer
+  (zero-config), allow allowlisted users, reject others with an ephemeral
+  notice.
+* Every real interactive View enforces the authorizer it is given.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from c_lord.claude.types import AskOption, AskQuestion
+from c_lord.cogs.auto_upgrade import UpgradeApprovalView
+from c_lord.discord_ui.ask_view import AskView
+from c_lord.discord_ui.authorization import AuthorizedViewMixin, Authorizer
+from c_lord.discord_ui.elicitation_view import ElicitationFormView, ElicitationUrlView
+from c_lord.discord_ui.permission_view import PermissionView
+from c_lord.discord_ui.plan_view import PlanApprovalView
+from c_lord.discord_ui.views import StopView
+
+# ---------------------------------------------------------------------------
+# Mock helpers (mirror tests/test_role_access.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_member(user_id: int = 1, role_names: list[str] | None = None) -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = user_id
+    roles: list[MagicMock] = []
+    for name in role_names or []:
+        role = MagicMock(spec=discord.Role)
+        role.name = name
+        roles.append(role)
+    everyone = MagicMock(spec=discord.Role)
+    everyone.name = "@everyone"
+    roles.insert(0, everyone)
+    member.roles = roles
+    return member
+
+
+def _make_user(user_id: int = 1) -> MagicMock:
+    user = MagicMock(spec=discord.User)
+    user.id = user_id
+    return user
+
+
+def _make_interaction(user: MagicMock) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = user
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Authorizer.is_allowed — same semantics as ClaudeChatCog._is_allowed
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizer:
+    def test_no_allowlist_allows_everyone(self) -> None:
+        auth = Authorizer(allowed_user_ids=None, allowed_role_name=None)
+        assert auth.is_allowed(_make_member(user_id=123)) is True
+
+    def test_allowed_by_user_id(self) -> None:
+        auth = Authorizer(allowed_user_ids={42})
+        assert auth.is_allowed(_make_member(user_id=42)) is True
+
+    def test_denied_by_user_id(self) -> None:
+        auth = Authorizer(allowed_user_ids={42})
+        assert auth.is_allowed(_make_member(user_id=99)) is False
+
+    def test_allowed_by_role(self) -> None:
+        auth = Authorizer(allowed_role_name="claude-operator")
+        member = _make_member(user_id=99, role_names=["claude-operator"])
+        assert auth.is_allowed(member) is True
+
+    def test_denied_without_role(self) -> None:
+        auth = Authorizer(allowed_role_name="claude-operator")
+        member = _make_member(user_id=99, role_names=["other"])
+        assert auth.is_allowed(member) is False
+
+    def test_role_check_rejects_plain_user(self) -> None:
+        # A discord.User (DM, no roles) can never satisfy a role requirement.
+        auth = Authorizer(allowed_role_name="claude-operator")
+        assert auth.is_allowed(_make_user(user_id=99)) is False
+
+    def test_user_id_or_role_is_or_logic(self) -> None:
+        auth = Authorizer(allowed_user_ids={42}, allowed_role_name="ops")
+        # matches by id, lacks role
+        assert auth.is_allowed(_make_member(user_id=42, role_names=["x"])) is True
+        # matches by role, wrong id
+        assert auth.is_allowed(_make_member(user_id=7, role_names=["ops"])) is True
+
+
+# ---------------------------------------------------------------------------
+# AuthorizedViewMixin.interaction_check
+# ---------------------------------------------------------------------------
+
+
+class _DummyView(AuthorizedViewMixin, discord.ui.View):
+    def __init__(self, authorizer: Authorizer | None) -> None:
+        super().__init__(timeout=None)
+        self._authorizer = authorizer
+
+
+class TestInteractionCheck:
+    async def test_none_authorizer_allows_everyone(self) -> None:
+        view = _DummyView(authorizer=None)
+        interaction = _make_interaction(_make_member(user_id=123))
+        assert await view.interaction_check(interaction) is True
+        interaction.response.send_message.assert_not_called()
+
+    async def test_allowlisted_user_passes(self) -> None:
+        view = _DummyView(authorizer=Authorizer(allowed_user_ids={42}))
+        interaction = _make_interaction(_make_member(user_id=42))
+        assert await view.interaction_check(interaction) is True
+        interaction.response.send_message.assert_not_called()
+
+    async def test_outsider_rejected_with_ephemeral(self) -> None:
+        view = _DummyView(authorizer=Authorizer(allowed_user_ids={42}))
+        interaction = _make_interaction(_make_member(user_id=99))
+        assert await view.interaction_check(interaction) is False
+        interaction.response.send_message.assert_called_once()
+        # The rejection notice must be ephemeral (only the clicker sees it).
+        _, kwargs = interaction.response.send_message.call_args
+        assert kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# Every interactive View enforces its authorizer (#466 — no View left open)
+# ---------------------------------------------------------------------------
+
+
+def _build_view(cls_name: str, authorizer: Authorizer | None):
+    runner = MagicMock()
+    if cls_name == "PermissionView":
+        return PermissionView(runner, MagicMock(), authorizer=authorizer)
+    if cls_name == "PlanApprovalView":
+        return PlanApprovalView(runner, "req-1", authorizer=authorizer)
+    if cls_name == "ElicitationUrlView":
+        req = MagicMock()
+        req.url = None  # skip the link-button branch
+        return ElicitationUrlView(runner, req, authorizer=authorizer)
+    if cls_name == "ElicitationFormView":
+        return ElicitationFormView(runner, MagicMock(), authorizer=authorizer)
+    if cls_name == "StopView":
+        return StopView(runner, authorizer=authorizer)
+    if cls_name == "AskView":
+        question = AskQuestion(
+            question="pick one",
+            options=[AskOption("A"), AskOption("B")],
+        )
+        return AskView(question, thread_id=1, q_idx=0, authorizer=authorizer)
+    if cls_name == "UpgradeApprovalView":
+        return UpgradeApprovalView(
+            approved_event=asyncio.Event(), bot_id=None, authorizer=authorizer
+        )
+    raise AssertionError(f"unknown view {cls_name}")
+
+
+ALL_VIEWS = [
+    "PermissionView",
+    "PlanApprovalView",
+    "ElicitationUrlView",
+    "ElicitationFormView",
+    "StopView",
+    "AskView",
+    "UpgradeApprovalView",
+]
+
+
+@pytest.mark.parametrize("cls_name", ALL_VIEWS)
+class TestEveryViewEnforcesAuthorizer:
+    async def test_outsider_rejected(self, cls_name: str) -> None:
+        view = _build_view(cls_name, Authorizer(allowed_user_ids={42}))
+        interaction = _make_interaction(_make_member(user_id=99))
+        assert await view.interaction_check(interaction) is False
+        interaction.response.send_message.assert_called_once()
+
+    async def test_allowlisted_user_passes(self, cls_name: str) -> None:
+        view = _build_view(cls_name, Authorizer(allowed_user_ids={42}))
+        interaction = _make_interaction(_make_member(user_id=42))
+        assert await view.interaction_check(interaction) is True
+
+    async def test_no_authorizer_allows_everyone(self, cls_name: str) -> None:
+        view = _build_view(cls_name, None)
+        interaction = _make_interaction(_make_member(user_id=99))
+        assert await view.interaction_check(interaction) is True


### PR DESCRIPTION
## What does this PR do?

Discord の選択肢ボタンに**認可（allowlist）を適用**する。これまで `discord.ui.View` の `interaction_check` をどの View も override しておらず（既定は常に `True`）、ボタンは「見える人なら誰でも押せる」状態だった。c-lord のスレッドは public_thread なので、allowlist 外の第三者でも Allow / Approve / Stop / 選択肢を押せて即座に効いていた（メッセージ・スラッシュコマンドには効いている認可がボタンだけ素通り）。

- `Authorizer`（`ClaudeChatCog._is_allowed` から切り出し）＋ `AuthorizedViewMixin`（`interaction_check`）を追加：allowlist 未設定→全員許可（zero-config）/ allowlist 内→許可 / allowlist 外→コールバック実行せず ephemeral で「権限がありません」
- `PermissionView` / `PlanApprovalView` / `Elicitation{Url,Form}View` / `StopView` / `AskView` / `UpgradeApprovalView` の**全 View** にミックスイン。`Authorizer` を `RunConfig`・ask_handler bridge・永続 View restore（`bot.py`）・`AutoUpgradeCog` 経由で配線
- `_is_allowed` は `Authorizer` に委譲（メッセージとボタンで同一ルール、DRY）。allowlist は bot に publish して cross-cog で共有

## Why?

allowlist（`DISCORD_OWNER_ID` / `CLORD_ALLOWED_ROLE`）で owner/role に絞って運用していても、第三者がツール実行許可の Allow や再起動の Approve を押せてしまい、Claude に任意操作をさせうる認可の抜けだった。特に `PermissionView` が高リスク。

Closes #466

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: allowlist 外の第三者が Discord の選択肢ボタン（許可/承認/Stop 等）を押せて即座に効く → allowlist 外が押しても本人だけに「⛔ あなたはこの bot を操作する権限がありません。」と出て**何も実行されない**（allowlist 未設定なら従来どおり全員 OK）

## Acceptance Criteria (copied from the issue)

- [x] `Authorizer.is_allowed()` を切り出し、`ClaudeChatCog._is_allowed` がそれに委譲する（DRY、挙動不変）
- [x] `AuthorizedViewMixin.interaction_check()`: authorizer=None → True（zero-config）/ allowlist 内 → True / allowlist 外 → False かつ ephemeral 通知、を単体テストで網羅
- [x] `PermissionView` / `PlanApprovalView` / `ElicitationUrlView` / `ElicitationFormView` / `StopView` / `AskView` / `UpgradeApprovalView` の**全 View** が authorizer を受け取り allowlist 外のクリックを拒否（全 View 網羅のパラメトライズドテスト）
- [x] 永続 View（AskView / UpgradeApprovalView）の再起動 restore 経路でも authorizer が再注入される（`bot.py` restore / `AutoUpgradeCog` に配線）
- [x] consumer 側のコード変更なしで有効（cog に allowlist を渡すだけ＝zero-config）。未設定時は全員許可のまま（後方互換）
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` green

## Staging Evidence (証跡)

**環境**: staging-2（`C-lord-staging-2`, branch を main↔fix で切替）。`DISCORD_OWNER_ID=1`（ダミー）を設定し、検証者 yousan（実 user id `499163459418587176`）を **allowlist 外**にした。セッション起動は trusted-bot 方式。検証後 `.env`/branch/lease は原状復帰済み（idle=main）。同じ「選択肢ボタン（AskUserQuestion）」を main と fix で yousan が1回ずつクリック。

### RED（修正前 = main）: allowlist 外でもボタンが効く

yousan（allowlist 外）が「りんご」を押す → **選択が成立し Claude が継続**（拒否なし）。

```
2026-06-29 14:50:29 [INFO] tmux_runner: Answering AskUserQuestion menu: option index=0 (thread=1514545583459926117)
2026-06-29 14:50:29 [INFO] event_processor: AskUserQuestion bridged and answered for thread 1514545583459926117
```

![RED: allowlist 外の click が main では通って「Selected: りんご」になる](https://github.com/yousan/c-lord/releases/download/evidence/i466-466-red-outsider-selected-on-main-20260629T060203Z-00.png)

### GREEN（修正後 = fix branch `aa28422`）: allowlist 外は拒否される

yousan（allowlist 外）が「ねこ」を押す → **ephemeral で拒否、ボタンは未選択のまま、Claude は回答待ち継続**。

```
2026-06-29 14:58:09 [INFO] c_lord.discord_ui.authorization: Rejected unauthorized button interaction from user 499163459418587176 on AskView
```
(REST 確認: AskView の3ボタンは click 後も all `enabled`／`content` 空 = 未選択)

本人に見える ephemeral（「⛔ あなたはこの bot を操作する権限がありません。」「これはあなただけに表示されています」）:

![GREEN: 修正後は allowlist 外に ephemeral 拒否が出て選択は通らない](https://github.com/yousan/c-lord/releases/download/evidence/i466-466-green-ephemeral-permission-denied-20260629T060203Z-01.png)

observer 視点（click 後もボタンが残り未選択 = 何も実行されていない）:

![GREEN observer: click 後もボタンが live のまま残る](https://github.com/yousan/c-lord/releases/download/evidence/i466-466-green-buttons-stay-unselected-20260629T060203Z-02.png)

<details>
<summary>単体 RED→GREEN（mock）</summary>

```
RED:   bare discord.ui.View.interaction_check(outsider) -> True   (誰でも押せる)
GREEN: AuthorizedViewMixin.interaction_check(outsider) -> False   (拒否) + ephemeral

$ uv run pytest tests/test_button_authorization.py -q
31 passed
```
TDD: テストを先に書き、実装前は `ModuleNotFoundError: No module named 'c_lord.discord_ui.authorization'` で RED → 実装後 31 passed。フルスイート `2005 passed, 3 skipped`。
</details>

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/` passes（2005 passed, 3 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check`（変更ファイル）+ `pyright`（変更ファイル 0 errors）pass
- [x] Staging Evidence above is filled in（staging-2 で RED→GREEN を実機クリックで確認・スクショ主証跡）
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたので「あるべき動き」のドキュメント（`docs/SECURITY.md`）を更新した
- [x] `Closes #466`（全 AC 充足・DoD 全 box チェック済み）
