### PR TITLE
feat: 完了通知の宛先を owner 固定→そのターンの投稿者へ (#481)

### DIFF
--- a/c_lord/cogs/claude_chat.py
+++ b/c_lord/cogs/claude_chat.py
@@ -1649,4 +1649,8 @@ class ClaudeChatCog(commands.Cog):
                             ThreadState.WAITING_INPUT,
                             description,
                             thread=thread,
+                            # #481: ping the poster of THIS turn, not a fixed
+                            # owner — so completion reaches whoever is waiting
+                            # (any guild / any authorized user, owner or not).
+                            notify_user_id=user_message.author.id,
                         )

--- a/c_lord/discord_ui/thread_dashboard.py
+++ b/c_lord/discord_ui/thread_dashboard.py
@@ -2,13 +2,14 @@
 
 Posts and maintains a pinned embed in the main channel that shows which
 threads are processing automatically vs. waiting for user input.
-When a thread transitions to WAITING_INPUT, the bot mentions the owner
-so Discord's notification system surfaces the request immediately.
+When a thread transitions to WAITING_INPUT, the bot mentions the turn's poster
+(``notify_user_id``, falling back to the configured owner) so Discord's
+notification system surfaces the request immediately (#481).
 
 Why the mention is its OWN message (not appended to Claude's final reply)
 ------------------------------------------------------------------------
 Two different actors post: Claude posts the answer itself via the discord-reply
-skill (``POST /api/reply``), while c-lord posts this ``@owner`` mention when the
+skill (``POST /api/reply``), while c-lord posts this ``@poster`` mention when the
 bot's turn-completion detector fires (WAITING_INPUT). Merging them into one
 message was considered (issue discussion under #365) and is intentionally NOT
 done:
@@ -125,12 +126,13 @@ class ThreadStatusDashboard:
         state: ThreadState,
         description: str,
         thread: discord.Thread | None = None,
+        notify_user_id: int | None = None,
     ) -> None:
         """Update a thread's state and refresh the dashboard embed.
 
         When transitioning to ``WAITING_INPUT`` for the first time, the bot
-        posts a reply in *thread* mentioning the owner so Discord surfaces the
-        notification immediately.
+        posts a reply in *thread* mentioning the turn's poster so Discord
+        surfaces the notification immediately.
 
         Parameters
         ----------
@@ -141,7 +143,13 @@ class ThreadStatusDashboard:
         description:
             Short human-readable summary (e.g. the first 100 chars of the prompt).
         thread:
-            The ``discord.Thread`` object, required for owner mentions.
+            The ``discord.Thread`` object, required for mentions.
+        notify_user_id:
+            #481: the Discord user to @-mention on the WAITING_INPUT transition —
+            the poster of this turn. Falls back to the configured ``owner_id``
+            when ``None``. This makes the completion ping reach whoever is
+            actually waiting (any guild, any authorized user) instead of a single
+            fixed owner, and still fires when no owner is configured.
         """
         async with self._lock:
             prev_state = self._threads[thread_id].state if thread_id in self._threads else None
@@ -159,11 +167,13 @@ class ThreadStatusDashboard:
                 if description:
                     info.description = description
 
-            # Mention owner on first WAITING_INPUT transition
+            # #481: mention the turn's poster (notify_user_id); fall back to the
+            # configured owner. Mention on the first WAITING_INPUT transition.
+            mention_id = notify_user_id if notify_user_id is not None else self._owner_id
             should_mention = (
                 state == ThreadState.WAITING_INPUT
                 and prev_state != ThreadState.WAITING_INPUT
-                and self._owner_id is not None
+                and mention_id is not None
                 and thread is not None
             )
 
@@ -177,10 +187,12 @@ class ThreadStatusDashboard:
                 # mention pings anywhere in the content, so trailing it does not
                 # weaken the notification.
                 await thread.send(
-                    f"🟡 Claude has finished — your reply is needed here. <@{self._owner_id}>"
+                    f"🟡 Claude has finished — your reply is needed here. <@{mention_id}>"
                 )
             except discord.HTTPException:
-                logger.debug("Failed to send owner mention in thread %d", thread_id, exc_info=True)
+                logger.debug(
+                    "Failed to send completion mention in thread %d", thread_id, exc_info=True
+                )
 
     async def remove(self, thread_id: int) -> None:
         """Remove a thread from the dashboard and refresh."""

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -186,6 +186,51 @@ class TestOwnerMention:
         )
 
     @pytest.mark.asyncio
+    async def test_mentions_notify_user_over_owner(self) -> None:
+        """#481: the completion mention targets the turn's poster, not a fixed owner."""
+        dashboard, _ = _make_dashboard(owner_id=42)
+        await dashboard.initialize()
+        thread = _make_thread(10)
+
+        await dashboard.set_state(10, ThreadState.PROCESSING, "w", thread=thread)
+        await dashboard.set_state(
+            10, ThreadState.WAITING_INPUT, "w", thread=thread, notify_user_id=999
+        )
+
+        sent_text = thread.send.call_args.args[0]
+        assert "<@999>" in sent_text, f"should mention the poster (999); got: {sent_text!r}"
+        assert "<@42>" not in sent_text, f"should NOT mention the fixed owner (42); got: {sent_text!r}"
+
+    @pytest.mark.asyncio
+    async def test_mentions_author_even_when_owner_unset(self) -> None:
+        """#481: with no owner configured (e.g. another guild), the poster is still pinged."""
+        dashboard, _ = _make_dashboard(owner_id=None)
+        await dashboard.initialize()
+        thread = _make_thread(10)
+
+        await dashboard.set_state(10, ThreadState.PROCESSING, "w", thread=thread)
+        await dashboard.set_state(
+            10, ThreadState.WAITING_INPUT, "w", thread=thread, notify_user_id=999
+        )
+
+        thread.send.assert_called_once()
+        sent_text = thread.send.call_args.args[0]
+        assert "<@999>" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_owner_when_no_notify_user(self) -> None:
+        """Backward compat: without notify_user_id, the owner is still mentioned."""
+        dashboard, _ = _make_dashboard(owner_id=42)
+        await dashboard.initialize()
+        thread = _make_thread(10)
+
+        await dashboard.set_state(10, ThreadState.PROCESSING, "w", thread=thread)
+        await dashboard.set_state(10, ThreadState.WAITING_INPUT, "w", thread=thread)
+
+        sent_text = thread.send.call_args.args[0]
+        assert "<@42>" in sent_text
+
+    @pytest.mark.asyncio
     async def test_mention_not_sent_if_already_waiting(self) -> None:
         """Repeated WAITING_INPUT transitions should NOT spam mentions."""
         dashboard, _ = _make_dashboard(owner_id=42)


### PR DESCRIPTION
## What does this PR do?

ターン完了通知「Claude has finished — your reply is needed here」の宛先を、**単一の `DISCORD_OWNER_ID` 固定** から **そのターンの投稿者** に変更する。

- `ThreadStatusDashboard.set_state()` に `notify_user_id` を追加。mention 先 = `notify_user_id`（そのターンの投稿者）、無ければ `owner_id` にフォールバック。
- `claude_chat` の WAITING_INPUT 遷移で `notify_user_id=user_message.author.id` を渡す。

## Why?

完了通知の @メンションは単一のグローバル `DISCORD_OWNER_ID` にしか飛ばず、複数ギルド／複数ユーザーで2つの実害があった:

1. **別ギルドで通知が来ない**: `DISCORD_OWNER_ID` 未設定だと完了通知が**誰にも飛ばない**（最初のご報告の症状）。
2. **設定すると副作用でロックダウン**: `owner_id` は認可 allowlist を兼ねる（`main.py`）ため、通知欲しさに設定するとギルドが**その1人しか使えない**。

通知先を「そのターンを投げた本人」にすれば `DISCORD_OWNER_ID` に触れず、どのギルド・投稿者にも飛び、**owner 未設定でも機能**する。認可 allowlist は不変。

Closes #481

## 利用者から見た before/after（1行・必須）

- before（この PR 前）→ after（この PR 後）: 別ギルドや非オーナーがスレッドを回すと完了通知が飛ばない（or 無関係な固定オーナーに飛ぶ）→ そのターンを投げた本人に必ず完了通知が飛ぶ（owner 未設定でも）。

## Acceptance Criteria (copied from the issue)

- [x] Discord 駆動のターン完了時、@メンションの宛先は**起点メッセージの author**（`user_message.author.id`）であり、`owner_id` 固定ではない
- [x] `DISCORD_OWNER_ID` **未設定**のインスタンスでも、Discord 駆動ターンの完了通知が author に飛ぶ（別ギルド回帰）
- [~] ~~端末（tmux）直入力で完了したターンは owner フォールバック~~ → **本 AC は Issue で正式にスコープ外へ改訂**（[#481 コメント](https://github.com/yousan/c-lord/issues/481#issuecomment-4981673993)）。完了通知は `_run_claude`（Discord 駆動）からのみ発火し、純粋な端末打ち込みには**発火点が無い**（現状も飛ばない＝回帰なし）。`set_state` の owner フォールバックは後方互換用に保持。必要なら別 Issue 化。
- [x] 認可 allowlist（`allowed_user_ids` / `Authorizer`）の挙動は本 PR で**変更しない**（diff に認可の変更なし）
- [x] TDD: 「宛先 = author.id（owner ではない）」を検証する失敗テスト（RED）→ 緑（GREEN）
- [x] staging で RED（owner 未設定→飛ばない）→ GREEN（owner 未設定でも author に飛ぶ）を提示

## Staging Evidence (証跡)

環境: staging-2（`DISCORD_OWNER_ID` **未設定** = 別ギルド相当。.env 未編集）。E2E スレッドに prod bot（信頼 bot）で普通の質問を投げてターンを完了させ、完了通知メッセージの有無/宛先を Discord REST API で観測。borrow → RED(main) → GREEN(fix) → 原状復帰(main) → release。

**RED（`main`）** — トリガー `1526955360714227804`（Claude が「6」と回答して完了）:
→ 完了通知メッセージ（"Claude has finished…"）は**出ない**（owner 未設定なので発火しない＝別ギルドの症状）。

**GREEN（`feat/481-notify-poster` @ 17db8c2）** — トリガー `1526955764395151482`:
→ 完了通知 `msg 1526955824600322088` が発火:
```
🟡 Claude has finished — your reply is needed here. <@1475105094071750818>
```
`<@1475105094071750818>` = そのターンの投稿者（信頼 bot）。**owner 未設定でも投稿者に飛ぶ。**

RED vs GREEN（Discord REST API 実データから作図）:
![redgreen](https://github.com/yousan/c-lord/releases/download/evidence/i481-redgreen-i481_redgreen_owner_to_poster-20260715T142213Z.png)

## Definition of Done checklist

See CLAUDE.md → "Definition of Done (DoD)". Merge only when ALL are checked.

- [x] Every Acceptance Criterion above is checked
- [x] TDD: test failed before (RED) and passes after (GREEN) — RED line pasted below
- [x] `uv run pytest tests/ -v` passes（2055 passed, 3 skipped）
- [x] `uv run ruff check c_lord/` + `ruff format --check` + `pyright` pass
- [x] Staging Evidence above is filled in（RED→GREEN 実データ + 比較図）
- [x] No unrelated changes in the diff; self-review done（thread_dashboard + claude_chat + テストのみ）
- [x] 動きを変えたら「あるべき動き」も更新: `thread_dashboard.py` モジュール docstring を「mentions the turn's poster（owner フォールバック）」に更新。USER_GUIDE は #480 で追加した通知先の記述（「そのターンを投げた人 / 自動は owner」）が既に整合するため据え置き
- [x] `Closes #481` は 100% の AC を満たすため独立行で使用

<details>
<summary>TDD RED line</summary>

```
tests/test_thread_dashboard.py::TestOwnerMention::test_mentions_notify_user_over_owner
E   TypeError: ThreadStatusDashboard.set_state() got an unexpected keyword argument 'notify_user_id'
```
（実装後は GREEN。owner=42 + notify_user_id=999 → `<@999>` を mention・`<@42>` は出さない。owner 未設定でも `<@999>` に飛ぶ。）
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
