### PR TITLE
fix: sanitize tmux-illegal chars (. :) in derive_session_name (#474)

### DIFF
--- a/c_lord/database/channel_repo.py
+++ b/c_lord/database/channel_repo.py
@@ -77,10 +77,20 @@ def derive_session_name(source_repo: str) -> str:
         'https://github.com/org/my-project.git' → 'my-project'
         'git@github.com:org/my-project.git'     → 'my-project'
         '/home/user/repos/my-project'           → 'my-project'
+        'git@github.com:org/NiyaReco.love.git'  → 'NiyaReco_love'
+
+    tmux forbids ``.`` and ``:`` in session names — its target syntax
+    ``session:window.pane`` uses them as separators — and silently rewrites
+    them to ``_`` when a session is created. We mirror that rewrite here so the
+    name c-lord later hands to ``tmux -t`` matches the one tmux actually stored.
+    Otherwise a dotted repo name (e.g. ``NiyaReco.love``) makes every window
+    op target a non-existent session and Claude never starts (#474).
     """
     name = source_repo.rstrip("/").rsplit("/", 1)[-1]
     if name.endswith(".git"):
         name = name[:-4]
+    # Match tmux's own `.`/`:` → `_` substitution (see session_check_name).
+    name = name.replace(".", "_").replace(":", "_")
     return name or "clord"
 
 

--- a/tests/test_channel_repo.py
+++ b/tests/test_channel_repo.py
@@ -158,6 +158,20 @@ class TestDeriveSessionName:
     def test_dot_git_only_returns_fallback(self) -> None:
         assert derive_session_name(".git") == "clord"
 
+    def test_dotted_repo_name_sanitized_for_tmux(self) -> None:
+        # tmux forbids '.' in session names and silently rewrites it to '_'
+        # (its target syntax `session:window.pane` uses '.'/':' as separators).
+        # derive_session_name must mirror that rewrite so the name c-lord hands
+        # to `tmux -t` matches the one tmux actually stored — otherwise every
+        # window op for a dotted repo targets a non-existent session and Claude
+        # never starts ("Failed to start Claude in tmux"). (#474)
+        assert derive_session_name("git@github.com:sakana1235/NiyaReco.love.git") == "NiyaReco_love"
+        assert derive_session_name("https://github.com/foo/site.dev") == "site_dev"
+
+    def test_colon_in_name_sanitized_for_tmux(self) -> None:
+        # ':' is likewise illegal in a tmux session name.
+        assert derive_session_name("/home/user/repos/weird:name") == "weird_name"
+
 
 # ===========================================================================
 # normalize_repo_url tests (#88)


### PR DESCRIPTION
## これがこうなる（利用者目線）

ドット入りの repo 名（例 `NiyaReco.love`, `*.github.io`, `*.dev`）でチャンネルを `/clord-init` したチャンネルでは、スレッドを立てても Claude が起動せず **`❌ Failed to start Claude in tmux`** で詰んでいました。**このPRで、ドット入り repo 名でも通常どおり Claude が起動する**ようになります。ドット無しの repo 名（従来動いていたもの）には影響なし。

## 原因

`derive_session_name("git@github.com:sakana1235/NiyaReco.love.git")` は `.git` を落として最後のパス要素を返すだけ → **`NiyaReco.love`（ドットが残る）**。tmux はセッション名に `.`/`:` を使えず、作成時に内部で `_` に改名する（実体 `NiyaReco_love`）。一方 `c_lord/tmux.py` はこの名前をサニタイズせず `-t "NiyaReco.love:w1"` の形で参照するため、**作成名と参照名が永久にズレ**、window 作成が `can't specify pane here` で失敗 → `start_claude` が False → 「Failed to start Claude in tmux」。

## 修正

`derive_session_name` で tmux と同じ `.`/`:` → `_` 置換を行い、derive 結果を tmux が実際に格納する名前と一致させる（`c_lord/database/channel_repo.py`、2行）。ドット無し repo 名は無改名なので回帰なし。

Closes #474

## Acceptance Criteria（#474 の全項目）

- [x] `derive_session_name("git@github.com:sakana1235/NiyaReco.love.git") == "NiyaReco_love"`
- [x] `derive_session_name("https://github.com/foo/site.dev") == "site_dev"`
- [x] `.`/`:` 以外の既存挙動は不変（`my-project` 系の既存テスト green のまま = 無改名 repo に回帰なし）
- [x] 新テストが修正前 **RED** → 修正後 **GREEN**（下記）
- [x] staging で「ドット入り repo を bind → スレッドで Claude が実際に起動する」ことを確認（RED: 修正前 `Failed to start Claude in tmux` / GREEN: 修正後 Claude 起動）

## TDD evidence

RED（修正前、失敗行）:

```
FAILED tests/test_channel_repo.py::TestDeriveSessionName::test_dotted_repo_name_sanitized_for_tmux
FAILED tests/test_channel_repo.py::TestDeriveSessionName::test_colon_in_name_sanitized_for_tmux
E   AssertionError: assert 'weird:name' == 'weird_name'
E     - weird_name
E     + weird:name
```

GREEN（修正後）: `9 passed`（`TestDeriveSessionName` 全件）。

## CI

- `ruff check c_lord/` ✅ / `ruff format --check c_lord/` ✅ / `pyright c_lord/` ✅（0 errors）
- `pytest tests/` ✅ **2025 passed, 3 skipped**

## Staging Evidence

staging-2（`C-lord-staging-2`）を借用し、clone は成功して**tmux 名だけが変数**になるようドット入りローカル repo `/tmp/clord474.demo` をチャンネルに bind → E2E スレッドへ投稿（信頼bot方式）。検証後に原状復帰（元 binding へ再バインド・main 復帰・test tmux 削除・lease 返却）済み。

**RED（`main` + dotted binding）— `Failed to start Claude in tmux`**

```
09:17:48 c_lord.tmux: Created global tmux session: clord474.demo
09:17:49 c_lord.tmux: Failed to create tmux window w1: can't specify pane here   ← '.demo' を pane と誤解
09:17:49 c_lord.tmux: start_claude: no window for thread 1514545583459926117
09:17:51 _run_helper: run_claude: exit                                           ← Claude 起動せず即終了
```
Discord embed: `❌ Error / Failed to start Claude in tmux`

![staging-red](https://github.com/yousan/c-lord/releases/download/evidence/i474-staging-staging-red-474-20260714T002455Z-00.png)

**GREEN（`fix/derive-session-name-tmux-sanitize` + 同じ dotted binding）— Claude 起動・応答**

```
09:21:33 c_lord.tmux: Created tmux window: w1 (thread=1514545583459926117)       ← window 作成成功
09:21:34 _run_helper: run_claude: enter
09:21:34 c_lord.tmux: start_claude: sent command to clord474_demo:w1             ← サニタイズ名で起動
09:21:54 _run_helper: run_claude: exit
```
Discord: Claude が `OK474` と応答（エラー embed なし、sonnet-5 セッション実走）

![staging-green](https://github.com/yousan/c-lord/releases/download/evidence/i474-staging-staging-green-474-20260714T002455Z-01.png)

> スクショ中央の Nitro プロモは証跡用テストアカウント固有のもので、キャプチャツールは入力注入しない仕様のため閉じられません。該当行（RED=エラー / GREEN=`OK474`）は下部に表示。ログ抜粋＋REST 取得メッセージが主証跡です。

## ドキュメント

`README.md` / `docs/USER_GUIDE.md` の「session 名は repo 名から derive/auto-generate される」という記述は**依然正確**（derive 元は変わらない）。本PRは不正文字（`.`/`:`）のエッジケースを修正するのみで、記述と実態のズレは生じないため doc 更新なし。

## Self-review

- 差分は `derive_session_name` のサニタイズ2行＋テスト2ケースのみ（`git diff main` 確認済み、無関係変更なし）
- セキュリティ: 純粋な文字列サニタイズ。subprocess/env に無関係で、むしろ tmux 引数から `.`/`:` を除去し injection surface を縮小する方向

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（2025 passed, 3 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in (or a skip reason is written)
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメント（仕様 / README / docs）も更新した。変えないなら本文に `no-user-visible-change` と明記した（→ docs の derive 記述は依然正確なため更新不要と本文に明記）
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met (else `Refs #N`), and written on its own line
