### PR TITLE
fix(session_manage): 停止セッションで /resync・/tmux-screenshot を詰まらせない (#464 ②-2)

### DIFF
--- a/c_lord/cogs/session_manage.py
+++ b/c_lord/cogs/session_manage.py
@@ -44,6 +44,17 @@ logger = logging.getLogger(__name__)
 _Responder = Callable[..., Awaitable[None]]
 _Acknowledger = Callable[..., Awaitable[None]]
 
+# #464 ②-2: commands that inspect/reconnect a live session (/tmux-screenshot,
+# /resync) used to dead-end with a bare "No tmux window found for this thread."
+# when the work session was stopped (bot restart / tmux-server death). That left
+# the user stuck with no next step during the 2026-06-25 incident. Point them at
+# the recovery path instead: a normal message auto-resumes the on-disk session
+# via --continue (#270) and announces it (#465), so the session comes back.
+_SESSION_STOPPED_HINT = (
+    "ℹ️ この作業セッションは現在停止しています（tmux ウィンドウがありません）。\n"
+    "**このスレッドにメッセージを送れば自動で復元し、続きから再開します。**"
+)
+
 
 # Model management
 SETTING_CLAUDE_MODEL = "claude_model"
@@ -830,7 +841,7 @@ class SessionManageCog(commands.Cog):
 
         window = await asyncio.to_thread(tmux_mgr._find_window_for_thread, thread_id)
         if window is None:
-            await respond("ℹ️ No tmux window found for this thread.", ephemeral=True)
+            await respond(_SESSION_STOPPED_HINT, ephemeral=True)
             return
 
         ansi = await asyncio.to_thread(tmux_mgr.capture_screen, thread_id)
@@ -970,7 +981,7 @@ class SessionManageCog(commands.Cog):
             await ack()
             session_name, window_name = await self._find_thread_window(thread_id)
             if not session_name or not window_name:
-                await respond("ℹ️ No tmux window found for this thread.", ephemeral=True)
+                await respond(_SESSION_STOPPED_HINT, ephemeral=True)
                 return
             # 1. Re-bridge any stranded TUI menu so its buttons (re)appear.
             await self._rebridge_menu(thread_id, session_name, window_name)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -104,6 +104,8 @@ Available models: `haiku` (fast), `sonnet` (balanced, default), `opus` (powerful
 
 It does **not** touch the Claude process or the conversation — the session is untouched. `/resync-channel` runs the same reconnect for every thread in the channel's tmux session and reports how many it touched.
 
+If the thread's work session is **stopped** (no tmux window — e.g. after a bot restart or a tmux-server death), `/resync` and `/tmux-screenshot` no longer dead-end with a bare "No tmux window found." Instead they tell you the session is stopped and that **sending a message auto-restores it** (the on-disk conversation resumes via `--continue`, announced with a "🔄 …会話を復元して続けます" notice — #270 / #465). This is what keeps a restart from leaving you stuck (#464).
+
 **`/restart-claude`** restarts the Claude *process* for this thread **while keeping the conversation**. Use it when the process is wedged (e.g. a stuck turn silently blocks further input). It kills the active runner and the tmux window so the old/stuck process is gone, but — unlike `/clear` — it does **not** reset the session. Your next message then resumes the same conversation via `--continue`, so the context survives. (The fresh process spawns on that next message through the normal reply path, which is what keeps session setup correct.)
 
 **The three recovery commands, by what they touch:**

--- a/tests/test_resync.py
+++ b/tests/test_resync.py
@@ -96,6 +96,30 @@ class TestResyncThread:
         assert respond.await_count >= 1
 
     @pytest.mark.asyncio
+    async def test_thread_no_window_gives_actionable_recovery_hint(self, monkeypatch):
+        """#464 ②-2: /resync on a stopped session must guide the user to restore
+        it (send a message) instead of dead-ending with a bare 'No tmux window
+        found for this thread.' — that bare message is what left the user stuck
+        during the 2026-06-25 incident."""
+        cog, bot, watchdog = _make_cog()
+        thread = _make_thread(12345)
+        monkeypatch.setattr(tss, "_list_all_windows", lambda: [])
+        cog._snapshot_pane = AsyncMock(return_value=b"PNGDATA")
+
+        respond, ack = _io()
+        await cog._resync_impl(channel=thread, scope="thread", respond=respond, ack=ack)
+
+        texts = []
+        for a, k in respond.await_args_list:
+            if a:
+                texts.append(a[0])
+            if k.get("content"):
+                texts.append(k["content"])
+        joined = " ".join(t for t in texts if isinstance(t, str))
+        assert "復元" in joined or "メッセージを送" in joined, joined
+        assert joined != "ℹ️ No tmux window found for this thread."
+
+    @pytest.mark.asyncio
     async def test_thread_scope_outside_thread_is_rejected(self):
         cog, bot, watchdog = _make_cog()
         channel = MagicMock(spec=discord.TextChannel)

--- a/tests/test_session_manage.py
+++ b/tests/test_session_manage.py
@@ -495,6 +495,26 @@ class TestTmuxScreenshot:
         assert sent and sent[-1]["ephemeral"] is True
         assert all(s["file"] is None for s in sent)
 
+    async def test_impl_no_window_gives_actionable_recovery_hint(self):
+        """#464 ②-2: a stopped session must not dead-end with a bare 'No tmux
+        window found for this thread.' — tell the user that sending a message
+        auto-restores it (the #270/#465 dead-pane recovery)."""
+        cog = _make_cog()
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 123
+        thread.parent_id = 456
+
+        tmux_mgr = MagicMock()
+        tmux_mgr._find_window_for_thread = MagicMock(return_value=None)
+        cog._resolve_tmux_manager = AsyncMock(return_value=tmux_mgr)
+
+        respond, ack, sent = _capture_responder()
+        await cog._screenshot_impl(channel=thread, respond=respond, ack=ack)
+
+        msg = sent[-1]["content"] or ""
+        assert "復元" in msg or "メッセージを送" in msg, msg
+        assert msg != "ℹ️ No tmux window found for this thread."
+
     async def test_impl_render_unavailable_sends_ephemeral(self, monkeypatch):
         import c_lord.cogs.session_manage as sm
 


### PR DESCRIPTION
## 概要（利用者目線・先頭）

再起動や tmux サーバー死で作業セッションが**停止している**とき、`/resync` と `/tmux-screenshot` は **「No tmux window found for this thread.」とだけ返して行き止まり**になっていました。ユーザーは次に何をすればいいか分からず**詰まって**いました（2026-06-25 のインシデントで実害。ユーザーが症状として貼ったのがこのメッセージ）。

このPRで、停止時は **「ℹ️ この作業セッションは現在停止しています（tmux ウィンドウがありません）。このスレッドにメッセージを送れば自動で復元し、続きから再開します。」** という**実行可能な案内**を返します。実際の復元は、メッセージを送ると走る既存の dead-pane `--continue`（#270）＋復元通知（#465）が担います。

Refs #464

> #464 ②（「消えても会話を自動で復活／『見つからない』で詰まらせない」）の **2/2**。②-1（復元の可視化）は PR #465（マージ済み）。`Closes` ではなく `Refs`。

## 変更点

- `c_lord/cogs/session_manage.py` — `_screenshot_impl` と `_resync_impl`（thread scope）の window 不在分岐を、bare メッセージ → 実行可能な案内 `_SESSION_STOPPED_HINT` に変更。
- **`/workspace-delete`・`/close-workspace` の "no window" は変更しない** — 削除/クローズ操作では「window 無し」は正常な結果。
- `docs/COMMANDS.md` — `/resync` 節に停止時の新挙動を追記。
- `tests/test_session_manage.py` / `tests/test_resync.py` — RED→GREEN テスト各1件。

## TDD evidence (RED → GREEN)

- **RED**: `test_thread_no_window_gives_actionable_recovery_hint` / `test_impl_no_window_gives_actionable_recovery_hint`
  → `AssertionError: ℹ️ No tmux window found for this thread.`（案内語 "復元"/"メッセージを送" を含まない）
- **GREEN**: 実装後 2 passed。既存の no-window テストも緑。

## Staging Evidence

- **環境**: staging-3 (`c-lord-staging-3`)。トリガは `!resync`（`/resync` の text twin）を webhook 経由で E2E スレッドへ投稿。E2E スレッドの tmux window を `tmux kill-window` で落として **no-window** 状態にした上で実行。

**RED（`main` = 修正前）**: `!resync` → bare **「ℹ️ No tmux window found for this thread.」**（行き止まり）。

![pr470-red-bare-nowindow](https://github.com/yousan/c-lord/releases/download/evidence/i464-pr470-red-bare-nowindow-20260709T011045Z-00.png)

**GREEN（`verify/464-both` = 修正後）**: `!resync` → **「ℹ️ この作業セッションは現在停止しています…メッセージを送れば自動で復元し、続きから再開します。」**（実行可能な案内）。同スレッドで旧コードの別 staging bot が bare メッセージを返しているので **RED/GREEN の対比が同一画面**に写っている。

![pr470-green-actionable-hint](https://github.com/yousan/c-lord/releases/download/evidence/i464-pr470-green-actionable-hint-20260709T011045Z-01.png)

> 証跡 PNG は `evidence` prerelease にアップロード（git には commit していない）。webhook は prod bot token で一時作成し、検証後に削除。

## Definition of Done checklist

- [x] Refs #464（② の 2/2。`Closes` は使わない）
- [x] TDD: RED 失敗行を掲示 → GREEN
- [x] `pytest` 全緑（**2013 passed, 3 skipped**）/ `ruff` / `pyright` green
- [x] 動きを変えた → `docs/COMMANDS.md` を同PRで更新
- [x] 無関係な変更なし（session_manage.py / 2 test / COMMANDS.md のみ）
- [x] Staging behavior verified（上記 RED/GREEN 実画面スクショ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)