### PR TITLE
feat(tmux): /tmux-screenshot を縦に伸ばす＋高さを設定可能に (#471)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ SESSION_TIMEOUT_SECONDS=300
 # Tmux Session Management (enabled by default, degrades gracefully)
 # CLORD_TMUX_ENABLED=true          # Set to "false" to disable
 # CLORD_TMUX_SESSION_NAME=         # Defaults to current directory name
+# CLORD_TMUX_SCREENSHOT_ROWS=100   # /tmux-screenshot height in rows. The live
+#                                  # window is ~40 rows, so the window is grown
+#                                  # to this height before capture to show more
+#                                  # history, then restored. Set 0 to capture
+#                                  # the current window as-is. Default: 100
 
 # Thread-name status lamp 🟢🟡🔴⚪ (OFF by default — #329)
 # When enabled, the leading emoji of each thread name reflects the live state

--- a/c_lord/tmux.py
+++ b/c_lord/tmux.py
@@ -19,6 +19,10 @@ import re
 import subprocess
 import threading
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # Discord snowflake IDs are 17–19 digits. Require ≥10 to avoid matching
 # unrelated trailing-numeric path components (PIDs, ports, etc.).
@@ -50,6 +54,18 @@ _SORT_TMP_BASE = 9000
 # this default when none is attached) at creation, so they still look right and
 # then stay fixed. Chosen large enough for a usable Claude TUI.
 DEFAULT_MANAGED_WINDOW_SIZE = (160, 40)
+
+# #471: /tmux-screenshot height. capture_screen() only ever sees the *visible*
+# window (DEFAULT_MANAGED_WINDOW_SIZE → 40 rows), so a screenshot cut off the
+# conversation history. Claude Code runs as a full-screen TUI whose alternate
+# screen keeps no scrollback, so the only way to reveal more history is to
+# transiently grow the window before capture (SIGWINCH → Claude redraws more of
+# the conversation), then restore the exact original size — the same trick as
+# capture_pane_tall (#468). This is the default target height in rows; override
+# with CLORD_TMUX_SCREENSHOT_ROWS, or set it to 0 to disable the growth and
+# capture the current window as-is.
+DEFAULT_SCREENSHOT_ROWS = 100
+_SCREENSHOT_ROWS_ENV = "CLORD_TMUX_SCREENSHOT_ROWS"
 
 # Effort levels the ``claude --effort`` flag accepts (commander-validated; it
 # hard-errors on anything else).  ``ultracode``/``auto`` are real effort levels
@@ -102,6 +118,38 @@ def parse_work_number(window_name: str) -> int | None:
     return None
 
 
+def _screenshot_rows_from_env() -> int:
+    """Read the configured tmux-screenshot height (rows) from the environment.
+
+    ``CLORD_TMUX_SCREENSHOT_ROWS`` overrides :data:`DEFAULT_SCREENSHOT_ROWS`. A
+    non-integer or negative value is ignored (falls back to the default) with a
+    warning, so a typo can't silently break the taller screenshot. ``0`` is a
+    valid, explicit "don't grow the window — capture it as-is".
+    """
+    raw = os.getenv(_SCREENSHOT_ROWS_ENV)
+    if raw is None or raw.strip() == "":
+        return DEFAULT_SCREENSHOT_ROWS
+    try:
+        rows = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r (not an integer); using default %d",
+            _SCREENSHOT_ROWS_ENV,
+            raw,
+            DEFAULT_SCREENSHOT_ROWS,
+        )
+        return DEFAULT_SCREENSHOT_ROWS
+    if rows < 0:
+        logger.warning(
+            "Negative %s=%r; using default %d",
+            _SCREENSHOT_ROWS_ENV,
+            raw,
+            DEFAULT_SCREENSHOT_ROWS,
+        )
+        return DEFAULT_SCREENSHOT_ROWS
+    return rows
+
+
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a subprocess and return the result (never raises on non-zero exit)."""
     return subprocess.run(
@@ -147,8 +195,19 @@ class TmuxSessionManager:
     window option.
     """
 
-    def __init__(self, session_name: str | None = None, mapping_path: str | None = None) -> None:
+    def __init__(
+        self,
+        session_name: str | None = None,
+        mapping_path: str | None = None,
+        screenshot_rows: int | None = None,
+    ) -> None:
         self.session_name: str = session_name or SESSION_NAME
+        # #471: target height (rows) for /tmux-screenshot. Defaults to the env
+        # (CLORD_TMUX_SCREENSHOT_ROWS) / DEFAULT_SCREENSHOT_ROWS so every manager
+        # picks up the config with no wiring; an explicit arg wins (tests / API).
+        self.screenshot_rows: int = (
+            screenshot_rows if screenshot_rows is not None else _screenshot_rows_from_env()
+        )
         self._available: bool | None = None
         self._next_work_id: int = 1
         self._thread_to_window: dict[int, str] = {}
@@ -1181,54 +1240,45 @@ class TmuxSessionManager:
 
         return result.stdout
 
-    def capture_pane_tall(
+    def _capture_after_grow(
         self,
-        thread_id: int,
-        tall_rows: int = 240,
-        history_lines: int = 500,
+        target: str,
+        capture_args: list[str],
+        tall_rows: int,
+        fallback: Callable[[], str],
         settle_timeout: float = 3.0,
         poll_interval: float = 0.25,
     ) -> str:
-        """Capture the pane after transiently enlarging the window height (#468).
+        """Grow *target* to ``tall_rows``, let the TUI redraw, capture, restore.
 
         Claude Code runs as a full-screen TUI whose alternate screen keeps no
-        scrollback, so :meth:`capture_pane` only ever returns the *visible*
-        rows. When the prose above an AskUserQuestion menu is taller than the
-        window, its head scrolls off and is unrecoverable — and
-        ``_extract_pane_context`` then returns ``""`` (the pre-menu 経緯/推し is
-        lost, so the question reaches Discord with no decision context).
-
-        Claude redraws its whole conversation from memory on SIGWINCH, so
-        briefly growing the window reveals the scrolled-off prose. We grow, wait
-        for the redraw to settle, capture, then restore the original size
-        *exactly* (so an attached human's view is unchanged). Returns raw text
-        (``-e``) like :meth:`capture_pane`; callers normalize. Empty string on
-        failure / no window.
+        scrollback, so a plain capture only ever returns the *visible* rows.
+        Growing the window makes Claude redraw more of its conversation from
+        memory (SIGWINCH). We grow, poll until the redraw settles (two
+        consecutive identical captures — bounded by ``settle_timeout`` so a slow
+        or never-settling redraw degrades to a best-effort frame, never a hang;
+        ``settle_timeout=0`` does exactly one capture), run ``capture_args``,
+        then restore the exact original size in a ``finally`` so an attached
+        human's view is unchanged. ``fallback`` supplies the result when the
+        size can't be read or the window is already ``>= tall_rows`` (a resize
+        round-trip would gain nothing / risk a needless SIGWINCH). Shared by
+        :meth:`capture_pane_tall` (#468) and :meth:`capture_screen` (#471).
         """
-        if not self._check_available():
-            return ""
-
-        window = self._find_window_for_thread(thread_id)
-        if window is None:
-            return ""
-
-        target = f"{self.session_name}:{window}"
-
         size = _run(
             ["tmux", "display-message", "-p", "-t", target, "#{window_width} #{window_height}"]
         )
         if size.returncode != 0:
             # Can't read the current size → never risk leaving the window resized.
-            return self.capture_pane(thread_id, history_lines)
+            return fallback()
         try:
             width_s, height_s = size.stdout.split()
             orig_width, orig_height = int(width_s), int(height_s)
         except ValueError:
-            return self.capture_pane(thread_id, history_lines)
+            return fallback()
 
         if orig_height >= tall_rows:
             # Already tall enough — a resize round-trip would gain nothing.
-            return self.capture_pane(thread_id, history_lines)
+            return fallback()
 
         def _resize(height: int) -> None:
             _run(
@@ -1247,28 +1297,10 @@ class TmuxSessionManager:
         text = ""
         try:
             _resize(tall_rows)
-            # Poll until the redraw settles (two consecutive identical captures).
-            # The menu is idle-waiting for input, so there is no spinner to make
-            # the pane flap — once Claude has re-laid-out the conversation the
-            # capture stops changing. Bounded by ``settle_timeout`` so a slow or
-            # never-settling redraw degrades to a best-effort capture, never a
-            # hang. ``settle_timeout=0`` (tests) does exactly one capture.
             attempts = max(1, int(settle_timeout / poll_interval))
             prev: str | None = None
             for i in range(attempts):
-                result = _run(
-                    [
-                        "tmux",
-                        "capture-pane",
-                        "-e",
-                        "-p",
-                        "-J",
-                        "-t",
-                        target,
-                        "-S",
-                        f"-{history_lines}",
-                    ]
-                )
+                result = _run(capture_args)
                 cur = result.stdout if result.returncode == 0 else ""
                 if cur:
                     text = cur
@@ -1282,13 +1314,82 @@ class TmuxSessionManager:
 
         return text
 
-    def capture_screen(self, thread_id: int) -> str:
-        """Capture the *visible* pane as ANSI text for a screenshot (#285).
+    def capture_pane_tall(
+        self,
+        thread_id: int,
+        tall_rows: int = 240,
+        history_lines: int = 500,
+        settle_timeout: float = 3.0,
+        poll_interval: float = 0.25,
+    ) -> str:
+        """Capture the pane after transiently enlarging the window height (#468).
+
+        Claude Code runs as a full-screen TUI whose alternate screen keeps no
+        scrollback, so :meth:`capture_pane` only ever returns the *visible*
+        rows. When the prose above an AskUserQuestion menu is taller than the
+        window, its head scrolls off and is unrecoverable — and
+        ``_extract_pane_context`` then returns ``""`` (the pre-menu 経緯/推し is
+        lost, so the question reaches Discord with no decision context).
+
+        Claude redraws its whole conversation from memory on SIGWINCH, so
+        briefly growing the window reveals the scrolled-off prose. Delegates the
+        grow → settle → capture → restore round-trip to
+        :meth:`_capture_after_grow`; the menu is idle-waiting for input (no
+        spinner) so the capture settles quickly. Falls back to a scrollback
+        :meth:`capture_pane` when the window is already tall enough. Returns raw
+        text (``-e``) like :meth:`capture_pane`; callers normalize. Empty string
+        on failure / no window.
+        """
+        if not self._check_available():
+            return ""
+
+        window = self._find_window_for_thread(thread_id)
+        if window is None:
+            return ""
+
+        target = f"{self.session_name}:{window}"
+        capture_args = [
+            "tmux",
+            "capture-pane",
+            "-e",
+            "-p",
+            "-J",
+            "-t",
+            target,
+            "-S",
+            f"-{history_lines}",
+        ]
+        return self._capture_after_grow(
+            target,
+            capture_args,
+            tall_rows,
+            lambda: self.capture_pane(thread_id, history_lines),
+            settle_timeout,
+            poll_interval,
+        )
+
+    def capture_screen(
+        self,
+        thread_id: int,
+        rows: int | None = None,
+        settle_timeout: float = 3.0,
+        poll_interval: float = 0.25,
+    ) -> str:
+        """Capture the pane as ANSI text for a screenshot (#285, #471).
 
         Unlike :meth:`capture_pane` (which pulls scrollback and joins wrapped
-        lines for the event stream), this grabs only the on-screen region with
-        escape sequences preserved (``-e``) and no wrapped-line joining, so the
-        PNG renderer reproduces the exact current screen.
+        lines for the event stream), this grabs the on-screen region with escape
+        sequences preserved (``-e``) and no wrapped-line joining, so the PNG
+        renderer reproduces the exact current screen.
+
+        Because Claude's TUI keeps no scrollback, the only way to show *more*
+        history than the ~40-row live window is to transiently grow the window
+        so Claude redraws more of the conversation (#471); the taller visible
+        screen is then captured and the original size restored exactly (via
+        :meth:`_capture_after_grow`). ``rows`` defaults to
+        :attr:`screenshot_rows` (env ``CLORD_TMUX_SCREENSHOT_ROWS`` /
+        :data:`DEFAULT_SCREENSHOT_ROWS`); ``rows=0`` disables the growth and
+        captures the current window as-is.
 
         Returns the raw ANSI text, or empty string on failure / no window.
         """
@@ -1302,12 +1403,19 @@ class TmuxSessionManager:
         target = f"{self.session_name}:{window}"
         # -e: keep ANSI colors/hyperlinks. No -S (visible region only) and no
         # -J (preserve the exact on-screen layout) — this is a screenshot of
-        # the *current* screen, not a scrollback dump.
-        result = _run(["tmux", "capture-pane", "-e", "-p", "-t", target])
-        if result.returncode != 0:
-            return ""
+        # the *current* screen (after the optional growth), not a scrollback dump.
+        capture_args = ["tmux", "capture-pane", "-e", "-p", "-t", target]
 
-        return result.stdout
+        def _capture_visible() -> str:
+            result = _run(capture_args)
+            return result.stdout if result.returncode == 0 else ""
+
+        target_rows = self.screenshot_rows if rows is None else rows
+        if target_rows and target_rows > 0:
+            return self._capture_after_grow(
+                target, capture_args, target_rows, _capture_visible, settle_timeout, poll_interval
+            )
+        return _capture_visible()
 
     def list_window_tabs(self) -> list[tuple[int, str, bool]]:
         """List this session's windows as ``(index, name, is_active)`` tuples.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -106,6 +106,8 @@ It does **not** touch the Claude process or the conversation — the session is 
 
 If the thread's work session is **stopped** (no tmux window — e.g. after a bot restart or a tmux-server death), `/resync` and `/tmux-screenshot` no longer dead-end with a bare "No tmux window found." Instead they tell you the session is stopped and that **sending a message auto-restores it** (the on-disk conversation resumes via `--continue`, announced with a "🔄 …会話を復元して続けます" notice — #270 / #465). This is what keeps a restart from leaving you stuck (#464).
 
+**Screenshot height (#471)**: `/tmux-screenshot` (and the `/resync` PNG snapshot) show **more history than the live ~40-row window**. Claude's TUI keeps no scrollback, so before capturing, c-lord transiently grows the window so Claude redraws more of the conversation, captures the taller screen, then restores the exact original size (the human's attached view is unchanged). The default height is **100 rows**; override it with `CLORD_TMUX_SCREENSHOT_ROWS` (rows), or set it to `0` to capture the current window as-is.
+
 **`/restart-claude`** restarts the Claude *process* for this thread **while keeping the conversation**. Use it when the process is wedged (e.g. a stuck turn silently blocks further input). It kills the active runner and the tmux window so the old/stuck process is gone, but — unlike `/clear` — it does **not** reset the session. Your next message then resumes the same conversation via `--continue`, so the context survives. (The fresh process spawns on that next message through the normal reply path, which is what keeps session setup correct.)
 
 **The three recovery commands, by what they touch:**

--- a/tests/test_tmux_capture_screen.py
+++ b/tests/test_tmux_capture_screen.py
@@ -9,33 +9,92 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from c_lord.tmux import SESSION_NAME, TmuxSessionManager
+from c_lord.tmux import DEFAULT_SCREENSHOT_ROWS, SESSION_NAME, TmuxSessionManager
+
+
+def _mgr(**kwargs: object) -> TmuxSessionManager:
+    mgr = TmuxSessionManager(mapping_path="", **kwargs)  # type: ignore[arg-type]
+    mgr._available = True
+    # Isolate from window-resolution _run calls — tested elsewhere.
+    mgr._find_window_for_thread = lambda tid: "work1"  # type: ignore[method-assign]
+    return mgr
 
 
 class TestCaptureScreen:
-    def test_visible_region_only(self) -> None:
-        """capture_screen grabs the visible region with ANSI escapes preserved."""
-        mgr = TmuxSessionManager(mapping_path="")
-        mgr._available = True
-        mgr._thread_to_window[12345] = "work1"
+    def test_grows_window_then_captures_visible_screen(self) -> None:
+        """By default capture_screen transiently grows the window (so Claude
+        redraws more conversation history), captures the taller *visible* screen
+        with ANSI escapes preserved, then restores the exact original size.
+
+        The capture stays visible-region-only — no -S (scrollback) and no -J
+        (wrapped-line join) — so the PNG reproduces the grown on-screen layout.
+        """
+        mgr = _mgr()
+        assert mgr.screenshot_rows > 40  # default is taller than the live window
 
         with patch("c_lord.tmux._run") as mock_run:
             mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
-                MagicMock(returncode=0, stdout="\x1b[31mRED\x1b[0m\n"),  # capture-pane
+                MagicMock(returncode=0, stdout="160 40\n"),  # display-message: size
+                MagicMock(returncode=0),  # resize-window UP
+                MagicMock(returncode=0, stdout="\x1b[31mRED\x1b[0m\n"),  # capture (tall)
+                MagicMock(returncode=0),  # resize-window RESTORE
             ]
-            text = mgr.capture_screen(12345)
+            text = mgr.capture_screen(12345, settle_timeout=0.0)
 
         assert text == "\x1b[31mRED\x1b[0m\n"
 
-        cap_args = mock_run.call_args_list[1][0][0]
-        assert "capture-pane" in cap_args
+        # Grow → capture → restore, in that order.
+        order = [
+            ("resize" if "resize-window" in c.args[0] else "capture")
+            for c in mock_run.call_args_list
+            if "resize-window" in c.args[0] or "capture-pane" in c.args[0]
+        ]
+        assert order == ["resize", "capture", "resize"]
+
+        resize_calls = [c.args[0] for c in mock_run.call_args_list if "resize-window" in c.args[0]]
+        assert str(mgr.screenshot_rows) in resize_calls[0]  # grow to the configured height
+        assert resize_calls[-1][-1] == "40"  # restore the original height
+
+        cap_args = [c.args[0] for c in mock_run.call_args_list if "capture-pane" in c.args[0]][0]
         assert "-e" in cap_args  # preserve ANSI colors/hyperlinks
         assert "-p" in cap_args
         assert f"{SESSION_NAME}:work1" in cap_args
-        # Current screen = visible region only, exact on-screen layout.
-        assert "-S" not in cap_args  # no scrollback
+        assert "-S" not in cap_args  # exact visible screen, not a scrollback dump
         assert "-J" not in cap_args  # no wrapped-line joining
+
+    def test_rows_zero_disables_growth(self) -> None:
+        """rows=0 captures the current window as-is (no resize round-trip)."""
+        mgr = _mgr()
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="\x1b[31mRED\x1b[0m\n")
+            text = mgr.capture_screen(12345, rows=0)
+
+        assert text == "\x1b[31mRED\x1b[0m\n"
+        assert all("resize-window" not in c.args[0] for c in mock_run.call_args_list)
+        assert all("display-message" not in c.args[0] for c in mock_run.call_args_list)
+        cap_args = mock_run.call_args_list[0].args[0]
+        assert "capture-pane" in cap_args
+        assert "-S" not in cap_args
+        assert "-J" not in cap_args
+
+    def test_growth_skipped_when_window_already_tall(self) -> None:
+        """No resize when the live window is already at/above the target — just
+        a plain visible capture (a resize round-trip would gain nothing)."""
+        mgr = _mgr(screenshot_rows=80)
+
+        with patch("c_lord.tmux._run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="160 120\n"),  # size: 120 >= 80
+                MagicMock(returncode=0, stdout="\x1b[31mRED\x1b[0m\n"),  # plain capture
+            ]
+            text = mgr.capture_screen(12345, settle_timeout=0.0)
+
+        assert text == "\x1b[31mRED\x1b[0m\n"
+        assert all("resize-window" not in c.args[0] for c in mock_run.call_args_list)
+        cap_args = [c.args[0] for c in mock_run.call_args_list if "capture-pane" in c.args[0]][0]
+        assert "-S" not in cap_args
+        assert "-J" not in cap_args
 
     def test_no_window_returns_empty(self) -> None:
         mgr = TmuxSessionManager(mapping_path="")
@@ -51,16 +110,44 @@ class TestCaptureScreen:
         assert mgr.capture_screen(12345) == ""
 
     def test_capture_failure_returns_empty(self) -> None:
-        mgr = TmuxSessionManager(mapping_path="")
-        mgr._available = True
-        mgr._thread_to_window[12345] = "work1"
+        mgr = _mgr()
 
         with patch("c_lord.tmux._run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=0, stdout="12345\n"),  # _find: verify
-                MagicMock(returncode=1, stdout=""),  # capture-pane fails
-            ]
-            assert mgr.capture_screen(12345) == ""
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert mgr.capture_screen(12345, rows=0) == ""
+
+
+class TestScreenshotRowsConfig:
+    def test_default_is_taller_than_live_window(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("CLORD_TMUX_SCREENSHOT_ROWS", raising=False)
+        mgr = TmuxSessionManager(mapping_path="")
+        assert mgr.screenshot_rows == DEFAULT_SCREENSHOT_ROWS
+        assert DEFAULT_SCREENSHOT_ROWS > 40  # taller than DEFAULT_MANAGED_WINDOW_SIZE height
+
+    def test_env_override(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("CLORD_TMUX_SCREENSHOT_ROWS", "150")
+        mgr = TmuxSessionManager(mapping_path="")
+        assert mgr.screenshot_rows == 150
+
+    def test_env_zero_disables_growth(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("CLORD_TMUX_SCREENSHOT_ROWS", "0")
+        mgr = TmuxSessionManager(mapping_path="")
+        assert mgr.screenshot_rows == 0
+
+    def test_constructor_override_wins(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("CLORD_TMUX_SCREENSHOT_ROWS", "150")
+        mgr = TmuxSessionManager(mapping_path="", screenshot_rows=200)
+        assert mgr.screenshot_rows == 200
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("CLORD_TMUX_SCREENSHOT_ROWS", "not-a-number")
+        mgr = TmuxSessionManager(mapping_path="")
+        assert mgr.screenshot_rows == DEFAULT_SCREENSHOT_ROWS
+
+    def test_negative_env_falls_back_to_default(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("CLORD_TMUX_SCREENSHOT_ROWS", "-5")
+        mgr = TmuxSessionManager(mapping_path="")
+        assert mgr.screenshot_rows == DEFAULT_SCREENSHOT_ROWS
 
 
 class TestListWindowTabs:


### PR DESCRIPTION
## これがこうなる（利用者目線）

スレッドで `/tmux-screenshot`（および `/resync` の PNG スナップショット）を撮ると、**今までより多くの会話履歴が1枚に写る**ようになります。以前は tmux の可視ウィンドウ（約40行）ぶんしか写らず直近しか見えませんでしたが、キャプチャ直前にウィンドウを一時的に高くして Claude に会話を描き直させ、その高い画面を撮ってから元のサイズへ戻します（アタッチ中の人の見え方は変わりません）。

高さは環境変数で調整できます:

- `CLORD_TMUX_SCREENSHOT_ROWS=<行数>` … スクショの高さ（既定 **100 行**）
- `CLORD_TMUX_SCREENSHOT_ROWS=0` … 伸長せず現在のウィンドウをそのまま撮る（従来動作）

実装: `capture_screen` が grow→capture→restore を行う。この round-trip は `capture_pane_tall`（#468）と共有ヘルパ `_capture_after_grow` に集約。設定は `TmuxSessionManager(screenshot_rows=...)` / 環境変数で注入（ゼロコンフィグ: 既存の生成箇所は無改修で新既定を拾う）。

Closes #471

## Acceptance Criteria（Issue #471 から転記）

- [x] `capture_screen` はデフォルトでウィンドウを一時的に伸ばしてからキャプチャし、終了後に元サイズへ復元する（grow → capture → restore の順序をテストで固定）
- [x] デフォルト高さは 40 行より高い（`DEFAULT_SCREENSHOT_ROWS > 40`、実値 100）
- [x] 環境変数 `CLORD_TMUX_SCREENSHOT_ROWS` で高さ（行数）を上書きできる
- [x] `CLORD_TMUX_SCREENSHOT_ROWS=0` で伸長を無効化し、現在のウィンドウをそのままキャプチャできる
- [x] 不正値（非整数・負数）は警告して既定値にフォールバックする
- [x] キャプチャは可視領域のみ（`-S`/`-J` を付けない）を維持し、PNG が画面レイアウトを再現する
- [x] 既に十分高いウィンドウではリサイズを行わない（無駄な SIGWINCH を避ける）
- [x] `.env.example` と `docs/COMMANDS.md` に設定を記載する
- [x] `pytest` / `ruff check` / `ruff format --check` / `pyright` すべてグリーン

## TDD Evidence

**RED**（実装前、新シンボル未定義でテスト collection が失敗）:

```
tests/test_tmux_capture_screen.py:12: in <module>
    from c_lord.tmux import DEFAULT_SCREENSHOT_ROWS, SESSION_NAME, TmuxSessionManager
E   ImportError: cannot import name 'DEFAULT_SCREENSHOT_ROWS' from 'c_lord.tmux'
```

**GREEN**（実装後）:

```
tests/test_tmux_capture_screen.py .................  (grow/restore 順序・rows=0・already-tall・env/引数/不正値)
tests/test_tmux_tall_capture.py ....               (#468 共有ヘルパへのリファクタ後も緑)
48 passed  (screenshot + tall-capture + session_manage)
全体: 2023 passed, 3 skipped
```

`ruff check` / `ruff format --check` / `pyright c_lord/tmux.py` … all green。security-audit skill 済（subprocess は list ベースの `_run`、user メッセージ非注入、新 env は int 検証、`.env` は gitignore）。

## 実機検証（real tmux、mock なし）

CI は tmux をモックするため、**実 tmux + alt-screen（スクロールバック無し）で resize 時に会話を描き直す Claude 相当の curses TUI** を立て、実際の `TmuxSessionManager.capture_screen` を走らせて確認した（隔離セッション `cltest-shot-471`、本番セッションは非接触）。

```
configured screenshot_rows default = 100
window size BEFORE any capture = 160x40
window size AFTER grown capture  = 160x40  (= BEFORE, 正確に復元)
rows=0   capture -> 40 content lines;  earliest visible = line 0263
default  capture -> 100 content lines; earliest visible = line 0203
RESULT: PASS
```

→ 40行では line 0262–0300 しか見えないが、100行に伸ばすと line **0202**–0300 まで写り、**60 行ぶん過去の履歴が追加で見える**。撮影後ウィンドウは 160x40 に復元。

**Before（rows=0 / 40行）** — line 0262〜0300 で頭打ち:

![screenshot](https://github.com/yousan/c-lord/releases/download/evidence/i471-screenshot-before_40rows-20260709T054135Z-00.png)

**After（default / 100行）** — line 0202 まで遡って表示:

![screenshot](https://github.com/yousan/c-lord/releases/download/evidence/i471-screenshot-after_100rows-20260709T054135Z-01.png)

Discord への投稿経路（`_screenshot_impl` → `render_pane_png` → `discord.File`）は #285 のまま無改修 — 本 PR は `capture_screen` が返す行数を増やすだけ。

## あるべき動きの更新

- `docs/COMMANDS.md`: `/tmux-screenshot` が「可視40行より多くの履歴を写す」旨と `CLORD_TMUX_SCREENSHOT_ROWS` を追記。
- `.env.example`: `CLORD_TMUX_SCREENSHOT_ROWS` を追記。

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（2023 passed, 3 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in（実 tmux での real-tmux 検証 = RED(40行)→GREEN(100行) を実画面 PNG 2枚で提示。Discord 投稿経路は #285 のまま無改修）
- [x] No unrelated changes in the diff; self-review done（変更は tmux.py / test / .env.example / COMMANDS.md の4ファイルのみ）
- [x] 動きを変えたら「あるべき動き」のドキュメント（仕様 / README / docs）も更新した（`docs/COMMANDS.md` / `.env.example`）
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met（Issue #471 の AC は全達成）
