### PR TITLE
fix(ask): 長い前提つき選択肢で説明文が消える問題を一時リサイズで解消 (#468)

### DIFF
--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -1042,6 +1042,12 @@ class TmuxClaudeRunner:
                             )
                             if recovered is not None and recovered.context:
                                 ask_q = recovered
+                                logger.info(
+                                    "Recovered pre-menu context via tall capture "
+                                    "(thread=%d, context_chars=%d)",
+                                    self._thread_id,
+                                    len(recovered.context),
+                                )
                     logger.info(
                         "Interactive menu detected, bridging to Discord "
                         "(thread=%d, context_chars=%d)",

--- a/c_lord/claude/tmux_runner.py
+++ b/c_lord/claude/tmux_runner.py
@@ -1023,6 +1023,25 @@ class TmuxClaudeRunner:
                 ask_sig = "\n".join(o.label for o in ask_q.options)
                 if ask_stable >= _ASK_ALERT_DELAY and ask_sig != last_bridged_ask:
                     last_bridged_ask = ask_sig
+                    # #468: long pre-menu prose (経緯・推し) scrolls off the
+                    # alternate screen and is lost to the normal capture
+                    # (context_chars=0), so the question would reach Discord with
+                    # no decision context. Claude redraws its whole conversation
+                    # on SIGWINCH, so re-capture at a taller height to recover
+                    # the prose, then the window is restored. Only when context
+                    # is empty (the failing case) — avoids a resize round-trip on
+                    # every menu.
+                    if not ask_q.context and hasattr(self._tmux, "capture_pane_tall"):
+                        tall = await asyncio.to_thread(
+                            self._tmux.capture_pane_tall, self._thread_id
+                        )
+                        if isinstance(tall, str) and tall:
+                            norm_tall = _normalize_capture(tall)
+                            recovered = _parse_ask_from_pane(norm_tall) or _parse_plan_from_pane(
+                                norm_tall
+                            )
+                            if recovered is not None and recovered.context:
+                                ask_q = recovered
                     logger.info(
                         "Interactive menu detected, bridging to Discord "
                         "(thread=%d, context_chars=%d)",

--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -1181,6 +1181,107 @@ class TmuxSessionManager:
 
         return result.stdout
 
+    def capture_pane_tall(
+        self,
+        thread_id: int,
+        tall_rows: int = 240,
+        history_lines: int = 500,
+        settle_timeout: float = 3.0,
+        poll_interval: float = 0.25,
+    ) -> str:
+        """Capture the pane after transiently enlarging the window height (#468).
+
+        Claude Code runs as a full-screen TUI whose alternate screen keeps no
+        scrollback, so :meth:`capture_pane` only ever returns the *visible*
+        rows. When the prose above an AskUserQuestion menu is taller than the
+        window, its head scrolls off and is unrecoverable — and
+        ``_extract_pane_context`` then returns ``""`` (the pre-menu 経緯/推し is
+        lost, so the question reaches Discord with no decision context).
+
+        Claude redraws its whole conversation from memory on SIGWINCH, so
+        briefly growing the window reveals the scrolled-off prose. We grow, wait
+        for the redraw to settle, capture, then restore the original size
+        *exactly* (so an attached human's view is unchanged). Returns raw text
+        (``-e``) like :meth:`capture_pane`; callers normalize. Empty string on
+        failure / no window.
+        """
+        if not self._check_available():
+            return ""
+
+        window = self._find_window_for_thread(thread_id)
+        if window is None:
+            return ""
+
+        target = f"{self.session_name}:{window}"
+
+        size = _run(
+            ["tmux", "display-message", "-p", "-t", target, "#{window_width} #{window_height}"]
+        )
+        if size.returncode != 0:
+            # Can't read the current size → never risk leaving the window resized.
+            return self.capture_pane(thread_id, history_lines)
+        try:
+            width_s, height_s = size.stdout.split()
+            orig_width, orig_height = int(width_s), int(height_s)
+        except ValueError:
+            return self.capture_pane(thread_id, history_lines)
+
+        if orig_height >= tall_rows:
+            # Already tall enough — a resize round-trip would gain nothing.
+            return self.capture_pane(thread_id, history_lines)
+
+        def _resize(height: int) -> None:
+            _run(
+                [
+                    "tmux",
+                    "resize-window",
+                    "-t",
+                    target,
+                    "-x",
+                    str(orig_width),
+                    "-y",
+                    str(height),
+                ]
+            )
+
+        text = ""
+        try:
+            _resize(tall_rows)
+            # Poll until the redraw settles (two consecutive identical captures).
+            # The menu is idle-waiting for input, so there is no spinner to make
+            # the pane flap — once Claude has re-laid-out the conversation the
+            # capture stops changing. Bounded by ``settle_timeout`` so a slow or
+            # never-settling redraw degrades to a best-effort capture, never a
+            # hang. ``settle_timeout=0`` (tests) does exactly one capture.
+            attempts = max(1, int(settle_timeout / poll_interval))
+            prev: str | None = None
+            for i in range(attempts):
+                result = _run(
+                    [
+                        "tmux",
+                        "capture-pane",
+                        "-e",
+                        "-p",
+                        "-J",
+                        "-t",
+                        target,
+                        "-S",
+                        f"-{history_lines}",
+                    ]
+                )
+                cur = result.stdout if result.returncode == 0 else ""
+                if cur:
+                    text = cur
+                if cur and cur == prev:
+                    break
+                prev = cur
+                if i < attempts - 1:
+                    time.sleep(poll_interval)
+        finally:
+            _resize(orig_height)
+
+        return text
+
     def capture_screen(self, thread_id: int) -> str:
         """Capture the *visible* pane as ANSI text for a screenshot (#285).
 

--- a/docs/askuserquestion-bridge.md
+++ b/docs/askuserquestion-bridge.md
@@ -183,6 +183,20 @@ TUI-scrape leak class). It rides on `AskQuestion.context` and
 menu embed (the embed is wiped on resolution, so the context must be a separate
 message to stay readable).
 
+**Long prose recovery via a transient tall capture (#468).** Claude Code runs as
+a full-screen TUI whose *alternate screen keeps no scrollback*, so a normal
+`capture_pane` only ever returns the visible rows. When the prose is taller than
+the window (default 40 rows), its head scrolls off and `_extract_pane_context`
+recovers nothing (`context_chars=0`) — the failure looked like "short prose works,
+long prose doesn't". The JSONL can't help either: the prose is only flushed there
+*after* the menu resolves. Since Claude redraws its whole conversation from memory
+on `SIGWINCH`, c-lord now does a **transient tall re-capture** when the first
+extraction yields empty context: it briefly grows the window
+(`TmuxSessionManager.capture_pane_tall`), waits for the redraw to settle,
+re-captures, restores the original window size exactly, and re-extracts. The
+recovery only fires on empty context, so menus whose context already extracted are
+untouched (no resize round-trip).
+
 **De-duplication** (`bridged_context`): the CLI eventually flushes the same
 prose to the JSONL, which the mirror would re-post. The two delivery paths
 (pane-bridge, mirror) dedup against each other in an **order-independent** way —
@@ -201,9 +215,14 @@ Either way the prose appears **exactly once**, before the menu.
 - **Free text on the Submit screen is not re-editable from Discord.** The review
   screen is auto-submitted as-is; to change an answer, use `/attach`.
 - **Pre-menu prose extraction is best-effort and fail-closed** (#399): if the
-  block above the menu isn't a clean `●` prose block (tool output, chrome, or
-  the header scrolled off), no context is carried rather than risk leaking
-  chrome. The mirror still delivers it (late) in that case.
+  block above the menu isn't a clean `●` prose block (tool output, chrome), no
+  context is carried rather than risk leaking chrome. The mirror still delivers
+  it (late) in that case.
+- **Prose taller than the transient capture height is still truncated** (#468):
+  the tall re-capture recovers prose up to `capture_pane_tall`'s height
+  (240 rows). Prose longer than that still loses its head and falls back to the
+  late mirror flush — the same degraded mode as before, just with a much higher
+  ceiling.
 
 ## Source map
 
@@ -211,6 +230,7 @@ Either way the prose appears **exactly once**, before the menu.
 |---|---|
 | Parse menu from pane | `c_lord/claude/tmux_runner.py::_parse_ask_from_pane` |
 | Extract pre-menu prose (#399) | `tmux_runner.py::_extract_pane_context` |
+| Recover long prose via transient tall capture (#468) | `c_lord/tmux.py::TmuxSessionManager.capture_pane_tall`, wired in `tmux_runner.py::run` (poll loop) |
 | Detect & yield `pane_ask` event | `tmux_runner.py::run` (poll loop) |
 | Show buttons / route answer / post context | `c_lord/discord_ui/ask_handler.py::bridge_pane_ask` |
 | Order-independent context dedup (#399) | `c_lord/discord_ui/bridged_context.py` |

--- a/tests/fixtures/panes/bug_468_long_prose_40rows.txt
+++ b/tests/fixtures/panes/bug_468_long_prose_40rows.txt
@@ -1,0 +1,40 @@
+  meaning that two packets from the same message might take entirely different paths before arriving. This packet-switching approach makes the network resilient, because if one route fails, traffic   
+  can simply be redirected around the damage.                                                                                                                                                           
+                                                                                                                                                                                                        
+  Raw addressing alone does not guarantee that data arrives intact or in the right order, which is where the Transmission Control Protocol comes in. TCP sits atop IP and establishes a reliable        
+  connection between two endpoints through a process known as the three-way handshake, ensuring both sides are ready to communicate. It numbers each packet, waits for acknowledgments, and retransmits
+  anything that gets lost, reassembling the pieces into a faithful copy of the original data. For applications where speed matters more than perfect reliability, such as live video or online gaming, 
+  the lighter User Datagram Protocol offers a faster but less careful alternative. The pairing of IP for addressing and TCP for reliability forms the celebrated TCP/IP suite that underpins nearly all 
+  internet communication.                                                                                                                                                                               
+                                                                                                                                                                                                        
+  Because humans remember names far better than strings of numbers, the Domain Name System acts as the internet's distributed phone book. When you type a web address like example.com, your computer   
+  first queries a DNS resolver to translate that human-friendly name into the numerical IP address of the server that hosts the site. This lookup may cascade through several tiers of servers, from   
+  root servers down to authoritative name servers, with results cached along the way to speed up future requests. The hierarchical and decentralized nature of DNS means no single machine holds the   
+  entire map, yet the system reliably resolves billions of queries every day. Once the address is known, your device can finally open a connection to the correct server and begin requesting the       
+  content you actually want.                                                                                                                                                                            
+                                                                                                                                                                                                        
+  With a connection established to the right server, the web browser and the server converse using the Hypertext Transfer Protocol, or its encrypted variant HTTPS. The browser sends a request asking  
+  for a particular resource, and the server responds with the requested data along with status codes indicating success or failure. When HTTPS is used, a layer of encryption called TLS wraps the     
+  entire exchange, scrambling the data so that eavesdroppers along the path cannot read or tamper with it. This security relies on certificates and cryptographic keys that let the browser verify it is
+  genuinely talking to the intended server and not an impostor. The data that flows back is typically composed of HTML documents, stylesheets, scripts, images, and other assets that together make up  
+  a web page.                                                                                                                                                                                           
+                                                                                                                                                                                                        
+  Finally, the web browser takes this stream of raw resources and transforms it into the interactive experience a person actually sees and uses. It parses the HTML into a structured document tree,    
+  applies CSS rules to determine layout, color, and typography, and executes JavaScript to add behavior and interactivity. The browser's rendering engine paints pixels to the screen, while its       
+  networking, storage, and security subsystems quietly manage everything from cookies to cached files behind the scenes. All of this happens in a fraction of a second, repeated continuously as you   
+  scroll, click, and navigate from one page to the next. In this way the long journey from photons in a glass fiber culminates in the familiar window through which billions of people experience the   
+  internet every single day.                                                                                                                                                                            
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Continue?                                                                                                                                                                                            
+                                                                                                                                                                                                        
+The eight-paragraph essay is complete. Would you like me to continue?                                                                                                                                  
+                                                                                                                                                                                                        
+❯ 1. Yes                                                                                                                                                                                                
+     Continue with more content or a follow-up to the essay.                                                                                                                                            
+  2. No                                                                                                                                                                                                 
+     Stop here; the essay is finished.                                                                                                                                                                 
+  3. Type something.                                                                                                                                                                                    
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  4. Chat about this                                                                                                                                                                                    
+                                                                                                     
+Enter to select · ↑/↓ to navigate · Esc to cancel                          

--- a/tests/fixtures/panes/bug_468_long_prose_tall.txt
+++ b/tests/fixtures/panes/bug_468_long_prose_tall.txt
@@ -1,0 +1,200 @@
+
+╭─── Claude Code v2.1.195 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                    │ Tips for getting started                                                                                                                        │
+│                Welcome back Yousan!                │ Ask Claude to create a new app or clone a repository                                                                                            │
+│                                                    │ ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── │
+│                       ▐▛███▜▌                      │ What's new                                                                                                                                      │
+│                      ▝▜█████▛▘                     │ Added `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` to disable mouse click/drag/hover in fullscreen mode while keeping wheel scroll                        │
+│                        ▘▘ ▝▝                       │ Fixed hook matchers with hyphenated identifiers (e.g. `code-reviewer`, `mcp__brave-search`) accidentally substring-matching — they now exact-m… │
+│   Opus 4.8 (1M context) with xh… · Claude Max ·    │ Fixed voice dictation on macOS capturing silence in long-running sessions after the default input device changes                                │
+│   billing@kater.jp's Organization                  │ /release-notes for more                                                                                                                         │
+│                     ~/jxprobe5                     │                                                                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ ⚠ 2 MCP servers need authentication · run /mcp
+
+❯ Write a long essay of exactly EIGHT full paragraphs (each 4 to 5 sentences) explaining how the internet works, from physical cables up to web browsers. Make it genuinely long. After the entire      
+  essay is written as your message, use the AskUserQuestion tool to ask me whether to continue, with two options labelled Yes and No. Write the whole essay first, then call the tool last.             
+
+● The internet begins not as an abstraction but as physical infrastructure buried in the ground and sunk beneath oceans. The backbone of global connectivity is a network of fiber-optic cables, some
+  stretching thousands of kilometers across seabeds, that carry pulses of light encoding the ones and zeros of digital data. These glass strands, each thinner than a human hair, transmit information
+  at nearly the speed of light through total internal reflection, bouncing photons down their length with remarkably little loss. Copper cables, coaxial lines, and DSL connections handle shorter
+  distances, while the so-called "last mile" to homes and businesses often mixes fiber, copper, and increasingly wireless links. Without this tangible layer of cables, repeaters, and amplifiers, the
+  entire edifice of the digital world would have no foundation on which to stand.
+
+  At the edges of this physical network sit the devices that convert human-usable signals into the electrical or optical pulses that travel along the wires. A modem modulates and demodulates signals
+  so that a computer's digital data can ride over the analog characteristics of a phone line, cable, or fiber connection. Routers then direct traffic, examining where data needs to go and forwarding
+  it along the most sensible path toward its destination. Network interface cards, switches, and wireless access points each play their part, with Wi-Fi and cellular radios translating data into
+  electromagnetic waves that travel through the air rather than along a cable. Together these devices form the boundary between the local environment of a single building and the vast interconnected
+  mesh of the global internet.
+
+  For all these disparate cables, radios, and devices to cooperate, they must agree on a shared set of rules, and these rules are called protocols. The internet is organized conceptually into layers,
+  often described by models such as the OSI seven-layer model or the simpler TCP/IP stack, each layer handling a specific concern. At the lower layers, protocols govern how raw bits are framed and how
+  devices on the same local network address one another using hardware identifiers like MAC addresses. Higher layers concern themselves with end-to-end delivery, reliability, and the meaning of the
+  data being exchanged between applications. This layered design is powerful because each layer can be improved or replaced independently, so long as it continues to honor the agreed-upon interface
+  with the layers above and below it.
+
+  The protocol that gives the internet its name and its coherence is the Internet Protocol, which assigns every connected device a numerical address. IPv4 addresses are written as four numbers
+  separated by dots, while the newer IPv6 standard uses a far larger address space to accommodate the explosive growth of connected devices. When data is sent, it is broken into small chunks called
+  packets, each stamped with a source and destination address so it can be routed independently across the network. Routers along the way inspect each packet's destination and forward it hop by hop,
+  meaning that two packets from the same message might take entirely different paths before arriving. This packet-switching approach makes the network resilient, because if one route fails, traffic
+  can simply be redirected around the damage.
+
+  Raw addressing alone does not guarantee that data arrives intact or in the right order, which is where the Transmission Control Protocol comes in. TCP sits atop IP and establishes a reliable
+  connection between two endpoints through a process known as the three-way handshake, ensuring both sides are ready to communicate. It numbers each packet, waits for acknowledgments, and retransmits
+  anything that gets lost, reassembling the pieces into a faithful copy of the original data. For applications where speed matters more than perfect reliability, such as live video or online gaming,
+  the lighter User Datagram Protocol offers a faster but less careful alternative. The pairing of IP for addressing and TCP for reliability forms the celebrated TCP/IP suite that underpins nearly all
+  internet communication.
+
+  Because humans remember names far better than strings of numbers, the Domain Name System acts as the internet's distributed phone book. When you type a web address like example.com, your computer
+  first queries a DNS resolver to translate that human-friendly name into the numerical IP address of the server that hosts the site. This lookup may cascade through several tiers of servers, from
+  root servers down to authoritative name servers, with results cached along the way to speed up future requests. The hierarchical and decentralized nature of DNS means no single machine holds the
+  entire map, yet the system reliably resolves billions of queries every day. Once the address is known, your device can finally open a connection to the correct server and begin requesting the
+  content you actually want.
+
+  With a connection established to the right server, the web browser and the server converse using the Hypertext Transfer Protocol, or its encrypted variant HTTPS. The browser sends a request asking
+  for a particular resource, and the server responds with the requested data along with status codes indicating success or failure. When HTTPS is used, a layer of encryption called TLS wraps the
+  entire exchange, scrambling the data so that eavesdroppers along the path cannot read or tamper with it. This security relies on certificates and cryptographic keys that let the browser verify it is
+  genuinely talking to the intended server and not an impostor. The data that flows back is typically composed of HTML documents, stylesheets, scripts, images, and other assets that together make up
+  a web page.
+
+  Finally, the web browser takes this stream of raw resources and transforms it into the interactive experience a person actually sees and uses. It parses the HTML into a structured document tree,
+  applies CSS rules to determine layout, color, and typography, and executes JavaScript to add behavior and interactivity. The browser's rendering engine paints pixels to the screen, while its
+  networking, storage, and security subsystems quietly manage everything from cookies to cached files behind the scenes. All of this happens in a fraction of a second, repeated continuously as you
+  scroll, click, and navigate from one page to the next. In this way the long journey from photons in a glass fiber culminates in the familiar window through which billions of people experience the
+  internet every single day.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Continue? 
+
+The eight-paragraph essay is complete. Would you like me to continue?
+
+❯ 1. Yes
+     Continue with more content or a follow-up to the essay.
+  2. No
+     Stop here; the essay is finished.
+  3. Type something.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  4. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/test_tmux_tall_capture.py
+++ b/tests/test_tmux_tall_capture.py
@@ -1,0 +1,124 @@
+"""Tests for ``TmuxSessionManager.capture_pane_tall`` (#468).
+
+A full-screen TUI like Claude Code keeps no scrollback in its alternate screen,
+so a normal ``capture_pane`` only ever returns the *visible* rows. When the prose
+above an AskUserQuestion menu is taller than the window, its head scrolls off and
+is unrecoverable — ``_extract_pane_context`` then returns "". Claude redraws its
+whole conversation on SIGWINCH, so transiently enlarging the window reveals the
+scrolled-off prose. ``capture_pane_tall`` grows the window, captures, then
+restores the original size.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from c_lord.claude.tmux_runner import _parse_ask_from_pane
+from c_lord.tmux import TmuxSessionManager
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures" / "panes"
+
+
+def _load_fixture(name: str) -> str:
+    return (_FIXTURES_DIR / name).read_text()
+
+
+def _mgr() -> TmuxSessionManager:
+    mgr = TmuxSessionManager(mapping_path="")
+    mgr._available = True
+    mgr._thread_to_window[12345] = "w1"
+    # Isolate from window-resolution _run calls — tested elsewhere.
+    mgr._find_window_for_thread = lambda tid: "w1"  # type: ignore[method-assign]
+    return mgr
+
+
+class TestCapturePaneTall:
+    def test_grows_captures_then_restores_original_size(self) -> None:
+        """The window is enlarged for the capture, then restored to its exact
+        pre-capture size — and the captured (tall) text is returned."""
+        tall_text = "● the full pre-menu prose that had scrolled off\n  more lines\n"
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="160 40\n"),  # display-message: current size
+                MagicMock(returncode=0),  # resize-window UP
+                MagicMock(returncode=0, stdout=tall_text),  # capture-pane (tall)
+                MagicMock(returncode=0),  # resize-window RESTORE
+            ]
+            out = _mgr().capture_pane_tall(12345, tall_rows=240, settle_timeout=0.0)
+
+        assert out == tall_text
+
+        resize_calls = [c.args[0] for c in mock_run.call_args_list if "resize-window" in c.args[0]]
+        assert len(resize_calls) == 2, f"expected grow+restore, got {resize_calls}"
+        # First resize grows to the tall height; last restores the original 40.
+        assert "240" in resize_calls[0]
+        assert resize_calls[-1][-1] == "40", f"must restore original height: {resize_calls[-1]}"
+        # Restore happens AFTER the capture (capture is between the two resizes).
+        order = [
+            ("resize" if "resize-window" in c.args[0] else "capture")
+            for c in mock_run.call_args_list
+            if "resize-window" in c.args[0] or "capture-pane" in c.args[0]
+        ]
+        assert order == ["resize", "capture", "resize"]
+
+    def test_restores_size_even_if_capture_fails(self) -> None:
+        """A failed capture must still restore the original window size."""
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="160 40\n"),  # current size
+                MagicMock(returncode=0),  # resize UP
+                MagicMock(returncode=1, stdout=""),  # capture FAILS
+                MagicMock(returncode=0),  # resize RESTORE (must still happen)
+            ]
+            _mgr().capture_pane_tall(12345, tall_rows=240, settle_timeout=0.0)
+
+        resize_calls = [c.args[0] for c in mock_run.call_args_list if "resize-window" in c.args[0]]
+        assert len(resize_calls) == 2
+        assert resize_calls[-1][-1] == "40"
+
+    def test_unavailable_returns_empty_without_resize(self) -> None:
+        mgr = _mgr()
+        mgr._available = False
+        with patch("c_lord.tmux._run") as mock_run:
+            assert mgr.capture_pane_tall(12345) == ""
+        mock_run.assert_not_called()
+
+
+class TestLongProseContextFixtures:
+    """Real captured panes (#468) showing WHY the tall capture is needed.
+
+    Both fixtures are the SAME AskUserQuestion menu with a long (~58-line)
+    prose block above it, captured from a live Claude TUI:
+    - ``..._40rows``: a 40-row window. The prose head scrolled off the
+      alternate screen, so ``_extract_pane_context`` recovers nothing.
+    - ``..._tall``: the same window grown to 240 rows. Claude redrew the whole
+      conversation, so the full prose is now captured and extracted.
+
+    The menu itself (question/options) parses identically in both — proving the
+    window height only affects the *context*, never menu detection (a question
+    appearing is always bridged).
+    """
+
+    SHORT = "bug_468_long_prose_40rows.txt"
+    TALL = "bug_468_long_prose_tall.txt"
+
+    def test_short_pane_loses_context(self) -> None:
+        q = _parse_ask_from_pane(_load_fixture(self.SHORT))
+        assert q is not None  # the menu is still detected
+        assert q.context == ""  # but the scrolled-off prose is lost (the bug)
+
+    def test_tall_pane_recovers_full_context(self) -> None:
+        q = _parse_ask_from_pane(_load_fixture(self.TALL))
+        assert q is not None
+        assert len(q.context) > 1000  # the full prose is back
+        # Real prose content, not chrome.
+        assert "internet" in q.context.lower()
+        for chrome in ("❯", "☐", "Chat about this", "●"):
+            assert chrome not in q.context
+
+    def test_menu_parses_the_same_regardless_of_height(self) -> None:
+        short = _parse_ask_from_pane(_load_fixture(self.SHORT))
+        tall = _parse_ask_from_pane(_load_fixture(self.TALL))
+        assert short is not None and tall is not None
+        assert [o.label for o in short.options] == [o.label for o in tall.options]


### PR DESCRIPTION
## What does this PR do?

長い「経緯・前提つき」の選択肢（AskUserQuestion）で、**選択肢ボタンの前に**前提の説明文が出るようにする。これまでは前提が長いと説明文が消え、クリックした**後**に遅れて出て順序が逆転していた（短い前提のときだけ正しく前に出ていた）。

## Why?

利用者は「選択肢を押す前」に判断の前提（経緯・推し）を読む必要がある。後出しになると**根拠を知らないまま選ばされる**＝意思決定の体験が壊れる。#399 で「前提を選択肢の前に出す」と決めた設計が、長文ケースで破れていた。

Closes #468

## 利用者から見た before/after（1行）

スレッドで長い前提つきの選択肢が出るとき、**before**: 説明文が消えてボタンだけ先に出る（説明はクリック後に遅延）/ **after**: 説明文がボタンの前にちゃんと出る。

## 原因（実機4実験で特定）

メニューが開いている瞬間、長い前提 prose の全文がどこにも無い：
- **jsonl は解決後にしか書かれない**（実験1）→ jsonl から前に取るのは不可能
- **TUI の alt-screen は履歴を持たない**（実験3で `context_chars=0` を再現）→ `capture-pane -S` でも可視行（ペイン高さ）しか取れず、長文だと先頭 `●` が画面外へ消える
- ペイン高さ（`DEFAULT_MANAGED_WINDOW_SIZE=160x40`）が上限

修正：Claude が SIGWINCH（リサイズ）で会話全体を再描画する性質を使い、**メニュー検出時に context が空なら一瞬ウィンドウを縦に伸ばして撮り直し→元サイズに正確に復元**して回復する。抽出ロジック `_extract_pane_context` は不変。

## Acceptance Criteria (copied from the issue)

- [x] `c_lord/tmux.py` に一時リサイズ撮影メソッド `capture_pane_tall()` を追加。**呼び出し後のサイズが呼び出し前と一致**（単体テスト + 実機 exp6/exp7 `SIZE_BEFORE==SIZE_AFTER`）。
- [x] AskUserQuestion / plan メニュー検出時、`context` が空なら再取得 context を使う（`c_lord/claude/tmux_runner.py`、空のときだけ発火）。
- [x] 単体テスト：実 pane fixture で 40 行相当→`context==""`、tall→full prose（`tests/test_tmux_tall_capture.py` + `tests/fixtures/panes/bug_468_long_prose_{40rows,tall}.txt`）。
- [x] **staging 実機 RED→GREEN（選択肢の前に説明）＋スクショ**：staging-4 のクリーンスレッドで **RED(main)=context_chars 0 / GREEN(branch)=2090 + 回復ログ**、Discord 実画面で RED=ボタンのみ / GREEN=説明文→ボタン（下記）。
- [x] **リサイズ往復後も選択肢の回答が効く**：exp7 で `capture_pane_tall` 往復後に Enter 選択→**メニュー閉鎖・Claude 継続（PASS）**。
- [x] `ruff check` + `ruff format --check` + `pytest`(1980 passed) + `pyright`(0 errors) green。
- [x] 「あるべき動き」ドキュメント更新（`docs/askuserquestion-bridge.md` に #468 の挙動・上限・source map）。

## TDD evidence

RED（修正前、メソッド未実装）:
```
E   AttributeError: 'TmuxSessionManager' object has no attribute 'capture_pane_tall'. Did you mean: 'capture_pane'?
tests/test_tmux_tall_capture.py ... 3 failed
```
GREEN（実装後）: `tests/test_tmux_tall_capture.py` 6 passed。

## Staging Evidence (証跡)

### staging bot 実機 RED→GREEN（staging-4 クリーンスレッド, window 160x20 で overflow 強制）

| | branch | bot ログ |
|---|---|---|
| **RED** | `main` (5c9795a) | `Interactive menu detected ... context_chars=0`（回復ログ無し） |
| **GREEN** | `fix/468` (4ef3371) | `context_chars=2090` ＋ `Recovered pre-menu context via tall capture (... context_chars=2090)` |

**RED（main）— 説明文が無いままボタンが出る:**
![staging-red](https://github.com/yousan/c-lord/releases/download/evidence/i468-staging-red-pr468_staging_red-20260630T003452Z.png)

**GREEN（fix）— 長い TCP 説明文が出た“あとに”ボタンが出る:**
![staging-green](https://github.com/yousan/c-lord/releases/download/evidence/i468-staging-green-pr468_staging_green-20260630T003256Z.png)

### 補強: 実 CLI × 実 shipping メソッド（mocks ではない・決定論的）

bot ホストで本物の `claude` を tmux 起動し、同一メニューに実メソッドを実行：
```
exp6 (160x28): RED capture_pane()=0 / GREEN capture_pane_tall()=8617 / WINDOW_SIZE 復元 / chrome 混入なし
exp7 (160x24): capture_pane_tall()=6971 復元 → リサイズ往復後 Enter で「menu CLOSED → 回答受理(PASS)」
```
![realcli-redgreen](https://github.com/yousan/c-lord/releases/download/evidence/i468-realcli-redgreen-evidence_468-20260629T083627Z.png)

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/` passes (1980 passed, 3 skipped)
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in（staging bot RED→GREEN 実画面 + 実 CLI 決定論的検証）
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたので「あるべき動き」ドキュメント（`docs/askuserquestion-bridge.md`）を更新した
- [x] `Closes #468` used（全 AC 達成のため）

## Self-review / security

- diff は当該変更のみ（`c_lord/tmux.py` / `c_lord/claude/tmux_runner.py` / `docs/askuserquestion-bridge.md` / 新規 test + fixtures）。無関係変更なし。
- security-audit: 新規 subprocess は `_run([...list...])` のみ（`shell=True` 無し）、コマンドに渡るのは内部 session/window 名と整数のみ（ユーザー入力混入なし）、env/秘密に無関係、`try/finally` でサイズ復元。指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
