### PR TITLE
fix: bash-mode マーカー(<bash-input>等)を生タグで流さず progress.txt に畳む (#487)

### DIFF
--- a/c_lord/transcript/formatter.py
+++ b/c_lord/transcript/formatter.py
@@ -5,10 +5,20 @@ counterpart in the tmux pane are rendered.  Everything else (thinking,
 framing meta like ``ai-title`` / ``pr-link`` / ``permission-mode``, the
 self-loopback of c-lord-driven input marked with a zero-width-space prefix)
 returns ``None`` and is dropped before it ever reaches Discord.
+
+The rendered form mirrors what a human sees in the Claude Code **TUI**, not
+the raw JSONL storage bytes.  In particular, a ``!``-prefixed bash-mode
+command is stored as ``user``-role string events wrapped in
+``<bash-input>`` / ``<bash-stdout>`` / ``<bash-stderr>`` tags — an internal
+encoding the TUI renders as a bash block and never shows raw.  We therefore
+classify those as tool activity (``tool_use`` / ``tool_result``) so they
+fold into ``progress.txt`` in minimal mode instead of leaking the raw tags
+as a 👤 user-input bubble (#487).
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -88,6 +98,57 @@ def _tool_result_body(block: dict[str, Any]) -> str:
     return ""
 
 
+# Claude Code bash-mode (``! command``) markers (#487).  A ``!``-prefixed pane
+# command is stored in the JSONL as ``user``-role *string* events wrapped in
+# these tags — the CLI's internal storage form, which the TUI renders as a bash
+# block and never shows raw.  They are a bash *execution*, not human-typed
+# input, so the mirror must render them like the Bash tool (``tool_use`` /
+# ``tool_result`` → folded into progress.txt in minimal mode) rather than leak
+# the raw ``<bash-*>`` tags as a 👤 user_input bubble.
+_BASH_INPUT_RE = re.compile(r"^<bash-input>(.*)</bash-input>$", re.DOTALL)
+_BASH_OUTPUT_RE = re.compile(
+    r"^<bash-stdout>(.*)</bash-stdout><bash-stderr>(.*)</bash-stderr>$", re.DOTALL
+)
+# Placeholder the CLI writes when a ``!`` command produced no output — noise, drop it.
+_BASH_NO_OUTPUT = "(Bash completed with no output)"
+_BASH_TAG_RE = re.compile(r"</?bash-(?:input|stdout|stderr)>")
+
+
+def _is_bash_mode_marker(text: str) -> bool:
+    """True when *text* (already stripped) is a Claude Code bash-mode marker."""
+    return text.startswith("<bash-input>") or text.startswith("<bash-stdout>")
+
+
+def _render_bash_mode(text: str, session_id: str | None) -> RenderedEvent | None:
+    """Render a bash-mode marker as tool activity, or ``None`` to drop it (#487).
+
+    ``<bash-input>`` → a ``tool_use`` rendered exactly like the Bash tool.
+    ``<bash-stdout>``/``<bash-stderr>`` → a ``tool_result`` carrying the combined
+    output; empty output (or the "no output" placeholder) is dropped.  A marker
+    that starts with a bash tag but does not fully match falls back to stripping
+    the tags so the raw storage form can never reach Discord.
+    """
+    m = _BASH_INPUT_RE.match(text)
+    if m is not None:
+        command = m.group(1).strip()
+        return RenderedEvent(kind="tool_use", body=f"🔧 Bash: `{command}`", session_id=session_id)
+    m = _BASH_OUTPUT_RE.match(text)
+    if m is not None:
+        parts = [
+            chunk.strip()
+            for chunk in (m.group(1), m.group(2))
+            if chunk.strip() and chunk.strip() != _BASH_NO_OUTPUT
+        ]
+        if not parts:
+            return None
+        return RenderedEvent(kind="tool_result", body="\n".join(parts), session_id=session_id)
+    # Malformed marker: strip the tags rather than leak them raw.
+    stripped = _BASH_TAG_RE.sub("", text).strip()
+    if not stripped:
+        return None
+    return RenderedEvent(kind="tool_result", body=stripped, session_id=session_id)
+
+
 def _render_user(event: dict[str, Any]) -> RenderedEvent | None:
     if event.get("isMeta"):
         return None
@@ -115,10 +176,17 @@ def _render_user(event: dict[str, Any]) -> RenderedEvent | None:
         )
 
     if isinstance(content, str):
+        stripped = content.strip()
+        # #487: bash-mode markers are a bash execution, not human input — render
+        # them like the Bash tool (buffered to progress.txt) instead of leaking
+        # the raw ``<bash-*>`` tags as a 👤 bubble.  Handles both the render and
+        # the drop (empty output) cases.
+        if _is_bash_mode_marker(stripped):
+            return _render_bash_mode(stripped, event.get("sessionId"))
         if content.startswith(ZWSP_MARKER):
             # Echo of c-lord-driven send-keys; Discord already has the original.
             return None
-        if not content.strip():
+        if not stripped:
             return None
         return RenderedEvent(
             kind="user_input",

--- a/tests/transcript/test_formatter.py
+++ b/tests/transcript/test_formatter.py
@@ -127,6 +127,76 @@ def test_user_input_without_marker_is_mirrored() -> None:
     assert "typed directly in tmux" in out.body
 
 
+# --- Claude Code bash-mode (``! command``) markers (#487) ---
+# The CLI stores a ``!``-prefixed pane command as ``user``-role string events
+# wrapped in ``<bash-input>`` / ``<bash-stdout>`` / ``<bash-stderr>`` tags. These
+# are a bash *execution*, not human-typed input, so they must be classified as
+# tool activity (folded into progress.txt in minimal mode) — never posted raw
+# as a 👤 user_input bubble.
+
+
+def test_user_bash_input_marker_classified_as_tool_use_not_raw() -> None:
+    ev = _user("<bash-input> ls -la</bash-input>")
+    out = render_event(ev)
+    assert out is not None
+    # A bash execution, mirrored like the Bash tool — not a human 👤 input.
+    assert out.kind == "tool_use"
+    assert "Bash" in out.body and "ls -la" in out.body
+    # The raw storage tag must never reach Discord.
+    assert "<bash-input>" not in out.body
+    assert "</bash-input>" not in out.body
+
+
+def test_user_bash_input_real_capture_is_not_leaked_as_user_input() -> None:
+    # Verbatim string captured from a real JSONL transcript (the reported bug).
+    ev = _user(
+        "<bash-input> google-chrome --user-data-dir=$HOME/.clord/discord-evidence-profile "
+        '"https://discord.com/channels/1285582352596209694/1514545583459926117"</bash-input>'
+    )
+    out = render_event(ev)
+    assert out is not None
+    assert out.kind != "user_input"  # regression guard for the leak
+    assert "<bash-input>" not in out.body
+    assert "google-chrome" in out.body
+
+
+def test_user_bash_output_marker_classified_as_tool_result_not_raw() -> None:
+    ev = _user("<bash-stdout>hello stdout</bash-stdout><bash-stderr>some warning</bash-stderr>")
+    out = render_event(ev)
+    assert out is not None
+    assert out.kind == "tool_result"
+    assert "hello stdout" in out.body
+    assert "some warning" in out.body
+    for tag in ("<bash-stdout>", "</bash-stdout>", "<bash-stderr>", "</bash-stderr>"):
+        assert tag not in out.body
+
+
+def test_user_bash_output_stderr_only_real_capture() -> None:
+    ev = _user(
+        "<bash-stdout></bash-stdout><bash-stderr>"
+        "[ERROR:ui/aura/env.cc:257] The platform failed to initialize.  Exiting.\n"
+        "</bash-stderr>"
+    )
+    out = render_event(ev)
+    assert out is not None
+    assert out.kind == "tool_result"
+    assert "failed to initialize" in out.body
+    assert "<bash-stderr>" not in out.body
+
+
+def test_user_bash_output_empty_is_dropped() -> None:
+    ev = _user("<bash-stdout></bash-stdout><bash-stderr></bash-stderr>")
+    assert render_event(ev) is None
+
+
+def test_user_bash_output_no_output_placeholder_is_dropped() -> None:
+    # Claude Code emits this placeholder when a ``!`` command produced no output.
+    ev = _user(
+        "<bash-stdout>(Bash completed with no output)</bash-stdout><bash-stderr></bash-stderr>"
+    )
+    assert render_event(ev) is None
+
+
 def test_framing_event_types_are_skipped() -> None:
     for t in (
         "file-history-snapshot",

--- a/tests/transcript/test_mirror.py
+++ b/tests/transcript/test_mirror.py
@@ -49,6 +49,11 @@ def _user_tool_result(output: str) -> dict:
     }
 
 
+def _user_str(content: str) -> dict:
+    """A ``user``-role event whose content is a bare string (pane input / marker)."""
+    return {"type": "user", "message": {"role": "user", "content": content}}
+
+
 async def test_mirror_posts_rendered_events_to_sink(tmp_path: Path) -> None:
     project = tmp_path / "proj"
     project.mkdir()
@@ -324,6 +329,58 @@ async def test_mirror_minimal_attaches_progress_file_when_tools_buffered(
     assert os.path.exists(path) or not os.path.exists(path)  # file may be cleaned up
     # plain sink not called for this assistant_text
     assert not any("done" in c for c in sink_calls)
+
+
+async def test_mirror_minimal_bash_mode_buffered_not_leaked_as_bubble(tmp_path: Path) -> None:
+    """#487: Claude Code bash-mode markers (``! command``) are buffered into the
+    progress file like tool activity — never posted raw as a 👤 thread bubble."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    jsonl = project / "s.jsonl"
+    jsonl.write_text("")
+    import os
+
+    os.utime(jsonl, (1, 1))
+
+    sink_calls: list[str] = []
+    progress_contents: list[str] = []
+
+    async def sink(text: str) -> None:
+        sink_calls.append(text)
+
+    async def file_sink(text: str, file_path: str) -> None:
+        # Read inside the callback — the mirror unlinks the temp file afterwards.
+        with open(file_path, encoding="utf-8") as f:
+            progress_contents.append(f.read())
+
+    mirror = TranscriptMirror(
+        thread_id=1,
+        project_dir=project,
+        sink=sink,
+        file_sink=file_sink,
+        verbosity="minimal",
+        poll_interval=0.05,
+    )
+    mirror.start()
+    try:
+        await asyncio.sleep(0.1)
+        _write_event(jsonl, _user_str("<bash-input> google-chrome --headless</bash-input>"))
+        _write_event(
+            jsonl,
+            _user_str("<bash-stdout></bash-stdout><bash-stderr>Missing X server</bash-stderr>"),
+        )
+        _write_event(jsonl, _assistant_text("done"))
+        await asyncio.sleep(0.4)
+    finally:
+        await mirror.stop()
+
+    # No raw bash-mode tag ever reached the thread bubble (plain sink).
+    assert not any("<bash-input>" in c or "<bash-stdout>" in c for c in sink_calls)
+    # The bash command + output landed in the progress file (the "raw mirror" layer).
+    assert progress_contents, "progress file_sink should have been called"
+    joined = "\n".join(progress_contents)
+    assert "google-chrome --headless" in joined
+    assert "Missing X server" in joined
 
 
 async def test_mirror_minimal_no_file_sink_fallback_to_sink(tmp_path: Path) -> None:


### PR DESCRIPTION
## これがこうなる（利用者目線）

**スレッドで `!` バッシュモードのコマンド（例 `! google-chrome ...`）を実行すると、いままでは `👤 <bash-input> ...</bash-input>` という生タグがそのままスレッドに流れていた**（Claude Code の TUI では出ない内部マーカーで、Discord だけ見え方がズレていた）。**この PR で、bash 実行は他のツール実行と同じく `progress.txt` に畳まれ、生タグはスレッドに出なくなる**（full モードでは `🔧 Bash:` のきれいな embed）。

内部的には TranscriptMirror の `formatter.py::_render_user` が `<bash-input>` / `<bash-stdout>` / `<bash-stderr>` を「人がペインに打った入力(`user_input`)」と誤判定していたのを、実体どおり **tool 実行(`tool_use` / `tool_result`)に分類**するように直した。#432 / #50 / #39 と同じ「内部マーカー漏れ」クラスの JSONL ミラー経路版。

Closes #487

---

## Acceptance Criteria (copied from the issue)

- [x] `formatter.py::_render_user` が `<bash-input>...</bash-input>` を `kind="tool_use"`（body は `🔧 Bash: \`cmd\``）として分類する
- [x] `<bash-stdout>...</bash-stdout><bash-stderr>...</bash-stderr>` を `kind="tool_result"` として分類する。stdout/stderr が両方空、または `(Bash completed with no output)` プレースホルダのみのときは `None`（drop）を返す
- [x] 単体テスト: bash-input / bash-output を含むイベントが `user_input` として生タグでバブルに出ないことを assert（RED → GREEN）
- [x] 回帰: 生タグでない通常の human user_input は従来どおり `kind="user_input"`（👤）で mirror される
- [x] minimal モードで bash-mode イベントがバブルに post されず buffer（progress.txt）側に入ることを mirror レベルで確認
- [x] `pytest` + `ruff check` + `ruff format --check` + `pyright` green

## TDD Evidence

RED（修正前、テストが失敗）:

```
FAILED tests/transcript/test_formatter.py::test_user_bash_output_empty_is_dropped
AssertionError: assert RenderedEvent(kind='user_input', body='<bash-stdout></bash-stdout><bash-stderr></bash-stderr>', session_id=None) is None
```

GREEN（修正後）: `tests/transcript/ 81 passed` / 全体 `2044 passed, 3 skipped`。

新規テスト: `test_formatter.py` に bash-mode 分類 6 ケース、`test_mirror.py::test_mirror_minimal_bash_mode_buffered_not_leaked_as_bubble`（mirror レベルで「バブルに出ず progress.txt に入る」を assert）。

## Staging Evidence（RED→GREEN, `c-lord-staging-1`, `CLORD_BRIDGE_MODE=jsonl` / minimal）

手法: staging bot を borrow → E2E スレッド（`W13 │ staging E2E 疎通確認`, thread `1514085380666691664`）で稼働中の TranscriptMirror が tail している JSONL に、**実キャプチャ形式の bash-mode イベントを追記**して runtime パス（tail→render→sink→Discord）を再現。RED は `main`、GREEN は本ブランチ（`5b4a7cc`）。検証後 jsonl を原状復帰・main へ restore・lease release 済み。

**RED**（`main`）: 生タグが 👤 バブルでスレッドに漏れる

![RED](https://github.com/yousan/c-lord/releases/download/evidence/i487-pr487-RED-bash-marker-leaks-as-raw-bubble-20260714T031747Z-00.png)

**GREEN**（本ブランチ）: bash 実行は `🔧 Bash:` / `↳` に整形されて `progress.txt` に畳まれ、生タグバブルは出ない

![GREEN](https://github.com/yousan/c-lord/releases/download/evidence/i487-pr487-GREEN-bash-marker-folded-into-progress-20260714T031747Z-01.png)

<details><summary>Discord REST API による裏取り（テキスト・権威側の証跡）</summary>

RED（`main`）— E2E スレッドに raw タグが 2 バブル:
```
[03:04:31] C-lord-staging-1: '👤 <bash-input> echo RED-487-MARKER-LEAK-TEST</bash-input>'
[03:04:31] C-lord-staging-1: '👤 <bash-stdout>RED-487-MARKER-LEAK-TEST\n</bash-stdout><bash-stderr></bash-stderr>'
```

GREEN（本ブランチ）— raw バブルは出ず、assistant 応答に `progress.txt` 添付:
```
[03:10:32] C-lord-staging-1: 'GREEN-487: bash 実行は progress.txt に畳まれ、生タグは出ません。'  attachments=['progress.txt']
```
progress.txt の中身（bash 実行が整形されて格納）:
```
🔧 Bash: `echo GREEN-487-should-fold-into-progress`
↳ GREEN-487-should-fold-into-progress
```
</details>

> 補足: スクショ中央を覆う Nitro プロモ（`ショップ新着：プロフィールフレーム`）は使い捨てテストアカウント側の Discord 促進モーダルで、本 PR とは無関係。肝心部（RED の生バブル / GREEN の progress.txt fold）はモーダル下に写っており、REST API のテキスト証跡で裏取り済み。文脈込みの GREEN 全体像: [full-context shot](https://github.com/yousan/c-lord/releases/download/evidence/i487-pr487-GREEN-full-context-20260714T031747Z-02.png)。

## Docs

`c_lord/transcript/formatter.py` のモジュール docstring（レンダリング契約の「あるべき動き」）に、bash-mode マーカーを TUI と同じく tool 活動として整形し progress.txt に畳む旨を追記。README の `CLORD_BRIDGE_MODE` 説明は挙動一致のため変更不要。

## Self-review

- diff は 3 ファイルのみ（`formatter.py` 実装＋docstring / `test_formatter.py` / `test_mirror.py`）。無関係変更なし。
- Security: subprocess/shell/env/インジェクション面には触れず、アンカー付き単一量指定子の正規表現（ReDoS なし）。内容は元々 Discord に届いていたものの再整形で、新規の情報露出なし。

## Definition of Done checklist

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted
- [x] `uv run pytest tests/ -v` passes（2044 passed, 3 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in（RED→GREEN, スクショ＋REST 裏取り）
- [x] No unrelated changes in the diff; self-review done
- [x] 動きを変えたら「あるべき動き」のドキュメント（`formatter.py` docstring）も更新した
- [x] `Closes`/`Resolves #N` used only if 100% of the issue's ACs are met, and written on its own line
